### PR TITLE
fix: improve mobile UI for top panels

### DIFF
--- a/software/station/clients/station-viewer/src/components/Navigation.tsx
+++ b/software/station/clients/station-viewer/src/components/Navigation.tsx
@@ -33,8 +33,8 @@ function Navigation() {
 
   return (
     <div className="relative z-40 bg-surface-primary border-b-2 border-border-default">
-      <div className="px-4 py-2 flex items-center gap-4 overflow-x-auto scrollbar-thin">
-        <Link to="/" className="group shrink-0">
+      <div className="px-4 py-2 flex items-center gap-4">
+        <Link to="/" className="group">
           <img
             src="/logo.svg"
             alt="Station View"
@@ -42,7 +42,7 @@ function Navigation() {
             className="h-8 logo-first-load logo-invert opacity-80 transition-opacity duration-200 group-hover:opacity-100"
           />
         </Link>
-        <nav className="flex gap-4 shrink-0">
+        <nav className="flex gap-4">
           <Link
             to="/"
             className={`px-3 py-1 rounded text-sm font-medium transition-colors ${
@@ -73,16 +73,16 @@ function Navigation() {
           title={`Theme: ${THEME_LABELS[themePreference]} -> ${THEME_LABELS[nextThemePreference]}`}
         >
           <ThemeIcon size={14} className="text-text-muted" />
-          <span className="rounded bg-surface-primary px-2 py-0.5 text-text-primary shadow-sm">
+          <span className="hidden sm:inline rounded bg-surface-primary px-2 py-0.5 text-text-primary shadow-sm">
             {THEME_LABELS[themePreference]}
           </span>
-          <span className="pointer-events-none invisible absolute left-1/2 top-full z-50 mt-2 -translate-x-1/2 whitespace-nowrap rounded bg-surface-primary px-2 py-1 text-[11px] font-medium text-text-primary opacity-0 shadow-lg ring-1 ring-border-default transition-all duration-150 group-hover:visible group-hover:opacity-100">
+          <span className="pointer-events-none invisible absolute left-1/2 top-full z-50 mt-2 hidden -translate-x-1/2 whitespace-nowrap rounded bg-surface-primary px-2 py-1 text-[11px] font-medium text-text-primary opacity-0 shadow-lg ring-1 ring-border-default transition-all duration-150 group-hover:visible group-hover:opacity-100 sm:block">
             {`Switch to ${THEME_LABELS[nextThemePreference]}`}
           </span>
         </button>
 
         <span
-          className="text-[11px] font-mono text-text-muted shrink-0"
+          className="hidden text-[11px] font-mono text-text-muted sm:inline"
           title="Station build version and commit hash"
         >
           {`⎇ ${__STATION_VERSION__}`}

--- a/software/station/clients/station-viewer/src/components/Navigation.tsx
+++ b/software/station/clients/station-viewer/src/components/Navigation.tsx
@@ -33,8 +33,8 @@ function Navigation() {
 
   return (
     <div className="relative z-40 bg-surface-primary border-b-2 border-border-default">
-      <div className="px-4 py-2 flex items-center gap-4">
-        <Link to="/" className="group">
+      <div className="px-4 py-2 flex items-center gap-4 overflow-x-auto scrollbar-thin">
+        <Link to="/" className="group shrink-0">
           <img
             src="/logo.svg"
             alt="Station View"
@@ -42,7 +42,7 @@ function Navigation() {
             className="h-8 logo-first-load logo-invert opacity-80 transition-opacity duration-200 group-hover:opacity-100"
           />
         </Link>
-        <nav className="flex gap-4">
+        <nav className="flex gap-4 shrink-0">
           <Link
             to="/"
             className={`px-3 py-1 rounded text-sm font-medium transition-colors ${
@@ -82,7 +82,7 @@ function Navigation() {
         </button>
 
         <span
-          className="text-[11px] font-mono text-text-muted"
+          className="text-[11px] font-mono text-text-muted shrink-0"
           title="Station build version and commit hash"
         >
           {`⎇ ${__STATION_VERSION__}`}

--- a/software/station/clients/station-viewer/src/pages/HomePage.tsx
+++ b/software/station/clients/station-viewer/src/pages/HomePage.tsx
@@ -68,15 +68,20 @@ function HomePage() {
   return (
     <div className="flex-1 flex flex-col">
       <div className="relative z-20 bg-surface-primary border-b-2 border-border-default">
-        <div className="px-4 py-2 flex items-center gap-4 overflow-x-auto scrollbar-thin">
+        <div className="px-4 py-2 flex flex-wrap gap-x-4 gap-y-2 items-center">
           {connectionStats && (
             <>
-              <div className="flex items-center gap-2 shrink-0">
+              <div className="flex items-center gap-2">
                 <div className="flex items-center gap-2 px-2 py-1 bg-surface-secondary rounded border border-border-default">
-                  <span className="text-text-label text-xs uppercase tracking-wide">Status</span>
-                  <span className={`font-semibold uppercase text-xs ${getConnectionStatusColor(connectionStats.status)}`}>
+                  <span className="hidden sm:inline text-text-label text-xs uppercase tracking-wide">Status</span>
+                  <span className="hidden sm:inline font-semibold uppercase text-xs text-text-label">
                     {connectionStats.status}
                   </span>
+                  <span className={`sm:hidden inline-flex items-center justify-center w-4 h-4 rounded-full ${
+                    connectionStats.status === 'connected' ? 'bg-accent-success' :
+                    connectionStats.status === 'connecting' ? 'bg-accent-warning' :
+                    'bg-accent-critical'
+                  }`} aria-label={connectionStats.status}></span>
                 </div>
                 {connectionStats.status === 'connected' && inferenceState?.st3215?.data?.buses && inferenceState.st3215.data.buses.length > 0 && (
                   <div className="hidden sm:flex items-center gap-2 px-2 py-1 bg-surface-secondary rounded border border-border-default">
@@ -104,7 +109,7 @@ function HomePage() {
                   TAG
                 </button>
               </div>
-              <div className="flex items-center gap-x-4 gap-y-1 text-xs font-mono shrink-0">
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs font-mono">
                 <div className="flex items-center gap-1.5">
                   <span className="text-text-muted">Endpoint:</span>
                   <span className="text-accent-data">{connectionStats.endpoint}</span>

--- a/software/station/clients/station-viewer/src/pages/HomePage.tsx
+++ b/software/station/clients/station-viewer/src/pages/HomePage.tsx
@@ -68,10 +68,10 @@ function HomePage() {
   return (
     <div className="flex-1 flex flex-col">
       <div className="relative z-20 bg-surface-primary border-b-2 border-border-default">
-        <div className="px-4 py-2 flex flex-wrap gap-x-4 gap-y-2 items-center">
+        <div className="px-4 py-2 flex items-center gap-4 overflow-x-auto scrollbar-thin">
           {connectionStats && (
             <>
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2 shrink-0">
                 <div className="flex items-center gap-2 px-2 py-1 bg-surface-secondary rounded border border-border-default">
                   <span className="text-text-label text-xs uppercase tracking-wide">Status</span>
                   <span className={`font-semibold uppercase text-xs ${getConnectionStatusColor(connectionStats.status)}`}>
@@ -79,7 +79,7 @@ function HomePage() {
                   </span>
                 </div>
                 {connectionStats.status === 'connected' && inferenceState?.st3215?.data?.buses && inferenceState.st3215.data.buses.length > 0 && (
-                  <div className="flex items-center gap-2 px-2 py-1 bg-surface-secondary rounded border border-border-default">
+                  <div className="hidden sm:flex items-center gap-2 px-2 py-1 bg-surface-secondary rounded border border-border-default">
                     <span className="text-text-label text-xs uppercase tracking-wide">FPS</span>
                     <span className={`font-bold text-xs font-mono ${connectionStats.isFpsReady ? getFPSColor(connectionStats.fps) : 'text-text-label'}`}>
                       {connectionStats.isFpsReady ? `${connectionStats.fps.toFixed(1)} Hz` : '--'}
@@ -104,7 +104,7 @@ function HomePage() {
                   TAG
                 </button>
               </div>
-              <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs font-mono">
+              <div className="flex items-center gap-x-4 gap-y-1 text-xs font-mono shrink-0">
                 <div className="flex items-center gap-1.5">
                   <span className="text-text-muted">Endpoint:</span>
                   <span className="text-accent-data">{connectionStats.endpoint}</span>

--- a/software/station/clients/station-viewer/vite.config.ts
+++ b/software/station/clients/station-viewer/vite.config.ts
@@ -44,7 +44,7 @@ function resolveWorkspaceVersion(): string {
 
 function resolveGitHash(): string {
   try {
-    return execSync('git rev-parse --short=10 HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
+    return execSync('git rev-parse --short=7 HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
       .toString()
       .trim();
   } catch {


### PR DESCRIPTION
## Summary

Improve the station viewer mobile top panels so they fit narrow screens without horizontal scrolling.

## Demo

<img width="337" height="130" alt="Screenshot 2026-04-21 at 23 43 14" src="https://github.com/user-attachments/assets/ac052829-8d7d-4bf6-8d48-2da24f94c759" />
<img width="341" height="133" alt="Screenshot 2026-04-21 at 23 43 06" src="https://github.com/user-attachments/assets/bf3b1ed5-c1ac-45d2-a54f-e75635d7b21a" />
