### PR TITLE
Adjust URDF file: tune simulation dynamics and fix gripper joint

### DIFF
--- a/hardware/elrobot/simulation/elrobot_follower.urdf
+++ b/hardware/elrobot/simulation/elrobot_follower.urdf
@@ -30,7 +30,7 @@
   <link name="base_link">
     <inertial>
       <origin xyz="4.1532032114359136e-10 0.013084111185471562 0.019551044495005637" rpy="0 0 0"/>
-      <mass value="0.06831242050694149"/>
+      <mass value="0.03944"/>
       <inertia ixx="3.6e-05" iyy="5.9e-05" izz="5.1e-05" ixy="0.0" iyz="8e-06" ixz="-0.0"/>
     </inertial>
     <visual>
@@ -50,7 +50,7 @@
   <link name="ST3215_1_v1_1">
     <inertial>
       <origin xyz="4.076346987608891e-06 0.022690161600370684 -0.0014235772611572647" rpy="0 0 0"/>
-      <mass value="0.03190666159632515"/>
+      <mass value="0.055"/>
       <inertia ixx="8e-06" iyy="4e-06" izz="7e-06" ixy="0.0" iyz="-0.0" ixz="0.0"/>
     </inertial>
     <visual>
@@ -70,7 +70,7 @@
   <link name="Joint_01_1">
     <inertial>
       <origin xyz="0.00019293358229791917 0.01053544085767251 -0.002903406181002266" rpy="0 0 0"/>
-      <mass value="0.036024842090469696"/>
+      <mass value="0.05706"/>
       <inertia ixx="2e-05" iyy="2e-05" izz="1e-05" ixy="0.0" iyz="4e-06" ixz="-0.0"/>
     </inertial>
     <visual>
@@ -90,7 +90,7 @@
   <link name="ST3215_2_v1_1">
     <inertial>
       <origin xyz="-0.0014235768458915805 -0.00019407288276004214 0.02268943356342234" rpy="0 0 0"/>
-      <mass value="0.03190666159632515"/>
+      <mass value="0.055"/>
       <inertia ixx="7e-06" iyy="8e-06" izz="4e-06" ixy="0.0" iyz="0.0" ixz="-0.0"/>
     </inertial>
     <visual>
@@ -110,7 +110,7 @@
   <link name="Joint_02_1">
     <inertial>
       <origin xyz="0.020187292657891796 -0.0003607149418271213 0.04048886553547183" rpy="0 0 0"/>
-      <mass value="0.04313419527395414"/>
+      <mass value="0.05084"/>
       <inertia ixx="2.4e-05" iyy="3.4e-05" izz="1.7e-05" ixy="-0.0" iyz="0.0" ixz="0.0"/>
     </inertial>
     <visual>
@@ -130,7 +130,7 @@
   <link name="ST3215_3_v1_1">
     <inertial>
       <origin xyz="-0.0012258665484379326 -0.00019383890721715036 0.02270059947453923" rpy="0 0 0"/>
-      <mass value="0.03190666159632515"/>
+      <mass value="0.055"/>
       <inertia ixx="7e-06" iyy="8e-06" izz="4e-06" ixy="0.0" iyz="0.0" ixz="-0.0"/>
     </inertial>
     <visual>
@@ -150,7 +150,7 @@
   <link name="Joint_03_v1_1">
     <inertial>
       <origin xyz="0.021383489206350224 0.0025973738142313213 0.028573272567347596" rpy="0 0 0"/>
-      <mass value="0.03705485612134295"/>
+      <mass value="0.03822"/>
       <inertia ixx="1.1e-05" iyy="1.8e-05" izz="1.5e-05" ixy="0.0" iyz="-1e-06" ixz="-0.0"/>
     </inertial>
     <visual>
@@ -170,7 +170,7 @@
   <link name="ST3215_4_v1_1">
     <inertial>
       <origin xyz="-0.0014236012890871546 0.022688801414757966 0.00021876985314867037" rpy="0 0 0"/>
-      <mass value="0.03190666159632515"/>
+      <mass value="0.055"/>
       <inertia ixx="7e-06" iyy="4e-06" izz="8e-06" ixy="-0.0" iyz="-0.0" ixz="0.0"/>
     </inertial>
     <visual>
@@ -190,7 +190,7 @@
   <link name="Joint_04_v1_1">
     <inertial>
       <origin xyz="0.02041469568271767 0.04634775018812741 0.0004733773672222219" rpy="0 0 0"/>
-      <mass value="0.04910540016805011"/>
+      <mass value="0.05152"/>
       <inertia ixx="3.7e-05" iyy="2.1e-05" izz="4.7e-05" ixy="-0.0" iyz="-1e-06" ixz="0.0"/>
     </inertial>
     <visual>
@@ -210,7 +210,7 @@
   <link name="ST3215_5_v1_1">
     <inertial>
       <origin xyz="0.00038301708111886123 -0.001621005306100043 0.022431224025462493" rpy="0 0 0"/>
-      <mass value="0.03190666159632515"/>
+      <mass value="0.055"/>
       <inertia ixx="8e-06" iyy="7e-06" izz="4e-06" ixy="-0.0" iyz="-0.0" ixz="-0.0"/>
     </inertial>
     <visual>
@@ -230,7 +230,7 @@
   <link name="Joint_05_v1_1">
     <inertial>
       <origin xyz="-0.0014511731912585726 0.014886171505002432 0.00023918947669937518" rpy="0 0 0"/>
-      <mass value="0.015030395597527186"/>
+      <mass value="0.01756"/>
       <inertia ixx="3e-06" iyy="5e-06" izz="5e-06" ixy="0.0" iyz="-0.0" ixz="0.0"/>
     </inertial>
     <visual>
@@ -250,7 +250,7 @@
   <link name="ST3215_6_v1_1">
     <inertial>
       <origin xyz="-0.0012292541520895308 0.02270120751988408 1.7775252667578956e-05" rpy="0 0 0"/>
-      <mass value="0.03190666159632515"/>
+      <mass value="0.055"/>
       <inertia ixx="7e-06" iyy="4e-06" izz="8e-06" ixy="-0.0" iyz="-0.0" ixz="0.0"/>
     </inertial>
     <visual>
@@ -270,7 +270,7 @@
   <link name="Joint_06_v1_1">
     <inertial>
       <origin xyz="0.02043403340818753 0.03197650673728944 0.0003564813588719795" rpy="0 0 0"/>
-      <mass value="0.03727709058376948"/>
+      <mass value="0.03882"/>
       <inertia ixx="1.6e-05" iyy="1.6e-05" izz="2.2e-05" ixy="0.0" iyz="-0.0" ixz="0.0"/>
     </inertial>
     <visual>
@@ -290,7 +290,7 @@
   <link name="ST3215_7_v1_1">
     <inertial>
       <origin xyz="0.00037315403427122225 -0.0014257132266914385 0.022445026183495337" rpy="0 0 0"/>
-      <mass value="0.03190666159632515"/>
+      <mass value="0.055"/>
       <inertia ixx="8e-06" iyy="7e-06" izz="4e-06" ixy="-0.0" iyz="-0.0" ixz="-0.0"/>
     </inertial>
     <visual>
@@ -310,7 +310,7 @@
   <link name="Gripper_Base_v1_1">
     <inertial>
       <origin xyz="0.0005605249651253262 0.03191999437655846 -0.0005946931738743111" rpy="0 0 0"/>
-      <mass value="0.046895455343164964"/>
+      <mass value="0.06244"/>
       <inertia ixx="2.2e-05" iyy="2.9e-05" izz="3.1e-05" ixy="0.0" iyz="-0.0" ixz="0.0"/>
     </inertial>
     <visual>
@@ -330,7 +330,7 @@
   <link name="ST3215_8_v1_1">
     <inertial>
       <origin xyz="-0.000545923413501848 -0.018926109262623947 -0.01220636642566475" rpy="0 0 0"/>
-      <mass value="0.03190666159632515"/>
+      <mass value="0.055"/>
       <inertia ixx="8e-06" iyy="7e-06" izz="4e-06" ixy="-0.0" iyz="-0.0" ixz="-0.0"/>
     </inertial>
     <visual>
@@ -350,7 +350,7 @@
   <link name="Gripper_Gear_v1_1">
     <inertial>
       <origin xyz="6.406692942733175e-05 0.0037564011470480607 -3.383421367433859e-05" rpy="0 0 0"/>
-      <mass value="0.0024790841259162795"/>
+      <mass value="0.0039"/>
       <inertia ixx="0.0" iyy="0.0" izz="0.0" ixy="0.0" iyz="-0.0" ixz="-0.0"/>
     </inertial>
     <visual>
@@ -370,7 +370,7 @@
   <link name="Gripper_Jaw_02_v1_1">
     <inertial>
       <origin xyz="-0.3386809002581644 0.2625921677727179 -0.030316532660763146" rpy="0 0 0"/>
-      <mass value="0.012492175356778453"/>
+      <mass value="0.0125"/>
       <inertia ixx="5e-06" iyy="4e-06" izz="3e-06" ixy="0.0" iyz="0.0" ixz="-0.0"/>
     </inertial>
     <visual>
@@ -390,7 +390,7 @@
   <link name="Gripper_Jaw_01_v1_1">
     <inertial>
       <origin xyz="-0.27944183977334625 0.30531580207092573 0.046279678752686765" rpy="0 0 0"/>
-      <mass value="0.012492175356778453"/>
+      <mass value="0.0125"/>
       <inertia ixx="5e-06" iyy="4e-06" izz="3e-06" ixy="-0.0" iyz="-0.0" ixz="-0.0"/>
     </inertial>
     <visual>
@@ -417,7 +417,7 @@
     <parent link="ST3215_1_v1_1"/>
     <child link="Joint_01_1"/>
     <axis xyz="0.0 -0.008727 0.999962"/>
-    <limit upper="1.570796" lower="-1.570796" effort="2.94" velocity="4.71"/>
+    <limit upper="1.5509" lower="-1.5509" effort="2.94" velocity="4.71"/>
   </joint>
   <joint name="Rigid 3" type="fixed">
     <origin xyz="0.000625 -5.8e-05 0.0067" rpy="0 0 0"/>
@@ -429,7 +429,7 @@
     <parent link="ST3215_2_v1_1"/>
     <child link="Joint_02_1"/>
     <axis xyz="-0.999962 -7.6e-05 0.008726"/>
-    <limit upper="1.570796" lower="-1.570796" effort="2.94" velocity="4.71"/>
+    <limit upper="1.6122" lower="-1.6122" effort="2.94" velocity="4.71"/>
   </joint>
   <joint name="Rigid 7" type="fixed">
     <origin xyz="0.019863 -0.000487 0.055827" rpy="0 0 0"/>
@@ -441,7 +441,7 @@
     <parent link="ST3215_3_v1_1"/>
     <child link="Joint_03_v1_1"/>
     <axis xyz="-0.999848 -0.000152 0.017452"/>
-    <limit upper="1.570796" lower="-1.570796" effort="2.94" velocity="4.71"/>
+    <limit upper="1.7610" lower="-1.7610" effort="2.94" velocity="4.71"/>
   </joint>
   <joint name="Rigid 9" type="fixed">
     <origin xyz="0.021263 0.001933 0.036403" rpy="0 0 0"/>
@@ -453,7 +453,7 @@
     <parent link="ST3215_4_v1_1"/>
     <child link="Joint_04_v1_1"/>
     <axis xyz="-0.99981 0.008574 0.017527"/>
-    <limit upper="1.570796" lower="-1.570796" effort="2.94" velocity="4.71"/>
+    <limit upper="1.7533" lower="-1.7533" effort="2.94" velocity="4.71"/>
   </joint>
   <joint name="Rigid 11" type="fixed">
     <origin xyz="0.020391 0.065663 -0.010035" rpy="0 0 0"/>
@@ -465,7 +465,7 @@
     <parent link="ST3215_5_v1_1"/>
     <child link="Joint_05_v1_1"/>
     <axis xyz="-0.008573 -0.999963 0.000151"/>
-    <limit upper="2.96706" lower="-2.96706" effort="2.94" velocity="4.71"/>
+    <limit upper="2.6998" lower="-3.1907" effort="2.94" velocity="4.71"/>
   </joint>
   <joint name="Rigid 13" type="fixed">
     <origin xyz="6.5e-05 0.0075 -1e-06" rpy="0 0 0"/>
@@ -477,7 +477,7 @@
     <parent link="ST3215_6_v1_1"/>
     <child link="Joint_06_v1_1"/>
     <axis xyz="-0.999697 0.0173 0.017525"/>
-    <limit upper="1.570796" lower="-1.570796" effort="2.94" velocity="4.71"/>
+    <limit upper="1.7641" lower="-1.3775" effort="2.94" velocity="4.71"/>
   </joint>
   <joint name="Rigid 15" type="fixed">
     <origin xyz="0.020478 0.038023 -0.010611" rpy="0 0 0"/>
@@ -489,32 +489,34 @@
     <parent link="ST3215_7_v1_1"/>
     <child link="Gripper_Base_v1_1"/>
     <axis xyz="-0.017144 -0.999812 0.009029"/>
-    <limit upper="2.96706" lower="-2.96706" effort="2.94" velocity="4.71"/>
+    <limit upper="2.7796" lower="-3.0710" effort="2.94" velocity="4.71"/>
   </joint>
   <joint name="Rigid 17" type="fixed">
     <origin xyz="0.000776 0.045242 -0.000409" rpy="0 0 0"/>
     <parent link="Gripper_Base_v1_1"/>
     <child link="ST3215_8_v1_1"/>
   </joint>
-  <joint name="rev_motor_08" type="continuous">
+<joint name="rev_motor_08" type="revolute">
     <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
     <parent link="ST3215_8_v1_1"/>
     <child link="Gripper_Gear_v1_1"/>
     <axis xyz="0.017144 0.999812 -0.009029"/>
-    <limit upper="1.48" lower="-1.48" effort="2.94" velocity="4.71"/>
+    <limit upper="2.2028" lower="0" effort="2.94" velocity="4.71"/>
   </joint>
   <joint name="rev_motor_08_1" type="prismatic">
-    <origin xyz="0.311734 -0.199648 0.032849" rpy="0 0 0"/>
+    <origin xyz="0.311734 -0.199648 0.032849" rpy="0 0 0"/> 
     <parent link="Gripper_Base_v1_1"/>
-    <child link="Gripper_Jaw_02_v1_1"/>
-    <axis xyz="-0.999697 0.0173 0.017525"/>
-    <limit upper="0.0" lower="-0.025" effort="2.94" velocity="4.71"/>
+    <child link="Gripper_Jaw_02_v1_1"/> 
+    <axis xyz="-0.999697 0.0173 0.017525"/> 
+    <limit upper="0.0" lower="-0.0255" effort="2.94" velocity="4.71"/>
+    <mimic joint="rev_motor_08" multiplier="-0.0115" offset="0"/>
   </joint>
   <joint name="rev_motor_08_2" type="prismatic">
-    <origin xyz="0.308573 -0.243367 -0.047491" rpy="0 0 0"/>
+    <origin xyz="0.308573 -0.243367 -0.049391" rpy="0 0 0"/>
     <parent link="Gripper_Base_v1_1"/>
-    <child link="Gripper_Jaw_01_v1_1"/>
-    <axis xyz="-0.999697 0.0173 0.017525"/>
-    <limit upper="0.025" lower="0.0" effort="2.94" velocity="4.71"/>
+    <child link="Gripper_Jaw_01_v1_1"/> 
+    <axis xyz="-0.999697 0.0173 0.017525"/> 
+    <limit upper="0.0255" lower="0.0" effort="2.94" velocity="4.71"/>
+    <mimic joint="rev_motor_08" multiplier="0.0115" offset="0"/>
   </joint>
 </robot>


### PR DESCRIPTION
- Adjust inertial weights to improve simulation movements
- Update joint limits to reflect hardware constraints
- Use mimic joint for gripper jaws to ensure symmetrical opening and closing

<img width="1600" height="900" alt="urdf-weights" src="https://github.com/user-attachments/assets/ba7804c5-b020-4b71-aabe-fe19de4726fe" />
