### PR TITLE
Reduce Station Viewer camera memory pressure

### DIFF
--- a/software/station/clients/station-viewer/src/api/frame-parser.ts
+++ b/software/station/clients/station-viewer/src/api/frame-parser.ts
@@ -2,6 +2,10 @@ import Long from 'long';
 import { drivers, inference, motors_mirroring, normvla, st3215, sysinfo, usbvideo } from '@/api/proto.js';
 import { NormFsClient } from "./normfs.js";
 import { getGlobalTimeAdjustmentNs, isTimeSyncActive } from '@/api/time-sync.js';
+import {
+  createLiveCameraMetadataEnvelope,
+  publishLiveCameraFrame,
+} from '@/usbvideo/live-camera-store';
 
 export interface FrameEntry<T> {
   queueId: string;
@@ -37,6 +41,11 @@ export interface Frame {
 
 // Find entry in previous frame with matching queue and pointer
 type DecodedEntry = st3215.IInferenceState | st3215.ITxEnvelope | usbvideo.IRxEnvelope | motors_mirroring.IRxEnvelope | sysinfo.IEnvelope | normvla.IFrame | null;
+
+interface ParseFrameOptions {
+  retainRawData?: boolean;
+  publishVideoFrames?: boolean;
+}
 
 function findPreviousEntry(
   previousFrame: Frame | undefined,
@@ -112,12 +121,15 @@ export async function parseFrame(
   inferenceRx: inference.IInferenceRx,
   entryIdBytes: Uint8Array,
   normFs: NormFsClient,
-  previousFrame?: Frame
+  previousFrame?: Frame,
+  options: ParseFrameOptions = {},
 ): Promise<Frame> {
+  const retainRawData = options.retainRawData ?? true;
+  const publishVideoFrames = options.publishVideoFrames ?? false;
   const frame: Frame = {
     stateId: new Uint8Array(Array.from(entryIdBytes)),
     videoQueues: [],
-    otherEntries: {}
+    otherEntries: retainRawData ? {} : undefined
   };
 
   // Add timestamps from InferenceRx
@@ -250,16 +262,21 @@ export async function parseFrame(
               queueId: result.queue,
               ptr: result.ptr,
               data: result.decoded as st3215.IInferenceState,
-              rawData: result.rawData ?? null,
+              rawData: retainRawData ? result.rawData ?? null : null,
               queueType: result.type
             };
             break;
           case drivers.QueueDataType.QDT_USB_VIDEO_FRAMES:
+            if (publishVideoFrames) {
+              publishLiveCameraFrame(result.queue, result.decoded as usbvideo.IRxEnvelope);
+            }
             frame.videoQueues!.push({
               queueId: result.queue,
               ptr: result.ptr,
-              data: result.decoded as usbvideo.IRxEnvelope,
-              rawData: result.rawData ?? null,
+              data: publishVideoFrames
+                ? createLiveCameraMetadataEnvelope(result.decoded as usbvideo.IRxEnvelope)
+                : result.decoded as usbvideo.IRxEnvelope,
+              rawData: retainRawData ? result.rawData ?? null : null,
               queueType: result.type
             });
             break;
@@ -268,7 +285,7 @@ export async function parseFrame(
               queueId: result.queue,
               ptr: result.ptr,
               data: result.decoded as motors_mirroring.IRxEnvelope,
-              rawData: result.rawData ?? null,
+              rawData: retainRawData ? result.rawData ?? null : null,
               queueType: result.type
             };
             break;
@@ -277,7 +294,7 @@ export async function parseFrame(
               queueId: result.queue,
               ptr: result.ptr,
               data: result.decoded as sysinfo.IEnvelope,
-              rawData: result.rawData ?? null,
+              rawData: retainRawData ? result.rawData ?? null : null,
               queueType: result.type
             };
             break;
@@ -286,7 +303,7 @@ export async function parseFrame(
               queueId: result.queue,
               ptr: result.ptr,
               data: result.decoded as st3215.ITxEnvelope,
-              rawData: result.rawData ?? null,
+              rawData: retainRawData ? result.rawData ?? null : null,
               queueType: result.type
             };
             break;
@@ -296,11 +313,11 @@ export async function parseFrame(
             queueId: result.queue,
             ptr: result.ptr,
             data: result.decoded as normvla.IFrame,
-            rawData: result.rawData ?? null,
+            rawData: retainRawData ? result.rawData ?? null : null,
             queueType: result.type ?? drivers.QueueDataType.QDT_SYSTEM
           };
         }
-      } else if (result.rawData) {
+      } else if (retainRawData && result.rawData) {
         // Store unknown entries as raw bytes with pointers
         frame.otherEntries![result.queue] = {
           ptr: result.ptr,

--- a/software/station/clients/station-viewer/src/api/websocket.ts
+++ b/software/station/clients/station-viewer/src/api/websocket.ts
@@ -102,7 +102,10 @@ class WebSocketManager extends EventTarget {
 
         // Decode as InferenceRx and parse frame
         const inferenceRx = inference.InferenceRx.decode(entry.data);
-        const frame = await parseFrame(inferenceRx, entry.id, this.normFs, this.currentFrame || undefined);
+        const frame = await parseFrame(inferenceRx, entry.id, this.normFs, this.currentFrame || undefined, {
+          retainRawData: false,
+          publishVideoFrames: true,
+        });
 
         // Update and dispatch
         this.currentFrame = frame;

--- a/software/station/clients/station-viewer/src/st3215/BaseRobotRenderer.tsx
+++ b/software/station/clients/station-viewer/src/st3215/BaseRobotRenderer.tsx
@@ -37,6 +37,15 @@ const BaseRobotRenderer = forwardRef<BaseRobotRendererRef, BaseRobotRendererProp
   const sceneRef = useRef<any>(null);
   const isInitializedRef = useRef(false);
 
+  const disposeMaterial = (material: THREE.Material) => {
+    Object.values(material).forEach((value) => {
+      if (value instanceof THREE.Texture) {
+        value.dispose();
+      }
+    });
+    material.dispose();
+  };
+
   const disposeObject3D = (object: THREE.Object3D | null) => {
     if (!object) return;
     object.traverse((child: any) => {
@@ -45,9 +54,9 @@ const BaseRobotRenderer = forwardRef<BaseRobotRendererRef, BaseRobotRendererProp
       }
       if (child.material) {
         if (Array.isArray(child.material)) {
-          child.material.forEach((material: any) => material.dispose());
+          child.material.forEach((material: THREE.Material) => disposeMaterial(material));
         } else {
-          child.material.dispose();
+          disposeMaterial(child.material);
         }
       }
     });
@@ -204,13 +213,14 @@ const BaseRobotRenderer = forwardRef<BaseRobotRendererRef, BaseRobotRendererProp
 
   useEffect(() => {
     if (!mountRef.current || isInitializedRef.current) return;
+    const mountNode = mountRef.current;
     isInitializedRef.current = true;
 
     const scene = new THREE.Scene();
 
     const camera = new THREE.PerspectiveCamera(
       75,
-      mountRef.current.clientWidth / mountRef.current.clientHeight,
+      mountNode.clientWidth / mountNode.clientHeight,
       0.1,
       1000
     );
@@ -218,10 +228,10 @@ const BaseRobotRenderer = forwardRef<BaseRobotRendererRef, BaseRobotRendererProp
     camera.lookAt(0, 0, 0);
 
     const renderer = new THREE.WebGLRenderer({ antialias: true });
-    renderer.setSize(mountRef.current.clientWidth, mountRef.current.clientHeight);
+    renderer.setSize(mountNode.clientWidth, mountNode.clientHeight);
     renderer.setPixelRatio(window.devicePixelRatio);
     renderer.shadowMap.enabled = true;
-    mountRef.current.appendChild(renderer.domElement);
+    mountNode.appendChild(renderer.domElement);
 
     const ambientLight = new THREE.AmbientLight(0xffffff, 0.6);
     scene.add(ambientLight);
@@ -269,29 +279,32 @@ const BaseRobotRenderer = forwardRef<BaseRobotRendererRef, BaseRobotRendererProp
     animate();
 
     const resizeObserver = new ResizeObserver(() => {
-      if (sceneRef.current && mountRef.current) {
-        const { clientWidth, clientHeight } = mountRef.current;
+      if (sceneRef.current) {
+        const { clientWidth, clientHeight } = mountNode;
         sceneRef.current.renderer.setSize(clientWidth, clientHeight);
         sceneRef.current.camera.aspect = clientWidth / clientHeight;
         sceneRef.current.camera.updateProjectionMatrix();
       }
     });
 
-    if (mountRef.current) {
-      resizeObserver.observe(mountRef.current);
-    }
+    resizeObserver.observe(mountNode);
 
     return () => {
       resizeObserver.disconnect();
       if (sceneRef.current) {
-        cancelAnimationFrame(sceneRef.current.animationId);
-        if (sceneRef.current.robot) {
+        const currentScene = sceneRef.current;
+        cancelAnimationFrame(currentScene.animationId);
+        if (currentScene.robot) {
           cleanupRobot();
         }
-        sceneRef.current.controls.dispose();
-        sceneRef.current.renderer.dispose();
-        if (mountRef.current && sceneRef.current.renderer.domElement.parentNode) {
-          sceneRef.current.renderer.domElement.remove();
+        disposeObject3D(currentScene.scene);
+        currentScene.scene.clear();
+        currentScene.controls.dispose();
+        currentScene.renderer.renderLists.dispose();
+        currentScene.renderer.dispose();
+        currentScene.renderer.forceContextLoss();
+        if (currentScene.renderer.domElement.parentNode) {
+          currentScene.renderer.domElement.remove();
         }
         sceneRef.current = null;
         isInitializedRef.current = false;

--- a/software/station/clients/station-viewer/src/st3215/BusCard.tsx
+++ b/software/station/clients/station-viewer/src/st3215/BusCard.tsx
@@ -394,6 +394,8 @@ const BusCard: React.FC<BusCardProps> = ({
           <RobotCameraView
             primaryVideoSource={primaryVideoSource}
             secondaryVideoSource={secondaryVideoSource}
+            primaryVideoSourceId={primaryVideoSourceId}
+            secondaryVideoSourceId={secondaryVideoSourceId}
             bus={bus}
             busIndex={busIndex}
             showMotorData={true}
@@ -407,7 +409,7 @@ const BusCard: React.FC<BusCardProps> = ({
             bus={bus}
             busIndex={busIndex}
             showMotorData={true}
-            selectedVideoSource={primaryVideoSource}
+            selectedVideoSourceId={primaryVideoSourceId}
             showCalibrateButton={true}
             needsCalibration={needsCalibration}
             isWebControlled={isWebControlled}
@@ -459,9 +461,9 @@ const BusCard: React.FC<BusCardProps> = ({
                 />
               </div>
             </div>
-            {primaryVideoSource && (
+            {primaryVideoSourceId && (
               <div className="absolute top-4 right-4 h-[200px] w-2/5 max-w-[520px] overflow-hidden rounded-lg border border-border-default bg-black shadow-lg pointer-events-auto">
-                <CameraViewer inferenceState={primaryVideoSource} className="h-full w-full" />
+                <CameraViewer sourceId={primaryVideoSourceId} className="h-full w-full" />
               </div>
             )}
           </>

--- a/software/station/clients/station-viewer/src/st3215/BusWebGLRenderer.tsx
+++ b/software/station/clients/station-viewer/src/st3215/BusWebGLRenderer.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useImperativeHandle, useRef } from 'react';
-import { st3215, usbvideo } from '../api/proto';
+import { st3215 } from '../api/proto';
 import SO101Renderer from './SO101Renderer';
 import ElRobotRenderer from './ElRobotRenderer';
 import { BaseRobotRendererRef } from './BaseRobotRenderer';
@@ -14,7 +14,7 @@ interface BusWebGLRendererProps {
   showMotorData?: boolean;
   showCalibrateButton?: boolean;
   needsCalibration?: boolean;
-  selectedVideoSource?: usbvideo.IRxEnvelope;
+  selectedVideoSourceId?: string | null;
   isLeader?: boolean;
   inCalibrationView?: boolean;
   isWebControlled?: boolean;
@@ -33,7 +33,7 @@ const BusWebGLRendererComponent = forwardRef<BusWebGLRendererRef, BusWebGLRender
     },
   }));
 
-  const { bus, showMotorData, busIndex, isWebControlled, selectedVideoSource, showCalibrateButton, needsCalibration, inCalibrationView } = props;
+  const { bus, showMotorData, busIndex, isWebControlled, selectedVideoSourceId, showCalibrateButton, needsCalibration, inCalibrationView } = props;
 
   return (
     <div className="relative w-full h-full">
@@ -48,9 +48,9 @@ const BusWebGLRendererComponent = forwardRef<BusWebGLRendererRef, BusWebGLRender
             <MotorDataTable bus={bus} busIndex={busIndex} isWebControlled={isWebControlled} />
           </div>
         }
-        {selectedVideoSource && (
+        {selectedVideoSourceId && (
           <div className="absolute top-4 right-4 h-[200px] w-2/5 max-w-[520px] overflow-hidden rounded-lg border border-border-default bg-black shadow-lg pointer-events-auto">
-            <CameraViewer inferenceState={selectedVideoSource} className="h-full w-full" />
+            <CameraViewer sourceId={selectedVideoSourceId} className="h-full w-full" />
           </div>
         )}
         {showCalibrateButton && !inCalibrationView && needsCalibration && (

--- a/software/station/clients/station-viewer/src/usbvideo/CameraViewer.tsx
+++ b/software/station/clients/station-viewer/src/usbvideo/CameraViewer.tsx
@@ -1,83 +1,153 @@
-import { memo, useEffect, useState, useRef } from 'react';
-import Long from 'long';
-import { usbvideo } from '../api/proto.js';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import type { LiveCameraFrame } from './live-camera-store';
+import { subscribeLiveCameraFrame } from './live-camera-store';
 
 interface CameraViewerProps {
-  inferenceState: usbvideo.IRxEnvelope;
+  sourceId: string | null | undefined;
   className?: string;
   imageClassName?: string;
   overlay?: 'none' | 'fps';
   fit?: 'contain' | 'cover';
 }
 
+function toBlobPart(data: Uint8Array): BlobPart {
+  if (data.buffer instanceof ArrayBuffer) {
+    if (data.byteOffset === 0 && data.byteLength === data.buffer.byteLength) {
+      return data.buffer;
+    }
+
+    return data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
+  }
+
+  return new Uint8Array(data).buffer;
+}
+
 const CameraViewer = memo(function CameraViewer({
-  inferenceState,
+  sourceId,
   className = '',
   imageClassName = '',
   overlay = 'fps',
   fit = 'contain',
 }: CameraViewerProps) {
   const [fps, setFps] = useState<number>(0);
-  const [imageUrl, setImageUrl] = useState<string>('');
-  const imageUrlRef = useRef<string>('');
-  const previousIndexRef = useRef<Long | null>(null);
+  const [hasImage, setHasImage] = useState(false);
+  const hasImageRef = useRef(false);
+  const imageRef = useRef<HTMLImageElement>(null);
+  const displayedUrlRef = useRef<string | null>(null);
+  const pendingUrlRef = useRef<string | null>(null);
+  const lastFrameIndexRef = useRef<string | null>(null);
+  const generationRef = useRef(0);
   const frameCount = useRef<number>(0);
   const lastFpsTime = useRef<number>(Date.now());
 
-  useEffect(() => {
-    if (!inferenceState || !inferenceState.frames) {
-      return;
+  const revokeUrl = (url: string | null) => {
+    if (url) {
+      URL.revokeObjectURL(url);
+    }
+  };
+
+  const clearImage = useCallback((updateState = true) => {
+    generationRef.current++;
+    const img = imageRef.current;
+    if (img) {
+      img.onload = null;
+      img.onerror = null;
+      img.removeAttribute('src');
     }
 
-    const { frames, stamp } = inferenceState;
-
-    // Get frame data - try framesData first (single frame), then linearData (packed frames)
-    const data = (frames.framesData && frames.framesData.length > 0)
-      ? frames.framesData[0]
-      : frames.linearData;
-
-    if (!data || data.length === 0 || !stamp || !stamp.index) {
-      return;
+    revokeUrl(pendingUrlRef.current);
+    if (displayedUrlRef.current !== pendingUrlRef.current) {
+      revokeUrl(displayedUrlRef.current);
     }
-
-    const newIndex = Long.fromValue(stamp.index);
-
-    // Only create new blob URL if frame index has changed
-    if (!previousIndexRef.current || !previousIndexRef.current.equals(newIndex)) {
-      // FPS calculation
-      frameCount.current++;
-      const nowFps = Date.now();
-      const timeDiff = nowFps - lastFpsTime.current;
-
-      if (timeDiff >= 1000) { // Update every second
-        const calculatedFps = (frameCount.current / timeDiff) * 1000;
-        setFps(calculatedFps);
-        frameCount.current = 0;
-        lastFpsTime.current = nowFps;
-      }
-
-      const blob = new Blob([data.slice()], { type: 'image/jpeg' });
-      const url = URL.createObjectURL(blob);
-      if (imageUrlRef.current) {
-        URL.revokeObjectURL(imageUrlRef.current);
-      }
-      imageUrlRef.current = url;
-      setImageUrl(url);
-      previousIndexRef.current = newIndex;
+    pendingUrlRef.current = null;
+    displayedUrlRef.current = null;
+    lastFrameIndexRef.current = null;
+    hasImageRef.current = false;
+    frameCount.current = 0;
+    lastFpsTime.current = Date.now();
+    if (updateState) {
+      setFps(0);
+      setHasImage(false);
     }
-  }, [inferenceState]);
-
-  // Cleanup effect for component unmount
-  useEffect(() => {
-    return () => {
-      if (imageUrlRef.current) {
-        URL.revokeObjectURL(imageUrlRef.current);
-        imageUrlRef.current = '';
-      }
-    };
   }, []);
 
-  if (!inferenceState) {
+  const updateImage = useCallback((frame: LiveCameraFrame) => {
+    if (!frame.data || frame.data.length === 0) {
+      return;
+    }
+    if (frame.index && frame.index === lastFrameIndexRef.current) {
+      return;
+    }
+
+    const img = imageRef.current;
+    if (!img) {
+      return;
+    }
+
+    frameCount.current++;
+    const nowFps = Date.now();
+    const timeDiff = nowFps - lastFpsTime.current;
+
+    if (timeDiff >= 1000) {
+      const calculatedFps = (frameCount.current / timeDiff) * 1000;
+      setFps(calculatedFps);
+      frameCount.current = 0;
+      lastFpsTime.current = nowFps;
+    }
+
+    const url = URL.createObjectURL(new Blob([toBlobPart(frame.data)], { type: 'image/jpeg' }));
+    const previousPendingUrl = pendingUrlRef.current;
+    const generation = generationRef.current;
+
+    pendingUrlRef.current = url;
+    if (previousPendingUrl && previousPendingUrl !== displayedUrlRef.current) {
+      URL.revokeObjectURL(previousPendingUrl);
+    }
+
+    img.onload = () => {
+      if (generationRef.current !== generation || pendingUrlRef.current !== url) {
+        URL.revokeObjectURL(url);
+        return;
+      }
+
+      const previousDisplayedUrl = displayedUrlRef.current;
+      displayedUrlRef.current = url;
+      pendingUrlRef.current = null;
+      lastFrameIndexRef.current = frame.index;
+      if (!hasImageRef.current) {
+        hasImageRef.current = true;
+        setHasImage(true);
+      }
+
+      if (previousDisplayedUrl && previousDisplayedUrl !== url) {
+        URL.revokeObjectURL(previousDisplayedUrl);
+      }
+    };
+
+    img.onerror = () => {
+      if (pendingUrlRef.current === url) {
+        pendingUrlRef.current = null;
+      }
+      URL.revokeObjectURL(url);
+    };
+
+    img.src = url;
+  }, []);
+
+  useEffect(() => {
+    clearImage();
+    if (!sourceId) {
+      return () => clearImage(false);
+    }
+
+    const unsubscribe = subscribeLiveCameraFrame(sourceId, updateImage);
+    return () => {
+      unsubscribe();
+      clearImage(false);
+    };
+  }, [clearImage, sourceId, updateImage]);
+
+  if (!sourceId) {
     return <div className="text-text-primary p-4">Waiting for USB Video data...</div>;
   }
 
@@ -86,12 +156,13 @@ const CameraViewer = memo(function CameraViewer({
   return (
     <div className={`overflow-hidden h-full ${className}`}>
       <div className="relative flex justify-center items-center h-full w-full bg-black/20">
-        {imageUrl && (
-          <img
-            src={imageUrl}
-            alt="USB Camera Feed"
-            className={`h-full w-full ${fitClassName} ${imageClassName}`}
-          />
+        <img
+          ref={imageRef}
+          alt="USB Camera Feed"
+          className={`h-full w-full ${fitClassName} ${imageClassName} ${hasImage ? '' : 'hidden'}`}
+        />
+        {!hasImage && (
+          <div className="text-text-primary p-4">Waiting for USB Video data...</div>
         )}
         {overlay === 'fps' && (
           <div className="absolute top-0 right-0 p-2 text-right bg-surface-secondary/70 rounded-bl-lg backdrop-blur-sm">

--- a/software/station/clients/station-viewer/src/usbvideo/RobotCameraView.tsx
+++ b/software/station/clients/station-viewer/src/usbvideo/RobotCameraView.tsx
@@ -8,6 +8,8 @@ import CameraViewer from './CameraViewer';
 interface RobotCameraViewProps {
   primaryVideoSource?: usbvideo.IRxEnvelope;
   secondaryVideoSource?: usbvideo.IRxEnvelope;
+  primaryVideoSourceId?: string | null;
+  secondaryVideoSourceId?: string | null;
   bus: st3215.InferenceState.IBusState;
   busIndex: number;
   isWebControlled?: boolean;
@@ -17,8 +19,9 @@ interface RobotCameraViewProps {
 }
 
 const RobotCameraView = memo(function RobotCameraView({
-  primaryVideoSource,
   secondaryVideoSource,
+  primaryVideoSourceId,
+  secondaryVideoSourceId,
   bus,
   busIndex,
   isWebControlled,
@@ -34,9 +37,9 @@ const RobotCameraView = memo(function RobotCameraView({
   return (
     <div className="flex flex-col w-full h-full min-h-0 overflow-hidden bg-black rounded-b-lg">
       <div className="relative min-h-0" style={{ flex: '1 1 auto' }}>
-        {primaryVideoSource ? (
+        {primaryVideoSourceId ? (
           <CameraViewer
-            inferenceState={primaryVideoSource}
+            sourceId={primaryVideoSourceId}
             className="h-full w-full"
             imageClassName="select-none"
             fit="contain"
@@ -52,10 +55,10 @@ const RobotCameraView = memo(function RobotCameraView({
           </div>
         )}
 
-        {secondaryVideoSource && (
+        {secondaryVideoSourceId && (
           <div className="absolute bottom-4 right-4 z-30 h-[160px] w-2/5 min-w-[220px] max-w-[360px] overflow-hidden rounded-lg border-2 border-border-default bg-surface-primary shadow-2xl">
             <CameraViewer
-              inferenceState={secondaryVideoSource}
+              sourceId={secondaryVideoSourceId}
               className="h-full w-full"
               imageClassName="select-none"
               fit="contain"

--- a/software/station/clients/station-viewer/src/usbvideo/camera-source.ts
+++ b/software/station/clients/station-viewer/src/usbvideo/camera-source.ts
@@ -1,8 +1,9 @@
 import { FrameEntry } from '../api/frame-parser';
 import { usbvideo } from '../api/proto.js';
+import { getLiveCameraSourceId } from './live-camera-store';
 
 export function getVideoSourceId(entry: FrameEntry<usbvideo.IRxEnvelope>): string {
-  return entry.data.camera?.uniqueId || entry.queueId;
+  return getLiveCameraSourceId(entry.queueId, entry.data);
 }
 
 export function formatCameraName(source?: usbvideo.IRxEnvelope, fallback = 'No camera'): string {

--- a/software/station/clients/station-viewer/src/usbvideo/live-camera-store.ts
+++ b/software/station/clients/station-viewer/src/usbvideo/live-camera-store.ts
@@ -1,0 +1,88 @@
+import Long from 'long';
+import { usbvideo } from '@/api/proto.js';
+
+export interface LiveCameraFrame {
+  sourceId: string;
+  queueId: string;
+  envelope: usbvideo.IRxEnvelope;
+  data: Uint8Array;
+  index: string | null;
+}
+
+type LiveCameraListener = (frame: LiveCameraFrame) => void;
+
+const framesBySourceId = new Map<string, LiveCameraFrame>();
+const listenersBySourceId = new Map<string, Set<LiveCameraListener>>();
+
+export function getLiveCameraSourceId(queueId: string, envelope: usbvideo.IRxEnvelope): string {
+  return envelope.camera?.uniqueId || queueId;
+}
+
+export function createLiveCameraMetadataEnvelope(
+  envelope: usbvideo.IRxEnvelope,
+): usbvideo.IRxEnvelope {
+  return {
+    type: envelope.type,
+    stamp: envelope.stamp,
+    camera: envelope.camera,
+    formats: envelope.formats,
+    error: envelope.error,
+    lastInferenceQueuePtr: envelope.lastInferenceQueuePtr,
+    frames: envelope.frames
+      ? {
+          format: envelope.frames.format,
+          stamps: envelope.frames.stamps,
+        }
+      : undefined,
+  };
+}
+
+export function publishLiveCameraFrame(
+  queueId: string,
+  envelope: usbvideo.IRxEnvelope,
+): void {
+  const data = envelope.frames?.framesData?.[0] ?? envelope.frames?.linearData;
+  if (!data || data.length === 0) {
+    return;
+  }
+
+  const sourceId = getLiveCameraSourceId(queueId, envelope);
+  const index = envelope.stamp?.index != null
+    ? Long.fromValue(envelope.stamp.index).toString()
+    : null;
+  const frame = {
+    sourceId,
+    queueId,
+    envelope,
+    data,
+    index,
+  };
+
+  framesBySourceId.set(sourceId, frame);
+  listenersBySourceId.get(sourceId)?.forEach((listener) => listener(frame));
+}
+
+export function getLiveCameraFrame(sourceId: string): LiveCameraFrame | null {
+  return framesBySourceId.get(sourceId) ?? null;
+}
+
+export function subscribeLiveCameraFrame(
+  sourceId: string,
+  listener: LiveCameraListener,
+): () => void {
+  const listeners = listenersBySourceId.get(sourceId) ?? new Set<LiveCameraListener>();
+  listeners.add(listener);
+  listenersBySourceId.set(sourceId, listeners);
+
+  const currentFrame = getLiveCameraFrame(sourceId);
+  if (currentFrame) {
+    listener(currentFrame);
+  }
+
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) {
+      listenersBySourceId.delete(sourceId);
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- Move live USB camera frame bytes out of React-facing frame state into a per-camera live frame store
- Refactor camera rendering to subscribe by source id and update the image element imperatively
- Avoid per-frame React state updates for object URLs and tighten object URL revocation
- Harden Three.js/WebGL cleanup when switching away from 3D views