### PR TITLE
[station-web] Setup dependabot npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,28 @@
 version: 2
-registries: {}
 
 updates:
   - package-ecosystem: "npm"
     directory: "/software/station/clients/station-viewer"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
-    labels:
-      - "dependencies"
+      timezone: "Europe/Madrid"
+    open-pull-requests-limit: 3
+    cooldown:
+      default-days: 14
+      semver-major-days: 30
     commit-message:
       prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      development-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+registries: {}
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/software/station/clients/station-viewer"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"


### PR DESCRIPTION
# Summary
Enable Dependabot version updates for the station-viewer npm application.

## Configuration
Ecosystem: npm
Scope: software/station/clients/station-viewer
Schedule: Weekly (Europe/Madrid)
Max open PRs: 3

## Update grouping
Minor and patch updates are grouped to reduce PR noise:
production-dependencies — production deps, minor + patch
development-dependencies — dev deps, minor + patch

Major updates remain as individual PRs.

## Cooldown
Default: 14 days — newly released packages wait before Dependabot creates an update PR
Major updates: 30 days — extra cooldown for major semver bumps

## Commit messages
Prefix: deps
Scope included (e.g. deps(viewer): update react)
Labeled: dependencies