### PR TITLE
chore: target Dependabot PRs at dev branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/software/station/clients/station-viewer"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
       timezone: "Europe/Madrid"


### PR DESCRIPTION
## What

Add `target-branch: "dev"` to the existing Dependabot configuration so that all version-update PRs are opened against `dev` instead of `main` (the repository default branch).

## Why

All development work targets `dev`. Dependabot PRs landing directly on `main` skip the integration branch and could introduce untested dependency changes.

## Changes

- `.github/dependabot.yml` — add `target-branch: "dev"` to the npm ecosystem entry

No other settings (schedule, cooldown, groups, labels) are affected.

## Note

Security-update PRs created by Dependabot always target the default branch (`main`) regardless of `target-branch`. This is expected GitHub behaviour — only version updates are redirected.