### PR TITLE
station-viewer: camera-mode overhaul (dual-cam layouts, HUD controls, motor panel, fullscreen refactor)

### DIFF
--- a/software/station/clients/station-viewer/src/hooks/index.ts
+++ b/software/station/clients/station-viewer/src/hooks/index.ts
@@ -9,6 +9,7 @@ export { useInferenceTags, invalidateTagsCache } from "./useInferenceTags";
 export { useKeyboardNavigation } from "./useKeyboardNavigation";
 export { useWakeLock } from "./useWakeLock";
 export { useBusMonitor } from "./useBusMonitor";
+export { useElementFullscreen } from "./useElementFullscreen";
 export { ThemeProvider, useTheme } from "./useTheme";
 export type { Theme } from "./useTheme";
 export type { TimelineControlsRef } from "./useKeyboardNavigation";

--- a/software/station/clients/station-viewer/src/hooks/useElementFullscreen.ts
+++ b/software/station/clients/station-viewer/src/hooks/useElementFullscreen.ts
@@ -1,0 +1,87 @@
+import { RefObject, useCallback, useEffect, useState } from 'react';
+
+interface UseElementFullscreenOptions {
+  closeOnEscape?: boolean;
+}
+
+interface UseElementFullscreenResult {
+  isFullscreen: boolean;
+  toggleFullscreen: () => Promise<void>;
+  exitFullscreen: () => Promise<void>;
+}
+
+export function useElementFullscreen(
+  elementRef: RefObject<HTMLElement>,
+  options: UseElementFullscreenOptions = {},
+): UseElementFullscreenResult {
+  const { closeOnEscape = true } = options;
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  const syncFullscreenState = useCallback(() => {
+    const element = elementRef.current;
+    setIsFullscreen(Boolean(element && document.fullscreenElement === element));
+  }, [elementRef]);
+
+  const exitFullscreen = useCallback(async () => {
+    const element = elementRef.current;
+    if (!element || document.fullscreenElement !== element) {
+      return;
+    }
+
+    try {
+      await document.exitFullscreen();
+    } catch {
+      // Ignore fullscreen errors (for example, if blocked by browser policy).
+    }
+  }, [elementRef]);
+
+  const toggleFullscreen = useCallback(async () => {
+    const element = elementRef.current;
+    if (!element) {
+      return;
+    }
+
+    try {
+      if (document.fullscreenElement === element) {
+        await document.exitFullscreen();
+        return;
+      }
+
+      await element.requestFullscreen();
+    } catch {
+      // Ignore fullscreen errors (for example, if blocked by browser policy).
+    }
+  }, [elementRef]);
+
+  useEffect(() => {
+    document.addEventListener('fullscreenchange', syncFullscreenState);
+    return () => {
+      document.removeEventListener('fullscreenchange', syncFullscreenState);
+    };
+  }, [syncFullscreenState]);
+
+  useEffect(() => {
+    if (!closeOnEscape || !isFullscreen) {
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') {
+        return;
+      }
+
+      void exitFullscreen();
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [closeOnEscape, exitFullscreen, isFullscreen]);
+
+  return {
+    isFullscreen,
+    toggleFullscreen,
+    exitFullscreen,
+  };
+}

--- a/software/station/clients/station-viewer/src/st3215/BusCard.tsx
+++ b/software/station/clients/station-viewer/src/st3215/BusCard.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Long from 'long';
-import { ArrowLeftRight, Camera, Maximize2, Minimize2, SlidersHorizontal } from 'lucide-react';
+import { Camera } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { commandManager } from '@/api/commands';
 import { FrameEntry } from '@/api/frame-parser';
+import { useElementFullscreen } from '@/hooks/useElementFullscreen';
 import { motors_mirroring, st3215, usbvideo } from '@/api/proto.js';
 import { serverToLocal } from '@/api/timestamp-utils';
 import { getLatencyBgColor, getLatencyTextColor } from '@/utils/color-utils';
@@ -11,6 +12,7 @@ import { getVideoSourceId, getVideoSourceLabel } from '@/usbvideo/camera-source'
 import CameraViewer from '@/usbvideo/CameraViewer';
 import RobotCameraView from '@/usbvideo/RobotCameraView';
 import BusWebGLRenderer from '@/st3215/BusWebGLRenderer';
+import CameraHudControls from '@/st3215/CameraHudControls';
 import MotorDataTable from '@/st3215/MotorDataTable';
 import { ADDR_GOAL_POSITION, getMotorPosition } from '@/st3215/motor-parser';
 
@@ -27,6 +29,9 @@ interface LatencyStats {
 
 const STALE_CAMERA_MAX_AGE_MS = 60_000;
 const MIN_CALIBRATED_RANGE = 100;
+const WEB_CONTROL_STORAGE_TTL_MS = 60_000;
+const WEB_CONTROL_MIRROR_IGNORE_AFTER_LOCAL_REQUEST_MS = 5_000;
+const WEB_CONTROL_MIRROR_CONFIRM_MS = 800;
 
 type RobotViewMode = 'model' | 'camera';
 type CameraLayoutMode = 'pip' | 'side-by-side' | 'stacked';
@@ -56,6 +61,7 @@ const BusCard: React.FC<BusCardProps> = ({
   const latencyHistoryRef = useRef<Map<string, LatencyReading[]>>(new Map());
   const hasPrimaryVideoSourcePreferenceRef = useRef(false);
   const lastWebControlRequestMsRef = useRef(0);
+  const mirrorSeenWhileWebControlAtRef = useRef<number | null>(null);
   const [primaryVideoSourceId, setPrimaryVideoSourceId] = useState<string | null>(null);
   const [secondaryVideoSourceId, setSecondaryVideoSourceId] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<RobotViewMode>('model');
@@ -63,9 +69,13 @@ const BusCard: React.FC<BusCardProps> = ({
   const [primaryCameraFit, setPrimaryCameraFit] = useState<CameraFitMode>('contain');
   const [secondaryCameraFit, setSecondaryCameraFit] = useState<CameraFitMode>('contain');
   const [showCameraMotorData, setShowCameraMotorData] = useState(false);
-  const [isCameraFullscreen, setIsCameraFullscreen] = useState(false);
   const [isWebControlled, setIsWebControlled] = useState(false);
   const cameraContentRef = useRef<HTMLDivElement>(null);
+  const {
+    isFullscreen: isCameraFullscreen,
+    toggleFullscreen: toggleCameraFullscreen,
+    exitFullscreen: exitCameraFullscreen,
+  } = useElementFullscreen(cameraContentRef);
   const busSerialNumber = bus.bus?.serialNumber ?? null;
   const webControlledStorageKey = busSerialNumber
     ? `station-viewer:web-controlled:${busSerialNumber}`
@@ -104,7 +114,18 @@ const BusCard: React.FC<BusCardProps> = ({
   const setWebControlledState = useCallback((nextState: boolean) => {
     setIsWebControlled(nextState);
     if (webControlledStorageKey) {
-      sessionStorage.setItem(webControlledStorageKey, nextState ? 'true' : 'false');
+      if (!nextState) {
+        sessionStorage.removeItem(webControlledStorageKey);
+        return;
+      }
+
+      sessionStorage.setItem(
+        webControlledStorageKey,
+        JSON.stringify({
+          enabled: true,
+          timestamp: Date.now(),
+        }),
+      );
     }
   }, [webControlledStorageKey]);
 
@@ -141,19 +162,61 @@ const BusCard: React.FC<BusCardProps> = ({
       return;
     }
 
-    setIsWebControlled(sessionStorage.getItem(webControlledStorageKey) === 'true');
+    const persistedValue = sessionStorage.getItem(webControlledStorageKey);
+    if (!persistedValue) {
+      setIsWebControlled(false);
+      return;
+    }
+
+    try {
+      const parsedValue = JSON.parse(persistedValue) as { enabled?: boolean; timestamp?: number };
+      const isFresh = typeof parsedValue.timestamp === 'number'
+        && Date.now() - parsedValue.timestamp <= WEB_CONTROL_STORAGE_TTL_MS;
+      const isEnabled = parsedValue.enabled === true && isFresh;
+
+      setIsWebControlled(isEnabled);
+      if (!isEnabled) {
+        sessionStorage.removeItem(webControlledStorageKey);
+      }
+    } catch {
+      setIsWebControlled(false);
+      sessionStorage.removeItem(webControlledStorageKey);
+    }
   }, [webControlledStorageKey]);
 
   useEffect(() => {
-    if (!isWebControlled || !currentMirror) {
+    if (!isWebControlled) {
+      mirrorSeenWhileWebControlAtRef.current = null;
       return;
     }
 
-    const isFreshLocalWebControlRequest = Date.now() - lastWebControlRequestMsRef.current < 1000;
-    if (isFreshLocalWebControlRequest) {
+    if (!currentMirror) {
+      mirrorSeenWhileWebControlAtRef.current = null;
       return;
     }
 
+    const nowMs = Date.now();
+    const isTooSoonAfterLocalRequest =
+      nowMs - lastWebControlRequestMsRef.current < WEB_CONTROL_MIRROR_IGNORE_AFTER_LOCAL_REQUEST_MS;
+
+    if (isTooSoonAfterLocalRequest) {
+      mirrorSeenWhileWebControlAtRef.current = null;
+      return;
+    }
+
+    if (mirrorSeenWhileWebControlAtRef.current === null) {
+      mirrorSeenWhileWebControlAtRef.current = nowMs;
+      return;
+    }
+
+    const hasPersistentMirrorWhileWebControl =
+      nowMs - mirrorSeenWhileWebControlAtRef.current >= WEB_CONTROL_MIRROR_CONFIRM_MS;
+
+    if (!hasPersistentMirrorWhileWebControl) {
+      return;
+    }
+
+    mirrorSeenWhileWebControlAtRef.current = null;
     setWebControlledState(false);
   }, [currentMirror, isWebControlled, setWebControlledState]);
 
@@ -342,66 +405,14 @@ const BusCard: React.FC<BusCardProps> = ({
         : activeVideoSources,
     [activeVideoSources, secondaryVideoSourceId, viewMode],
   );
-  const toggleCameraFullscreen = useCallback(async () => {
-    const cameraContent = cameraContentRef.current;
-    if (!cameraContent) {
+
+  useEffect(() => {
+    if (viewMode === "camera") {
       return;
     }
 
-    try {
-      if (document.fullscreenElement === cameraContent) {
-        await document.exitFullscreen();
-        return;
-      }
-
-      await cameraContent.requestFullscreen();
-    } catch {
-      // Ignore fullscreen errors (for example, if blocked by browser policy).
-    }
-  }, []);
-
-  useEffect(() => {
-    const onFullscreenChange = () => {
-      const cameraContent = cameraContentRef.current;
-      setIsCameraFullscreen(Boolean(cameraContent && document.fullscreenElement === cameraContent));
-    };
-
-    document.addEventListener("fullscreenchange", onFullscreenChange);
-    return () => {
-      document.removeEventListener("fullscreenchange", onFullscreenChange);
-    };
-  }, []);
-
-  useEffect(() => {
-    if (!isCameraFullscreen) {
-      return;
-    }
-
-    const onKeyDown = (event: KeyboardEvent) => {
-      const cameraContent = cameraContentRef.current;
-      if (
-        event.key === "Escape" &&
-        cameraContent &&
-        document.fullscreenElement === cameraContent
-      ) {
-        void document.exitFullscreen();
-      }
-    };
-
-    document.addEventListener("keydown", onKeyDown);
-    return () => {
-      document.removeEventListener("keydown", onKeyDown);
-    };
-  }, [isCameraFullscreen]);
-
-  useEffect(() => {
-    const cameraContent = cameraContentRef.current;
-    if (!cameraContent || viewMode === "camera" || document.fullscreenElement !== cameraContent) {
-      return;
-    }
-
-    void document.exitFullscreen();
-  }, [viewMode]);
+    void exitCameraFullscreen();
+  }, [exitCameraFullscreen, viewMode]);
 
   return (
     <div className="min-w-0 border border-border-default rounded-lg bg-surface-primary/50">
@@ -439,7 +450,8 @@ const BusCard: React.FC<BusCardProps> = ({
                 : (currentMirror?.source?.id?.uniqueId ?? "")
             }
             onChange={(e) => handleControlSourceChange(e.target.value || null)}
-            className={`${selectControlClass} ${controlSourceWidthClass}`}
+            disabled={!busSerialNumber}
+            className={`${selectControlClass} ${controlSourceWidthClass} disabled:cursor-not-allowed disabled:opacity-60`}
           >
             <option value="">(Self-controlled)</option>
             <option value="web-controlled">(Web-controlled)</option>
@@ -573,91 +585,20 @@ const BusCard: React.FC<BusCardProps> = ({
               onPrimaryCameraFitToggle={() => setPrimaryCameraFit((fit) => (fit === "contain" ? "cover" : "contain"))}
               onSecondaryCameraFitToggle={() => setSecondaryCameraFit((fit) => (fit === "contain" ? "cover" : "contain"))}
             />
-            <div className="absolute left-2 top-2 z-50 flex max-w-[calc(100%-1rem)] flex-wrap gap-1.5 rounded-lg border border-border-default bg-surface-primary/75 p-1.5 shadow-lg backdrop-blur-sm sm:left-3 sm:top-3">
-              <div
-                className="flex rounded-md border border-border-subtle bg-surface-primary p-0.5"
-                role="group"
-                aria-label="Camera layout"
-              >
-                <button
-                  type="button"
-                  onClick={() => setCameraLayout("pip")}
-                  className={`flex h-8 w-8 items-center justify-center rounded transition-colors ${
-                    cameraLayout === "pip"
-                      ? "bg-accent-data text-surface-base"
-                      : "text-text-muted hover:text-text-primary"
-                  }`}
-                  title="PiP layout"
-                  aria-label="PiP layout"
-                >
-                  <span className="relative block h-4 w-4 rounded-[2px] border border-current">
-                    <span className="absolute -bottom-px -right-px h-2 w-2 rounded-[1px] border border-current bg-current/20" />
-                  </span>
-                </button>
-                <button
-                  type="button"
-                  onClick={() =>
-                    setCameraLayout((layout) =>
-                      layout === "side-by-side" ? "stacked" : "side-by-side",
-                    )
-                  }
-                  className={`flex h-8 w-8 items-center justify-center rounded transition-colors ${
-                    cameraLayout === "side-by-side" || cameraLayout === "stacked"
-                      ? "bg-accent-data text-surface-base"
-                      : "text-text-muted hover:text-text-primary"
-                  }`}
-                  title={cameraLayout === "stacked" ? "Top-bottom layout" : "Side-by-side layout"}
-                  aria-label={cameraLayout === "stacked" ? "Top-bottom layout" : "Side-by-side layout"}
-                >
-                  <span className={`grid h-4 w-4 grid-cols-2 gap-[2px] ${cameraLayout === "stacked" ? "rotate-90" : ""}`}>
-                    <span className="rounded-[1px] border border-current" />
-                    <span className="rounded-[1px] border border-current" />
-                  </span>
-                </button>
-              </div>
-              <button
-                type="button"
-                onClick={handleSwapVideoSources}
-                disabled={!primaryVideoSourceId || !secondaryVideoSourceId}
-                className="flex h-9 w-9 items-center justify-center rounded-md border border-border-subtle bg-surface-primary text-text-muted transition-colors hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40"
-                title="Swap cameras"
-                aria-label="Swap cameras"
-              >
-                <ArrowLeftRight className="h-4 w-4" aria-hidden="true" />
-              </button>
-              {hasMotors && (
-                <button
-                  type="button"
-                  onClick={() => setShowCameraMotorData((prev) => !prev)}
-                  className={`flex h-9 w-9 items-center justify-center rounded-md border transition-colors ${
-                    showCameraMotorData
-                      ? "border-accent-success-deep bg-accent-success-bg text-text-primary"
-                      : "border-border-subtle bg-surface-primary text-text-muted hover:text-text-primary"
-                  }`}
-                  title={showCameraMotorData ? "Hide motor panel" : "Show motor panel"}
-                  aria-label={showCameraMotorData ? "Hide motor panel" : "Show motor panel"}
-                >
-                  <SlidersHorizontal className="h-4 w-4" aria-hidden="true" />
-                </button>
-              )}
-              <button
-                type="button"
-                onClick={toggleCameraFullscreen}
-                className={`flex h-9 w-9 items-center justify-center rounded-md border transition-colors ${
-                  isCameraFullscreen
-                    ? "border-accent-data bg-accent-data text-surface-base"
-                    : "border-border-subtle bg-surface-primary text-text-muted hover:text-text-primary"
-                }`}
-                title={isCameraFullscreen ? "Exit fullscreen" : "Fullscreen cameras"}
-                aria-label={isCameraFullscreen ? "Exit fullscreen" : "Fullscreen cameras"}
-              >
-                {isCameraFullscreen ? (
-                  <Minimize2 className="h-4 w-4" aria-hidden="true" />
-                ) : (
-                  <Maximize2 className="h-4 w-4" aria-hidden="true" />
-                )}
-              </button>
-            </div>
+            <CameraHudControls
+              cameraLayout={cameraLayout}
+              hasMotors={hasMotors}
+              showMotorData={showCameraMotorData}
+              isFullscreen={isCameraFullscreen}
+              canSwapCameras={Boolean(primaryVideoSourceId && secondaryVideoSourceId)}
+              onSetPipLayout={() => setCameraLayout('pip')}
+              onToggleSplitLayout={() =>
+                setCameraLayout((layout) => (layout === 'side-by-side' ? 'stacked' : 'side-by-side'))
+              }
+              onSwapCameras={handleSwapVideoSources}
+              onToggleMotorData={() => setShowCameraMotorData((prev) => !prev)}
+              onToggleFullscreen={toggleCameraFullscreen}
+            />
           </>
         ) : canRender3d ? (
           <BusWebGLRenderer

--- a/software/station/clients/station-viewer/src/st3215/BusCard.tsx
+++ b/software/station/clients/station-viewer/src/st3215/BusCard.tsx
@@ -1,18 +1,18 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import Long from "long";
-import { ArrowLeftRight, Camera, Maximize2, Minimize2, SlidersHorizontal } from "lucide-react";
-import { Link } from "react-router-dom";
-import { commandManager } from "../api/commands";
-import { FrameEntry } from "../api/frame-parser";
-import { motors_mirroring, st3215, usbvideo } from "../api/proto";
-import { serverToLocal } from "../api/timestamp-utils";
-import { getLatencyBgColor, getLatencyTextColor } from "@/utils/color-utils";
-import { getVideoSourceId, getVideoSourceLabel } from "../usbvideo/camera-source";
-import CameraViewer from "../usbvideo/CameraViewer";
-import RobotCameraView from "../usbvideo/RobotCameraView";
-import BusWebGLRenderer from "./BusWebGLRenderer";
-import MotorDataTable from "./MotorDataTable";
-import { ADDR_GOAL_POSITION, getMotorPosition } from "./motor-parser";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Long from 'long';
+import { ArrowLeftRight, Camera, Maximize2, Minimize2, SlidersHorizontal } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { commandManager } from '@/api/commands';
+import { FrameEntry } from '@/api/frame-parser';
+import { motors_mirroring, st3215, usbvideo } from '@/api/proto.js';
+import { serverToLocal } from '@/api/timestamp-utils';
+import { getLatencyBgColor, getLatencyTextColor } from '@/utils/color-utils';
+import { getVideoSourceId, getVideoSourceLabel } from '@/usbvideo/camera-source';
+import CameraViewer from '@/usbvideo/CameraViewer';
+import RobotCameraView from '@/usbvideo/RobotCameraView';
+import BusWebGLRenderer from '@/st3215/BusWebGLRenderer';
+import MotorDataTable from '@/st3215/MotorDataTable';
+import { ADDR_GOAL_POSITION, getMotorPosition } from '@/st3215/motor-parser';
 
 interface LatencyReading {
   timestamp: number;
@@ -28,14 +28,14 @@ interface LatencyStats {
 const STALE_CAMERA_MAX_AGE_MS = 60_000;
 const MIN_CALIBRATED_RANGE = 100;
 
-type RobotViewMode = "model" | "camera";
-type CameraLayoutMode = "pip" | "side-by-side" | "stacked";
-type CameraFitMode = "contain" | "cover";
+type RobotViewMode = 'model' | 'camera';
+type CameraLayoutMode = 'pip' | 'side-by-side' | 'stacked';
+type CameraFitMode = 'contain' | 'cover';
 
 function getVideoSourceShortLabel(entry: FrameEntry<usbvideo.IRxEnvelope>): string {
   return entry.data.camera?.deviceNumber !== undefined
     ? String(entry.data.camera.deviceNumber)
-    : "Camera";
+    : 'Camera';
 }
 
 interface BusCardProps {
@@ -55,16 +55,21 @@ const BusCard: React.FC<BusCardProps> = ({
 }) => {
   const latencyHistoryRef = useRef<Map<string, LatencyReading[]>>(new Map());
   const hasPrimaryVideoSourcePreferenceRef = useRef(false);
+  const lastWebControlRequestMsRef = useRef(0);
   const [primaryVideoSourceId, setPrimaryVideoSourceId] = useState<string | null>(null);
   const [secondaryVideoSourceId, setSecondaryVideoSourceId] = useState<string | null>(null);
-  const [viewMode, setViewMode] = useState<RobotViewMode>("model");
-  const [cameraLayout, setCameraLayout] = useState<CameraLayoutMode>("pip");
-  const [primaryCameraFit, setPrimaryCameraFit] = useState<CameraFitMode>("contain");
-  const [secondaryCameraFit, setSecondaryCameraFit] = useState<CameraFitMode>("contain");
+  const [viewMode, setViewMode] = useState<RobotViewMode>('model');
+  const [cameraLayout, setCameraLayout] = useState<CameraLayoutMode>('pip');
+  const [primaryCameraFit, setPrimaryCameraFit] = useState<CameraFitMode>('contain');
+  const [secondaryCameraFit, setSecondaryCameraFit] = useState<CameraFitMode>('contain');
   const [showCameraMotorData, setShowCameraMotorData] = useState(false);
   const [isCameraFullscreen, setIsCameraFullscreen] = useState(false);
   const [isWebControlled, setIsWebControlled] = useState(false);
   const cameraContentRef = useRef<HTMLDivElement>(null);
+  const busSerialNumber = bus.bus?.serialNumber ?? null;
+  const webControlledStorageKey = busSerialNumber
+    ? `station-viewer:web-controlled:${busSerialNumber}`
+    : null;
 
   const activeVideoSources = useMemo(() => {
     if (!videoSources) {
@@ -86,19 +91,22 @@ const BusCard: React.FC<BusCardProps> = ({
     });
   }, [videoSources]);
 
-  const primaryVideoSource = activeVideoSources.find(
-    (entry) => getVideoSourceId(entry) === primaryVideoSourceId,
-  )?.data;
-
-  const secondaryVideoSource = activeVideoSources.find(
-    (entry) => getVideoSourceId(entry) === secondaryVideoSourceId,
-  )?.data;
-
   const activeVideoSourceIds = useMemo(
     () => activeVideoSources.map(getVideoSourceId),
     [activeVideoSources],
   );
   const firstActiveVideoSourceId = activeVideoSourceIds[0] ?? null;
+
+  const currentMirror = mirroringState?.mirroring?.find((m) =>
+    m.targets?.some((t) => t.id?.uniqueId === busSerialNumber),
+  );
+
+  const setWebControlledState = useCallback((nextState: boolean) => {
+    setIsWebControlled(nextState);
+    if (webControlledStorageKey) {
+      sessionStorage.setItem(webControlledStorageKey, nextState ? 'true' : 'false');
+    }
+  }, [webControlledStorageKey]);
 
   useEffect(() => {
     if (primaryVideoSourceId && !activeVideoSourceIds.includes(primaryVideoSourceId)) {
@@ -126,6 +134,28 @@ const BusCard: React.FC<BusCardProps> = ({
     primaryVideoSourceId,
     secondaryVideoSourceId,
   ]);
+
+  useEffect(() => {
+    if (!webControlledStorageKey) {
+      setIsWebControlled(false);
+      return;
+    }
+
+    setIsWebControlled(sessionStorage.getItem(webControlledStorageKey) === 'true');
+  }, [webControlledStorageKey]);
+
+  useEffect(() => {
+    if (!isWebControlled || !currentMirror) {
+      return;
+    }
+
+    const isFreshLocalWebControlRequest = Date.now() - lastWebControlRequestMsRef.current < 1000;
+    if (isFreshLocalWebControlRequest) {
+      return;
+    }
+
+    setWebControlledState(false);
+  }, [currentMirror, isWebControlled, setWebControlledState]);
 
   const handlePrimaryVideoSourceChange = useCallback((sourceId: string | null) => {
     // Keep this sticky even for "None" so an explicit user clear is not auto-filled again.
@@ -168,19 +198,17 @@ const BusCard: React.FC<BusCardProps> = ({
     hasPrimaryVideoSourcePreferenceRef.current = true;
   }, [primaryVideoSourceId, secondaryVideoSourceId]);
 
-  const handleControlSourceChange = async (sourceBusSerial: string | null) => {
-    if (!bus.bus?.serialNumber) {
+  const handleControlSourceChange = useCallback(async (sourceBusSerial: string | null) => {
+    if (!busSerialNumber) {
       return;
     }
 
-    // Handle Web-controlled mode
-    if (sourceBusSerial === "web-controlled") {
+    if (sourceBusSerial === 'web-controlled') {
       const target: motors_mirroring.IMirroringBus = {
         type: motors_mirroring.BusType.MBT_ST3215,
-        uniqueId: bus.bus.serialNumber,
+        uniqueId: busSerialNumber,
       };
 
-      // Stop any existing mirroring
       await commandManager.sendMirroringCommand({
         type: motors_mirroring.CommandType.CT_STOP_MIRROR,
         source: target,
@@ -195,7 +223,7 @@ const BusCard: React.FC<BusCardProps> = ({
 
             // Send command to set motor to its current position (freeze it)
             const command = st3215.Command.create({
-              targetBusSerial: bus.bus?.serialNumber,
+              targetBusSerial: busSerialNumber,
               write: {
                 motorId: motor.id,
                 address: ADDR_GOAL_POSITION,
@@ -213,15 +241,16 @@ const BusCard: React.FC<BusCardProps> = ({
         }
       }
 
-      setIsWebControlled(true);
+      lastWebControlRequestMsRef.current = Date.now();
+      setWebControlledState(true);
       return;
     }
 
-    setIsWebControlled(false);
+    setWebControlledState(false);
 
     const target: motors_mirroring.IMirroringBus = {
       type: motors_mirroring.BusType.MBT_ST3215,
-      uniqueId: bus.bus.serialNumber,
+      uniqueId: busSerialNumber,
     };
 
     if (sourceBusSerial) {
@@ -240,11 +269,7 @@ const BusCard: React.FC<BusCardProps> = ({
         source: target,
       });
     }
-  };
-
-  const currentMirror = mirroringState?.mirroring?.find((m) =>
-    m.targets?.some((t) => t.id?.uniqueId === bus.bus?.serialNumber),
-  );
+  }, [bus.motors, busSerialNumber, setWebControlledState]);
 
   // Function to calculate moving average for latency (15 second window)
   const getMovingAverageLatency = (
@@ -300,6 +325,13 @@ const BusCard: React.FC<BusCardProps> = ({
   const needsCalibration = hasMotors && (hasUnfrozenMotor || hasNarrowRange);
   const canRender3d = [6, 8].includes(bus.motors?.length || 0);
   const canShowCamera = activeVideoSources.length > 0;
+
+  useEffect(() => {
+    if (!canShowCamera && viewMode === 'camera') {
+      setViewMode('model');
+    }
+  }, [canShowCamera, viewMode]);
+
   const controlSourceWidthClass = viewMode === "camera" ? "w-[170px]" : "max-w-[180px]";
   const cameraSelectWidthClass = viewMode === "camera" ? "w-[150px]" : "max-w-[180px]";
   const selectControlClass = "block h-9 min-w-0 rounded-md border border-border-subtle bg-surface-secondary pl-3 pr-10 text-sm text-text-primary focus:border-accent-success-deep focus:outline-none focus:ring-accent-success-deep";
@@ -339,6 +371,28 @@ const BusCard: React.FC<BusCardProps> = ({
       document.removeEventListener("fullscreenchange", onFullscreenChange);
     };
   }, []);
+
+  useEffect(() => {
+    if (!isCameraFullscreen) {
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      const cameraContent = cameraContentRef.current;
+      if (
+        event.key === "Escape" &&
+        cameraContent &&
+        document.fullscreenElement === cameraContent
+      ) {
+        void document.exitFullscreen();
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [isCameraFullscreen]);
 
   useEffect(() => {
     const cameraContent = cameraContentRef.current;
@@ -423,6 +477,14 @@ const BusCard: React.FC<BusCardProps> = ({
                     : sourceId === secondaryVideoSourceId
                       ? "AUX"
                       : null;
+                const chipTitle =
+                  role === "MAIN"
+                    ? `MAIN: ${label}. Click to clear; AUX becomes MAIN.`
+                    : role === "AUX"
+                      ? `AUX: ${label}. Click to clear.`
+                      : primaryVideoSourceId
+                        ? `Select ${label} as AUX camera.`
+                        : `Select ${label} as MAIN camera.`;
 
                 return (
                   <button
@@ -436,7 +498,7 @@ const BusCard: React.FC<BusCardProps> = ({
                           ? "border-accent-success-deep bg-accent-success-bg text-text-primary"
                           : "border-border-subtle bg-surface-primary text-text-muted hover:text-text-primary"
                     }`}
-                    title={role ? `${role}: ${label}` : label}
+                    title={chipTitle}
                     aria-label={role ? `${role} camera ${label}` : `Select camera ${label}`}
                   >
                     <span className="truncate">{shortLabel}</span>
@@ -497,8 +559,6 @@ const BusCard: React.FC<BusCardProps> = ({
         {viewMode === "camera" ? (
           <>
             <RobotCameraView
-              primaryVideoSource={primaryVideoSource}
-              secondaryVideoSource={secondaryVideoSource}
               primaryVideoSourceId={primaryVideoSourceId}
               secondaryVideoSourceId={secondaryVideoSourceId}
               bus={bus}

--- a/software/station/clients/station-viewer/src/st3215/BusCard.tsx
+++ b/software/station/clients/station-viewer/src/st3215/BusCard.tsx
@@ -29,7 +29,14 @@ const STALE_CAMERA_MAX_AGE_MS = 60_000;
 const MIN_CALIBRATED_RANGE = 100;
 
 type RobotViewMode = "model" | "camera";
-type CameraLayoutMode = "pip" | "side-by-side";
+type CameraLayoutMode = "pip" | "side-by-side" | "stacked";
+type CameraFitMode = "contain" | "cover";
+
+function getVideoSourceShortLabel(entry: FrameEntry<usbvideo.IRxEnvelope>): string {
+  return entry.data.camera?.deviceNumber !== undefined
+    ? String(entry.data.camera.deviceNumber)
+    : "Camera";
+}
 
 interface BusCardProps {
   bus: st3215.InferenceState.IBusState;
@@ -52,6 +59,8 @@ const BusCard: React.FC<BusCardProps> = ({
   const [secondaryVideoSourceId, setSecondaryVideoSourceId] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<RobotViewMode>("model");
   const [cameraLayout, setCameraLayout] = useState<CameraLayoutMode>("pip");
+  const [primaryCameraFit, setPrimaryCameraFit] = useState<CameraFitMode>("contain");
+  const [secondaryCameraFit, setSecondaryCameraFit] = useState<CameraFitMode>("contain");
   const [showCameraMotorData, setShowCameraMotorData] = useState(false);
   const [isCameraFullscreen, setIsCameraFullscreen] = useState(false);
   const [isWebControlled, setIsWebControlled] = useState(false);
@@ -127,13 +136,27 @@ const BusCard: React.FC<BusCardProps> = ({
     }
   }, [secondaryVideoSourceId]);
 
-  const handleSecondaryVideoSourceChange = useCallback((sourceId: string | null) => {
-    if (sourceId && sourceId === primaryVideoSourceId) {
+  const handleCameraChipClick = useCallback((sourceId: string) => {
+    if (sourceId === primaryVideoSourceId) {
+      hasPrimaryVideoSourcePreferenceRef.current = true;
+      setPrimaryVideoSourceId(secondaryVideoSourceId);
+      setSecondaryVideoSourceId(null);
+      return;
+    }
+
+    if (sourceId === secondaryVideoSourceId) {
+      setSecondaryVideoSourceId(null);
+      return;
+    }
+
+    if (!primaryVideoSourceId) {
+      hasPrimaryVideoSourcePreferenceRef.current = true;
+      setPrimaryVideoSourceId(sourceId);
       return;
     }
 
     setSecondaryVideoSourceId(sourceId);
-  }, [primaryVideoSourceId]);
+  }, [primaryVideoSourceId, secondaryVideoSourceId]);
 
   const handleSwapVideoSources = useCallback(() => {
     if (!primaryVideoSourceId || !secondaryVideoSourceId) {
@@ -287,10 +310,6 @@ const BusCard: React.FC<BusCardProps> = ({
         : activeVideoSources,
     [activeVideoSources, secondaryVideoSourceId, viewMode],
   );
-  const secondaryVideoSourceOptions = useMemo(
-    () => activeVideoSources.filter((entry) => getVideoSourceId(entry) !== primaryVideoSourceId),
-    [activeVideoSources, primaryVideoSourceId],
-  );
   const toggleCameraFullscreen = useCallback(async () => {
     const cameraContent = cameraContentRef.current;
     if (!cameraContent) {
@@ -388,36 +407,57 @@ const BusCard: React.FC<BusCardProps> = ({
               );
             })}
           </select>
-          <select
-            value={primaryVideoSourceId ?? ""}
-            onChange={(e) => handlePrimaryVideoSourceChange(e.target.value || null)}
-            className={`${selectControlClass} ${cameraSelectWidthClass}`}
-            title="Main camera"
-          >
-            <option value="">None</option>
-            {primaryVideoSourceOptions.map((entry) => {
-              const sourceId = getVideoSourceId(entry);
-              const label = getVideoSourceLabel(entry);
-              return (
-                <option
-                  key={`${entry.queueId}-${sourceId}`}
-                  value={sourceId}
-                  title={label}
-                >
-                  {label}
-                </option>
-              );
-            })}
-          </select>
-          {viewMode === "camera" && (
+          {viewMode === "camera" ? (
+            <div
+              className="flex min-w-0 max-w-full flex-wrap items-center gap-1.5"
+              role="group"
+              aria-label="Camera selection"
+            >
+              {activeVideoSources.map((entry) => {
+                const sourceId = getVideoSourceId(entry);
+                const label = getVideoSourceLabel(entry);
+                const shortLabel = getVideoSourceShortLabel(entry);
+                const role =
+                  sourceId === primaryVideoSourceId
+                    ? "MAIN"
+                    : sourceId === secondaryVideoSourceId
+                      ? "AUX"
+                      : null;
+
+                return (
+                  <button
+                    key={`${entry.queueId}-${sourceId}`}
+                    type="button"
+                    onClick={() => handleCameraChipClick(sourceId)}
+                    className={`flex h-9 max-w-[9rem] items-center gap-1.5 rounded-md border px-2.5 text-sm font-bold transition-colors ${
+                      role === "MAIN"
+                        ? "border-accent-data bg-accent-data text-surface-base"
+                        : role === "AUX"
+                          ? "border-accent-success-deep bg-accent-success-bg text-text-primary"
+                          : "border-border-subtle bg-surface-primary text-text-muted hover:text-text-primary"
+                    }`}
+                    title={role ? `${role}: ${label}` : label}
+                    aria-label={role ? `${role} camera ${label}` : `Select camera ${label}`}
+                  >
+                    <span className="truncate">{shortLabel}</span>
+                    {role && (
+                      <span className="rounded bg-black/20 px-1 py-0.5 text-[10px] leading-none">
+                        {role}
+                      </span>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          ) : (
             <select
-              value={secondaryVideoSourceId ?? ""}
-              onChange={(e) => handleSecondaryVideoSourceChange(e.target.value || null)}
+              value={primaryVideoSourceId ?? ""}
+              onChange={(e) => handlePrimaryVideoSourceChange(e.target.value || null)}
               className={`${selectControlClass} ${cameraSelectWidthClass}`}
-              title="Picture-in-picture camera"
+              title="Main camera"
             >
               <option value="">None</option>
-              {secondaryVideoSourceOptions.map((entry) => {
+              {primaryVideoSourceOptions.map((entry) => {
                 const sourceId = getVideoSourceId(entry);
                 const label = getVideoSourceLabel(entry);
                 return (
@@ -468,6 +508,10 @@ const BusCard: React.FC<BusCardProps> = ({
               needsCalibration={needsCalibration}
               isWebControlled={isWebControlled}
               cameraLayout={cameraLayout}
+              primaryCameraFit={primaryCameraFit}
+              secondaryCameraFit={secondaryCameraFit}
+              onPrimaryCameraFitToggle={() => setPrimaryCameraFit((fit) => (fit === "contain" ? "cover" : "contain"))}
+              onSecondaryCameraFitToggle={() => setSecondaryCameraFit((fit) => (fit === "contain" ? "cover" : "contain"))}
             />
             <div className="absolute left-2 top-2 z-50 flex max-w-[calc(100%-1rem)] flex-wrap gap-1.5 rounded-lg border border-border-default bg-surface-primary/75 p-1.5 shadow-lg backdrop-blur-sm sm:left-3 sm:top-3">
               <div
@@ -492,16 +536,20 @@ const BusCard: React.FC<BusCardProps> = ({
                 </button>
                 <button
                   type="button"
-                  onClick={() => setCameraLayout("side-by-side")}
+                  onClick={() =>
+                    setCameraLayout((layout) =>
+                      layout === "side-by-side" ? "stacked" : "side-by-side",
+                    )
+                  }
                   className={`flex h-8 w-8 items-center justify-center rounded transition-colors ${
-                    cameraLayout === "side-by-side"
+                    cameraLayout === "side-by-side" || cameraLayout === "stacked"
                       ? "bg-accent-data text-surface-base"
                       : "text-text-muted hover:text-text-primary"
                   }`}
-                  title="Side-by-side layout"
-                  aria-label="Side-by-side layout"
+                  title={cameraLayout === "stacked" ? "Top-bottom layout" : "Side-by-side layout"}
+                  aria-label={cameraLayout === "stacked" ? "Top-bottom layout" : "Side-by-side layout"}
                 >
-                  <span className="grid h-4 w-4 grid-cols-2 gap-[2px]">
+                  <span className={`grid h-4 w-4 grid-cols-2 gap-[2px] ${cameraLayout === "stacked" ? "rotate-90" : ""}`}>
                     <span className="rounded-[1px] border border-current" />
                     <span className="rounded-[1px] border border-current" />
                   </span>
@@ -535,7 +583,11 @@ const BusCard: React.FC<BusCardProps> = ({
               <button
                 type="button"
                 onClick={toggleCameraFullscreen}
-                className="flex h-9 w-9 items-center justify-center rounded-md border border-border-subtle bg-surface-primary text-text-muted transition-colors hover:text-text-primary"
+                className={`flex h-9 w-9 items-center justify-center rounded-md border transition-colors ${
+                  isCameraFullscreen
+                    ? "border-accent-data bg-accent-data text-surface-base"
+                    : "border-border-subtle bg-surface-primary text-text-muted hover:text-text-primary"
+                }`}
                 title={isCameraFullscreen ? "Exit fullscreen" : "Fullscreen cameras"}
                 aria-label={isCameraFullscreen ? "Exit fullscreen" : "Fullscreen cameras"}
               >

--- a/software/station/clients/station-viewer/src/st3215/BusCard.tsx
+++ b/software/station/clients/station-viewer/src/st3215/BusCard.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Long from "long";
-import { Camera } from "lucide-react";
+import { Camera, Maximize2, Minimize2 } from "lucide-react";
 import { Link } from "react-router-dom";
 import { commandManager } from "../api/commands";
 import { FrameEntry } from "../api/frame-parser";
@@ -29,6 +29,7 @@ const STALE_CAMERA_MAX_AGE_MS = 60_000;
 const MIN_CALIBRATED_RANGE = 100;
 
 type RobotViewMode = "model" | "camera";
+type CameraLayoutMode = "pip" | "side-by-side";
 
 interface BusCardProps {
   bus: st3215.InferenceState.IBusState;
@@ -50,7 +51,11 @@ const BusCard: React.FC<BusCardProps> = ({
   const [primaryVideoSourceId, setPrimaryVideoSourceId] = useState<string | null>(null);
   const [secondaryVideoSourceId, setSecondaryVideoSourceId] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<RobotViewMode>("model");
+  const [cameraLayout, setCameraLayout] = useState<CameraLayoutMode>("pip");
+  const [showCameraMotorData, setShowCameraMotorData] = useState(false);
+  const [isCameraFullscreen, setIsCameraFullscreen] = useState(false);
   const [isWebControlled, setIsWebControlled] = useState(false);
+  const cameraContentRef = useRef<HTMLDivElement>(null);
 
   const activeVideoSources = useMemo(() => {
     if (!videoSources) {
@@ -262,8 +267,9 @@ const BusCard: React.FC<BusCardProps> = ({
   const needsCalibration = hasMotors && (hasUnfrozenMotor || hasNarrowRange);
   const canRender3d = [6, 8].includes(bus.motors?.length || 0);
   const canShowCamera = activeVideoSources.length > 0;
-  const controlSourceWidthClass = viewMode === "camera" ? "max-w-[140px]" : "max-w-[180px]";
-  const cameraSelectWidthClass = viewMode === "camera" ? "max-w-[120px]" : "max-w-[180px]";
+  const controlSourceWidthClass = viewMode === "camera" ? "w-[170px]" : "max-w-[180px]";
+  const cameraSelectWidthClass = viewMode === "camera" ? "w-[150px]" : "max-w-[180px]";
+  const selectControlClass = "block h-9 min-w-0 rounded-md border border-border-subtle bg-surface-secondary pl-3 pr-10 text-sm text-text-primary focus:border-accent-success-deep focus:outline-none focus:ring-accent-success-deep";
   const primaryVideoSourceOptions = useMemo(
     () =>
       viewMode === "camera"
@@ -275,6 +281,44 @@ const BusCard: React.FC<BusCardProps> = ({
     () => activeVideoSources.filter((entry) => getVideoSourceId(entry) !== primaryVideoSourceId),
     [activeVideoSources, primaryVideoSourceId],
   );
+  const toggleCameraFullscreen = useCallback(async () => {
+    const cameraContent = cameraContentRef.current;
+    if (!cameraContent) {
+      return;
+    }
+
+    try {
+      if (document.fullscreenElement === cameraContent) {
+        await document.exitFullscreen();
+        return;
+      }
+
+      await cameraContent.requestFullscreen();
+    } catch {
+      // Ignore fullscreen errors (for example, if blocked by browser policy).
+    }
+  }, []);
+
+  useEffect(() => {
+    const onFullscreenChange = () => {
+      const cameraContent = cameraContentRef.current;
+      setIsCameraFullscreen(Boolean(cameraContent && document.fullscreenElement === cameraContent));
+    };
+
+    document.addEventListener("fullscreenchange", onFullscreenChange);
+    return () => {
+      document.removeEventListener("fullscreenchange", onFullscreenChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    const cameraContent = cameraContentRef.current;
+    if (!cameraContent || viewMode === "camera" || document.fullscreenElement !== cameraContent) {
+      return;
+    }
+
+    void document.exitFullscreen();
+  }, [viewMode]);
 
   return (
     <div className="min-w-0 border border-border-default rounded-lg bg-surface-primary/50">
@@ -312,7 +356,7 @@ const BusCard: React.FC<BusCardProps> = ({
                 : (currentMirror?.source?.id?.uniqueId ?? "")
             }
             onChange={(e) => handleControlSourceChange(e.target.value || null)}
-            className={`block min-w-0 ${controlSourceWidthClass} pl-3 pr-10 py-1 text-base border-border-subtle bg-surface-secondary text-text-primary focus:outline-none focus:ring-accent-success-deep focus:border-accent-success-deep sm:text-sm rounded-md`}
+            className={`${selectControlClass} ${controlSourceWidthClass}`}
           >
             <option value="">(Self-controlled)</option>
             <option value="web-controlled">(Web-controlled)</option>
@@ -337,7 +381,7 @@ const BusCard: React.FC<BusCardProps> = ({
           <select
             value={primaryVideoSourceId ?? ""}
             onChange={(e) => handlePrimaryVideoSourceChange(e.target.value || null)}
-            className={`block min-w-0 ${cameraSelectWidthClass} pl-3 pr-10 py-1 text-base border-border-subtle bg-surface-secondary text-text-primary focus:outline-none focus:ring-accent-success-deep focus:border-accent-success-deep sm:text-sm rounded-md`}
+            className={`${selectControlClass} ${cameraSelectWidthClass}`}
             title="Main camera"
           >
             <option value="">None</option>
@@ -359,7 +403,7 @@ const BusCard: React.FC<BusCardProps> = ({
             <select
               value={secondaryVideoSourceId ?? ""}
               onChange={(e) => handleSecondaryVideoSourceChange(e.target.value || null)}
-              className={`block min-w-0 ${cameraSelectWidthClass} basis-full pl-3 pr-10 py-1 text-base border-border-subtle bg-surface-secondary text-text-primary focus:outline-none focus:ring-accent-success-deep focus:border-accent-success-deep sm:text-sm rounded-md`}
+              className={`${selectControlClass} ${cameraSelectWidthClass}`}
               title="Picture-in-picture camera"
             >
               <option value="">None</option>
@@ -377,6 +421,75 @@ const BusCard: React.FC<BusCardProps> = ({
                 );
               })}
             </select>
+          )}
+          {viewMode === "camera" && (
+            <div
+              className="flex rounded-md border border-border-subtle bg-surface-primary p-0.5"
+              role="group"
+              aria-label="Camera layout"
+            >
+              <button
+                type="button"
+                onClick={() => setCameraLayout("pip")}
+                className={`flex h-8 min-w-8 items-center justify-center rounded px-2 transition-colors ${
+                  cameraLayout === "pip"
+                    ? "bg-accent-data text-surface-base"
+                    : "text-text-muted hover:text-text-primary"
+                }`}
+                title="PiP layout"
+                aria-label="PiP layout"
+              >
+                <span className="relative block h-4 w-4 rounded-[2px] border border-current">
+                  <span className="absolute -bottom-px -right-px h-2 w-2 rounded-[1px] border border-current bg-current/20" />
+                </span>
+              </button>
+              <button
+                type="button"
+                onClick={() => setCameraLayout("side-by-side")}
+                className={`flex h-8 min-w-8 items-center justify-center rounded px-2 transition-colors ${
+                  cameraLayout === "side-by-side"
+                    ? "bg-accent-data text-surface-base"
+                    : "text-text-muted hover:text-text-primary"
+                }`}
+                title="Side-by-side layout"
+                aria-label="Side-by-side layout"
+              >
+                <span className="grid h-4 w-4 grid-cols-2 gap-[2px]">
+                  <span className="rounded-[1px] border border-current" />
+                  <span className="rounded-[1px] border border-current" />
+                </span>
+              </button>
+            </div>
+          )}
+          {viewMode === "camera" && hasMotors && (
+            <button
+              type="button"
+              onClick={() => setShowCameraMotorData((prev) => !prev)}
+              className={`flex h-9 items-center justify-center rounded border px-3 text-xs font-bold transition-colors ${
+                showCameraMotorData
+                  ? "border-accent-success-deep bg-accent-success-bg text-text-primary"
+                  : "border-border-subtle bg-surface-primary text-text-muted hover:text-text-primary"
+              }`}
+              title={showCameraMotorData ? "Hide motor panel" : "Show motor panel"}
+              aria-label={showCameraMotorData ? "Hide motor panel" : "Show motor panel"}
+            >
+              MOTORS
+            </button>
+          )}
+          {viewMode === "camera" && (
+            <button
+              type="button"
+              onClick={toggleCameraFullscreen}
+              className="flex h-9 items-center justify-center rounded border border-border-subtle bg-surface-primary px-2 text-text-muted transition-colors hover:text-text-primary"
+              title={isCameraFullscreen ? "Exit fullscreen" : "Fullscreen cameras"}
+              aria-label={isCameraFullscreen ? "Exit fullscreen" : "Fullscreen cameras"}
+            >
+              {isCameraFullscreen ? (
+                <Minimize2 className="h-4 w-4" aria-hidden="true" />
+              ) : (
+                <Maximize2 className="h-4 w-4" aria-hidden="true" />
+              )}
+            </button>
           )}
         </div>
         <div className="flex items-center gap-4 text-sm">
@@ -396,7 +509,10 @@ const BusCard: React.FC<BusCardProps> = ({
       </div>
 
       {/* Content */}
-      <div className="relative h-180">
+      <div
+        ref={cameraContentRef}
+        className={`relative h-180 ${isCameraFullscreen ? "bg-black" : ""}`}
+      >
         {viewMode === "camera" ? (
           <RobotCameraView
             primaryVideoSource={primaryVideoSource}
@@ -405,10 +521,11 @@ const BusCard: React.FC<BusCardProps> = ({
             secondaryVideoSourceId={secondaryVideoSourceId}
             bus={bus}
             busIndex={busIndex}
-            showMotorData={true}
+            showMotorData={showCameraMotorData}
             showCalibrateButton={true}
             needsCalibration={needsCalibration}
             isWebControlled={isWebControlled}
+            cameraLayout={cameraLayout}
           />
         ) : canRender3d ? (
           <BusWebGLRenderer

--- a/software/station/clients/station-viewer/src/st3215/BusCard.tsx
+++ b/software/station/clients/station-viewer/src/st3215/BusCard.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Long from "long";
-import { Camera, Maximize2, Minimize2 } from "lucide-react";
+import { ArrowLeftRight, Camera, Maximize2, Minimize2, SlidersHorizontal } from "lucide-react";
 import { Link } from "react-router-dom";
 import { commandManager } from "../api/commands";
 import { FrameEntry } from "../api/frame-parser";
@@ -134,6 +134,16 @@ const BusCard: React.FC<BusCardProps> = ({
 
     setSecondaryVideoSourceId(sourceId);
   }, [primaryVideoSourceId]);
+
+  const handleSwapVideoSources = useCallback(() => {
+    if (!primaryVideoSourceId || !secondaryVideoSourceId) {
+      return;
+    }
+
+    setPrimaryVideoSourceId(secondaryVideoSourceId);
+    setSecondaryVideoSourceId(primaryVideoSourceId);
+    hasPrimaryVideoSourcePreferenceRef.current = true;
+  }, [primaryVideoSourceId, secondaryVideoSourceId]);
 
   const handleControlSourceChange = async (sourceBusSerial: string | null) => {
     if (!bus.bus?.serialNumber) {
@@ -422,75 +432,6 @@ const BusCard: React.FC<BusCardProps> = ({
               })}
             </select>
           )}
-          {viewMode === "camera" && (
-            <div
-              className="flex rounded-md border border-border-subtle bg-surface-primary p-0.5"
-              role="group"
-              aria-label="Camera layout"
-            >
-              <button
-                type="button"
-                onClick={() => setCameraLayout("pip")}
-                className={`flex h-8 min-w-8 items-center justify-center rounded px-2 transition-colors ${
-                  cameraLayout === "pip"
-                    ? "bg-accent-data text-surface-base"
-                    : "text-text-muted hover:text-text-primary"
-                }`}
-                title="PiP layout"
-                aria-label="PiP layout"
-              >
-                <span className="relative block h-4 w-4 rounded-[2px] border border-current">
-                  <span className="absolute -bottom-px -right-px h-2 w-2 rounded-[1px] border border-current bg-current/20" />
-                </span>
-              </button>
-              <button
-                type="button"
-                onClick={() => setCameraLayout("side-by-side")}
-                className={`flex h-8 min-w-8 items-center justify-center rounded px-2 transition-colors ${
-                  cameraLayout === "side-by-side"
-                    ? "bg-accent-data text-surface-base"
-                    : "text-text-muted hover:text-text-primary"
-                }`}
-                title="Side-by-side layout"
-                aria-label="Side-by-side layout"
-              >
-                <span className="grid h-4 w-4 grid-cols-2 gap-[2px]">
-                  <span className="rounded-[1px] border border-current" />
-                  <span className="rounded-[1px] border border-current" />
-                </span>
-              </button>
-            </div>
-          )}
-          {viewMode === "camera" && hasMotors && (
-            <button
-              type="button"
-              onClick={() => setShowCameraMotorData((prev) => !prev)}
-              className={`flex h-9 items-center justify-center rounded border px-3 text-xs font-bold transition-colors ${
-                showCameraMotorData
-                  ? "border-accent-success-deep bg-accent-success-bg text-text-primary"
-                  : "border-border-subtle bg-surface-primary text-text-muted hover:text-text-primary"
-              }`}
-              title={showCameraMotorData ? "Hide motor panel" : "Show motor panel"}
-              aria-label={showCameraMotorData ? "Hide motor panel" : "Show motor panel"}
-            >
-              MOTORS
-            </button>
-          )}
-          {viewMode === "camera" && (
-            <button
-              type="button"
-              onClick={toggleCameraFullscreen}
-              className="flex h-9 items-center justify-center rounded border border-border-subtle bg-surface-primary px-2 text-text-muted transition-colors hover:text-text-primary"
-              title={isCameraFullscreen ? "Exit fullscreen" : "Fullscreen cameras"}
-              aria-label={isCameraFullscreen ? "Exit fullscreen" : "Fullscreen cameras"}
-            >
-              {isCameraFullscreen ? (
-                <Minimize2 className="h-4 w-4" aria-hidden="true" />
-              ) : (
-                <Maximize2 className="h-4 w-4" aria-hidden="true" />
-              )}
-            </button>
-          )}
         </div>
         <div className="flex items-center gap-4 text-sm">
           <div className="flex items-center gap-1.5">
@@ -511,22 +452,101 @@ const BusCard: React.FC<BusCardProps> = ({
       {/* Content */}
       <div
         ref={cameraContentRef}
-        className={`relative h-180 ${isCameraFullscreen ? "bg-black" : ""}`}
+        className={`relative ${isCameraFullscreen ? "h-screen bg-black" : "h-180"}`}
       >
         {viewMode === "camera" ? (
-          <RobotCameraView
-            primaryVideoSource={primaryVideoSource}
-            secondaryVideoSource={secondaryVideoSource}
-            primaryVideoSourceId={primaryVideoSourceId}
-            secondaryVideoSourceId={secondaryVideoSourceId}
-            bus={bus}
-            busIndex={busIndex}
-            showMotorData={showCameraMotorData}
-            showCalibrateButton={true}
-            needsCalibration={needsCalibration}
-            isWebControlled={isWebControlled}
-            cameraLayout={cameraLayout}
-          />
+          <>
+            <RobotCameraView
+              primaryVideoSource={primaryVideoSource}
+              secondaryVideoSource={secondaryVideoSource}
+              primaryVideoSourceId={primaryVideoSourceId}
+              secondaryVideoSourceId={secondaryVideoSourceId}
+              bus={bus}
+              busIndex={busIndex}
+              showMotorData={showCameraMotorData}
+              showCalibrateButton={true}
+              needsCalibration={needsCalibration}
+              isWebControlled={isWebControlled}
+              cameraLayout={cameraLayout}
+            />
+            <div className="absolute left-2 top-2 z-50 flex max-w-[calc(100%-1rem)] flex-wrap gap-1.5 rounded-lg border border-border-default bg-surface-primary/75 p-1.5 shadow-lg backdrop-blur-sm sm:left-3 sm:top-3">
+              <div
+                className="flex rounded-md border border-border-subtle bg-surface-primary p-0.5"
+                role="group"
+                aria-label="Camera layout"
+              >
+                <button
+                  type="button"
+                  onClick={() => setCameraLayout("pip")}
+                  className={`flex h-8 w-8 items-center justify-center rounded transition-colors ${
+                    cameraLayout === "pip"
+                      ? "bg-accent-data text-surface-base"
+                      : "text-text-muted hover:text-text-primary"
+                  }`}
+                  title="PiP layout"
+                  aria-label="PiP layout"
+                >
+                  <span className="relative block h-4 w-4 rounded-[2px] border border-current">
+                    <span className="absolute -bottom-px -right-px h-2 w-2 rounded-[1px] border border-current bg-current/20" />
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setCameraLayout("side-by-side")}
+                  className={`flex h-8 w-8 items-center justify-center rounded transition-colors ${
+                    cameraLayout === "side-by-side"
+                      ? "bg-accent-data text-surface-base"
+                      : "text-text-muted hover:text-text-primary"
+                  }`}
+                  title="Side-by-side layout"
+                  aria-label="Side-by-side layout"
+                >
+                  <span className="grid h-4 w-4 grid-cols-2 gap-[2px]">
+                    <span className="rounded-[1px] border border-current" />
+                    <span className="rounded-[1px] border border-current" />
+                  </span>
+                </button>
+              </div>
+              <button
+                type="button"
+                onClick={handleSwapVideoSources}
+                disabled={!primaryVideoSourceId || !secondaryVideoSourceId}
+                className="flex h-9 w-9 items-center justify-center rounded-md border border-border-subtle bg-surface-primary text-text-muted transition-colors hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40"
+                title="Swap cameras"
+                aria-label="Swap cameras"
+              >
+                <ArrowLeftRight className="h-4 w-4" aria-hidden="true" />
+              </button>
+              {hasMotors && (
+                <button
+                  type="button"
+                  onClick={() => setShowCameraMotorData((prev) => !prev)}
+                  className={`flex h-9 w-9 items-center justify-center rounded-md border transition-colors ${
+                    showCameraMotorData
+                      ? "border-accent-success-deep bg-accent-success-bg text-text-primary"
+                      : "border-border-subtle bg-surface-primary text-text-muted hover:text-text-primary"
+                  }`}
+                  title={showCameraMotorData ? "Hide motor panel" : "Show motor panel"}
+                  aria-label={showCameraMotorData ? "Hide motor panel" : "Show motor panel"}
+                >
+                  <SlidersHorizontal className="h-4 w-4" aria-hidden="true" />
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={toggleCameraFullscreen}
+                className="flex h-9 w-9 items-center justify-center rounded-md border border-border-subtle bg-surface-primary text-text-muted transition-colors hover:text-text-primary"
+                title={isCameraFullscreen ? "Exit fullscreen" : "Fullscreen cameras"}
+                aria-label={isCameraFullscreen ? "Exit fullscreen" : "Fullscreen cameras"}
+              >
+                {isCameraFullscreen ? (
+                  <Minimize2 className="h-4 w-4" aria-hidden="true" />
+                ) : (
+                  <Maximize2 className="h-4 w-4" aria-hidden="true" />
+                )}
+              </button>
+            </div>
+          </>
         ) : canRender3d ? (
           <BusWebGLRenderer
             busSerialNumber={bus.bus?.serialNumber}

--- a/software/station/clients/station-viewer/src/st3215/BusCard.tsx
+++ b/software/station/clients/station-viewer/src/st3215/BusCard.tsx
@@ -309,8 +309,6 @@ const BusCard: React.FC<BusCardProps> = ({
       return;
     }
 
-    setWebControlledState(false);
-
     const target: motors_mirroring.IMirroringBus = {
       type: motors_mirroring.BusType.MBT_ST3215,
       uniqueId: busSerialNumber,
@@ -326,11 +324,13 @@ const BusCard: React.FC<BusCardProps> = ({
         source: source,
         targets: [target],
       });
+      setWebControlledState(false);
     } else {
       await commandManager.sendMirroringCommand({
         type: motors_mirroring.CommandType.CT_STOP_MIRROR,
         source: target,
       });
+      setWebControlledState(false);
     }
   }, [bus.motors, busSerialNumber, setWebControlledState]);
 

--- a/software/station/clients/station-viewer/src/st3215/CameraHudControls.tsx
+++ b/software/station/clients/station-viewer/src/st3215/CameraHudControls.tsx
@@ -1,0 +1,113 @@
+import { ArrowLeftRight, Maximize2, Minimize2, SlidersHorizontal } from 'lucide-react';
+
+type CameraLayoutMode = 'pip' | 'side-by-side' | 'stacked';
+
+interface CameraHudControlsProps {
+  cameraLayout: CameraLayoutMode;
+  hasMotors: boolean;
+  showMotorData: boolean;
+  isFullscreen: boolean;
+  canSwapCameras: boolean;
+  onSetPipLayout: () => void;
+  onToggleSplitLayout: () => void;
+  onSwapCameras: () => void;
+  onToggleMotorData: () => void;
+  onToggleFullscreen: () => void;
+}
+
+export default function CameraHudControls({
+  cameraLayout,
+  hasMotors,
+  showMotorData,
+  isFullscreen,
+  canSwapCameras,
+  onSetPipLayout,
+  onToggleSplitLayout,
+  onSwapCameras,
+  onToggleMotorData,
+  onToggleFullscreen,
+}: CameraHudControlsProps) {
+  return (
+    <div className="absolute left-2 top-2 z-50 flex max-w-[calc(100%-1rem)] flex-wrap gap-1.5 rounded-lg border border-border-default bg-surface-primary/75 p-1.5 shadow-lg backdrop-blur-sm sm:left-3 sm:top-3">
+      <div
+        className="flex rounded-md border border-border-subtle bg-surface-primary p-0.5"
+        role="group"
+        aria-label="Camera layout"
+      >
+        <button
+          type="button"
+          onClick={onSetPipLayout}
+          className={`flex h-8 w-8 items-center justify-center rounded transition-colors ${
+            cameraLayout === 'pip'
+              ? 'bg-accent-data text-surface-base'
+              : 'text-text-muted hover:text-text-primary'
+          }`}
+          title="PiP layout"
+          aria-label="PiP layout"
+        >
+          <span className="relative block h-4 w-4 rounded-[2px] border border-current">
+            <span className="absolute -bottom-px -right-px h-2 w-2 rounded-[1px] border border-current bg-current/20" />
+          </span>
+        </button>
+        <button
+          type="button"
+          onClick={onToggleSplitLayout}
+          className={`flex h-8 w-8 items-center justify-center rounded transition-colors ${
+            cameraLayout === 'side-by-side' || cameraLayout === 'stacked'
+              ? 'bg-accent-data text-surface-base'
+              : 'text-text-muted hover:text-text-primary'
+          }`}
+          title={cameraLayout === 'stacked' ? 'Top-bottom layout' : 'Side-by-side layout'}
+          aria-label={cameraLayout === 'stacked' ? 'Top-bottom layout' : 'Side-by-side layout'}
+        >
+          <span className={`grid h-4 w-4 grid-cols-2 gap-[2px] ${cameraLayout === 'stacked' ? 'rotate-90' : ''}`}>
+            <span className="rounded-[1px] border border-current" />
+            <span className="rounded-[1px] border border-current" />
+          </span>
+        </button>
+      </div>
+      <button
+        type="button"
+        onClick={onSwapCameras}
+        disabled={!canSwapCameras}
+        className="flex h-9 w-9 items-center justify-center rounded-md border border-border-subtle bg-surface-primary text-text-muted transition-colors hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40"
+        title="Swap cameras"
+        aria-label="Swap cameras"
+      >
+        <ArrowLeftRight className="h-4 w-4" aria-hidden="true" />
+      </button>
+      {hasMotors && (
+        <button
+          type="button"
+          onClick={onToggleMotorData}
+          className={`flex h-9 w-9 items-center justify-center rounded-md border transition-colors ${
+            showMotorData
+              ? 'border-accent-success-deep bg-accent-success-bg text-text-primary'
+              : 'border-border-subtle bg-surface-primary text-text-muted hover:text-text-primary'
+          }`}
+          title={showMotorData ? 'Hide motor panel' : 'Show motor panel'}
+          aria-label={showMotorData ? 'Hide motor panel' : 'Show motor panel'}
+        >
+          <SlidersHorizontal className="h-4 w-4" aria-hidden="true" />
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={onToggleFullscreen}
+        className={`flex h-9 w-9 items-center justify-center rounded-md border transition-colors ${
+          isFullscreen
+            ? 'border-accent-data bg-accent-data text-surface-base'
+            : 'border-border-subtle bg-surface-primary text-text-muted hover:text-text-primary'
+        }`}
+        title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen cameras'}
+        aria-label={isFullscreen ? 'Exit fullscreen' : 'Fullscreen cameras'}
+      >
+        {isFullscreen ? (
+          <Minimize2 className="h-4 w-4" aria-hidden="true" />
+        ) : (
+          <Maximize2 className="h-4 w-4" aria-hidden="true" />
+        )}
+      </button>
+    </div>
+  );
+}

--- a/software/station/clients/station-viewer/src/st3215/CameraMotorStrip.tsx
+++ b/software/station/clients/station-viewer/src/st3215/CameraMotorStrip.tsx
@@ -1,18 +1,19 @@
+import { memo } from 'react';
 import Long from 'long';
-import { st3215 } from '../api/proto.js';
-import { serverToLocal } from '../api/timestamp-utils';
+import { st3215 } from '@/api/proto.js';
+import { serverToLocal } from '@/api/timestamp-utils';
 import {
   getCurrentColor,
   getMotorStatusTextColor,
   getTemperatureColor,
-} from '../utils/color-utils';
-import { getMotorCurrent, getMotorTemperature } from './motor-parser';
+} from '@/utils/color-utils';
+import { getMotorCurrent, getMotorTemperature } from '@/st3215/motor-parser';
 
 interface CameraMotorStripProps {
   bus: st3215.InferenceState.IBusState;
 }
 
-export default function CameraMotorStrip({ bus }: CameraMotorStripProps) {
+const CameraMotorStrip = memo(function CameraMotorStrip({ bus }: CameraMotorStripProps) {
   const motors = [...(bus.motors ?? [])].sort((a, b) => (a.id ?? 0) - (b.id ?? 0));
 
   if (!motors.length) {
@@ -26,6 +27,7 @@ export default function CameraMotorStrip({ bus }: CameraMotorStripProps) {
     const adjustedMotorStamp = motor.monotonicStampNs
       ? serverToLocal(Long.fromValue(motor.monotonicStampNs))
       : null;
+    // Latency is folded into OK/ERR color so stale motors still stand out in compact mode.
     const latency = adjustedMotorStamp ? now - adjustedMotorStamp.toNumber() / 1e6 : 0;
     const hasError = Boolean(motor.error);
 
@@ -39,27 +41,27 @@ export default function CameraMotorStrip({ bus }: CameraMotorStripProps) {
   });
   return (
     <div className="max-h-full overflow-y-auto overflow-x-hidden">
-      <div className="flex flex-wrap items-center gap-1.5 px-2 py-1.5 text-xs font-mono text-text-label sm:gap-2">
+      <div className="grid grid-cols-2 gap-1.5 px-2 py-1.5 text-xs font-mono text-text-label sm:flex sm:flex-wrap sm:items-center sm:gap-2">
         {motorRows.map(({ current, hasError, latency, motor, temperature }) => (
           <div
             key={motor.id}
-            className={`flex h-9 min-w-[7.5rem] flex-1 items-center justify-between gap-2 rounded-md border px-2 sm:flex-none ${
+            className={`flex h-9 min-w-0 items-center justify-between gap-1.5 rounded-md border px-2 sm:min-w-[7.5rem] sm:flex-none sm:gap-2 ${
               hasError
                 ? 'border-accent-critical/60 bg-accent-critical/10'
                 : 'border-border-default/60 bg-surface-secondary/80'
             }`}
             title={motor.error?.description || undefined}
           >
-            <span className={`font-bold ${getMotorStatusTextColor(latency, hasError)}`}>
+            <span className={`shrink-0 font-bold ${getMotorStatusTextColor(latency, hasError)}`}>
               M{motor.id}
             </span>
-            <span className={`tabular-nums ${getCurrentColor(current)}`}>
+            <span className={`shrink-0 whitespace-nowrap tabular-nums ${getCurrentColor(current)}`}>
               I {current}
             </span>
-            <span className={`tabular-nums ${getTemperatureColor(temperature)}`}>
+            <span className={`shrink-0 whitespace-nowrap tabular-nums ${getTemperatureColor(temperature)}`}>
               {temperature}°C
             </span>
-            <span className={`font-bold ${getMotorStatusTextColor(latency, hasError)}`}>
+            <span className={`shrink-0 font-bold ${getMotorStatusTextColor(latency, hasError)}`}>
               {hasError ? 'ERR' : 'OK'}
             </span>
           </div>
@@ -67,4 +69,6 @@ export default function CameraMotorStrip({ bus }: CameraMotorStripProps) {
       </div>
     </div>
   );
-}
+});
+
+export default CameraMotorStrip;

--- a/software/station/clients/station-viewer/src/st3215/CameraMotorStrip.tsx
+++ b/software/station/clients/station-viewer/src/st3215/CameraMotorStrip.tsx
@@ -1,0 +1,70 @@
+import Long from 'long';
+import { st3215 } from '../api/proto.js';
+import { serverToLocal } from '../api/timestamp-utils';
+import {
+  getCurrentColor,
+  getMotorStatusTextColor,
+  getTemperatureColor,
+} from '../utils/color-utils';
+import { getMotorCurrent, getMotorTemperature } from './motor-parser';
+
+interface CameraMotorStripProps {
+  bus: st3215.InferenceState.IBusState;
+}
+
+export default function CameraMotorStrip({ bus }: CameraMotorStripProps) {
+  const motors = [...(bus.motors ?? [])].sort((a, b) => (a.id ?? 0) - (b.id ?? 0));
+
+  if (!motors.length) {
+    return null;
+  }
+
+  const now = Date.now();
+  const motorRows = motors.map((motor) => {
+    const current = motor.state ? getMotorCurrent(motor.state) : 0;
+    const temperature = motor.state ? getMotorTemperature(motor.state) : 0;
+    const adjustedMotorStamp = motor.monotonicStampNs
+      ? serverToLocal(Long.fromValue(motor.monotonicStampNs))
+      : null;
+    const latency = adjustedMotorStamp ? now - adjustedMotorStamp.toNumber() / 1e6 : 0;
+    const hasError = Boolean(motor.error);
+
+    return {
+      current,
+      hasError,
+      latency,
+      motor,
+      temperature,
+    };
+  });
+  return (
+    <div className="max-h-full overflow-y-auto overflow-x-hidden">
+      <div className="flex flex-wrap items-center gap-1.5 px-2 py-1.5 text-xs font-mono text-text-label sm:gap-2">
+        {motorRows.map(({ current, hasError, latency, motor, temperature }) => (
+          <div
+            key={motor.id}
+            className={`flex h-9 min-w-[7.5rem] flex-1 items-center justify-between gap-2 rounded-md border px-2 sm:flex-none ${
+              hasError
+                ? 'border-accent-critical/60 bg-accent-critical/10'
+                : 'border-border-default/60 bg-surface-secondary/80'
+            }`}
+            title={motor.error?.description || undefined}
+          >
+            <span className={`font-bold ${getMotorStatusTextColor(latency, hasError)}`}>
+              M{motor.id}
+            </span>
+            <span className={`tabular-nums ${getCurrentColor(current)}`}>
+              I {current}
+            </span>
+            <span className={`tabular-nums ${getTemperatureColor(temperature)}`}>
+              {temperature}°C
+            </span>
+            <span className={`font-bold ${getMotorStatusTextColor(latency, hasError)}`}>
+              {hasError ? 'ERR' : 'OK'}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/software/station/clients/station-viewer/src/usbvideo/RobotCameraView.tsx
+++ b/software/station/clients/station-viewer/src/usbvideo/RobotCameraView.tsx
@@ -1,19 +1,19 @@
 import { memo } from 'react';
 import { Link } from 'react-router-dom';
 import { Scan } from 'lucide-react';
-import { st3215, usbvideo } from '../api/proto.js';
-import CameraMotorStrip from '../st3215/CameraMotorStrip';
-import MotorDataTable from '../st3215/MotorDataTable';
-import CameraViewer from './CameraViewer';
+import { st3215 } from '@/api/proto.js';
+import CameraMotorStrip from '@/st3215/CameraMotorStrip';
+import MotorDataTable from '@/st3215/MotorDataTable';
+import CameraViewer from '@/usbvideo/CameraViewer';
 
 type CameraFitMode = 'contain' | 'cover';
+type CameraLayoutMode = 'pip' | 'side-by-side' | 'stacked';
+type MotorStripPlacement = 'none' | 'bottom';
 
 interface RobotCameraViewProps {
-  primaryVideoSource?: usbvideo.IRxEnvelope;
-  secondaryVideoSource?: usbvideo.IRxEnvelope;
   primaryVideoSourceId?: string | null;
   secondaryVideoSourceId?: string | null;
-  cameraLayout?: 'pip' | 'side-by-side' | 'stacked';
+  cameraLayout?: CameraLayoutMode;
   primaryCameraFit?: CameraFitMode;
   secondaryCameraFit?: CameraFitMode;
   onPrimaryCameraFitToggle?: () => void;
@@ -48,12 +48,20 @@ const RobotCameraView = memo(function RobotCameraView({
     (cameraLayout === 'side-by-side' || cameraLayout === 'stacked') &&
     Boolean(secondaryVideoSourceId);
   const isStackedLayout = cameraLayout === 'stacked';
-  const shouldShowCompactMotorStrip = showMotorData && motorCount > 0 && !isWebControlled;
-  const shouldShowMobilePaneMotorStrip =
-    shouldShowCompactMotorStrip && isSplitLayout && !isStackedLayout;
-  const shouldShowStackedPaneMotorStrip =
-    shouldShowCompactMotorStrip && isSplitLayout && isStackedLayout;
-  const shouldLiftMobilePip = shouldShowCompactMotorStrip && !isSplitLayout;
+  const motorStripPlacement: MotorStripPlacement =
+    !showMotorData || motorCount === 0 ? 'none' : 'bottom';
+  const renderMotorStrip = () => (
+    isWebControlled ? (
+      <MotorDataTable
+        bus={bus}
+        busIndex={busIndex}
+        isWebControlled={isWebControlled}
+        layout="panel"
+      />
+    ) : (
+      <CameraMotorStrip bus={bus} />
+    )
+  );
   const renderFitButton = (
     fit: CameraFitMode,
     onToggle: (() => void) | undefined,
@@ -63,7 +71,11 @@ const RobotCameraView = memo(function RobotCameraView({
     <button
       type="button"
       onClick={onToggle}
-      className={`absolute z-30 flex h-8 w-8 items-center justify-center rounded-md border border-border-subtle bg-surface-primary/75 text-text-muted shadow-lg backdrop-blur-sm transition-colors hover:text-text-primary ${fit === 'cover' ? 'bg-accent-data/90 text-surface-base hover:text-surface-base' : ''} ${className}`}
+      className={`absolute z-30 flex h-8 w-8 items-center justify-center rounded-md border border-border-subtle shadow-lg backdrop-blur-sm transition-colors ${
+        fit === 'cover'
+          ? 'bg-accent-data/90 text-surface-base hover:text-surface-base'
+          : 'bg-surface-primary/75 text-text-muted hover:text-text-primary'
+      } ${className}`}
       title={`${label}: ${fit}`}
       aria-label={`Toggle ${label} fit`}
     >
@@ -92,15 +104,6 @@ const RobotCameraView = memo(function RobotCameraView({
                 fit={primaryCameraFit}
               />
               {renderFitButton(primaryCameraFit, onPrimaryCameraFitToggle, 'Primary camera')}
-              {(shouldShowMobilePaneMotorStrip || shouldShowStackedPaneMotorStrip) && (
-                <div
-                  className={`absolute bottom-0 left-0 right-0 z-40 max-h-[48%] min-h-0 border-t border-border-default bg-surface-base/95 shadow-2xl backdrop-blur-sm ${
-                    shouldShowMobilePaneMotorStrip ? 'sm:hidden' : ''
-                  }`}
-                >
-                  <CameraMotorStrip bus={bus} />
-                </div>
-              )}
             </div>
             <div className="relative min-h-0 min-w-0">
               <CameraViewer
@@ -123,9 +126,7 @@ const RobotCameraView = memo(function RobotCameraView({
             {renderFitButton(primaryCameraFit, onPrimaryCameraFitToggle, 'Primary camera')}
             {secondaryVideoSourceId && (
               <div
-                className={`absolute right-4 z-30 h-[160px] w-2/5 min-w-[220px] max-w-[360px] overflow-hidden rounded-lg border-2 border-border-default bg-surface-primary shadow-2xl ${
-                  shouldLiftMobilePip ? 'bottom-[36%] sm:bottom-4' : 'bottom-4'
-                }`}
+                className="absolute bottom-4 right-4 z-30 h-[160px] w-2/5 min-w-[220px] max-w-[360px] overflow-hidden rounded-lg border-2 border-border-default bg-surface-primary shadow-2xl"
               >
                 <CameraViewer
                   sourceId={secondaryVideoSourceId}
@@ -167,31 +168,14 @@ const RobotCameraView = memo(function RobotCameraView({
         )}
       </div>
 
-      {showMotorData &&
-        motorCount > 0 &&
-        !shouldShowMobilePaneMotorStrip &&
-        !shouldShowStackedPaneMotorStrip && (
+      {motorStripPlacement === 'bottom' && (
         <div
-          className={`absolute bottom-0 left-0 right-0 z-40 min-h-0 border-t border-border-default bg-surface-base/95 shadow-2xl backdrop-blur-sm ${
-            isWebControlled ? '' : 'max-h-[34%]'
+          className={`z-40 min-h-0 shrink-0 border-t border-border-default bg-surface-base/95 shadow-2xl backdrop-blur-sm ${
+            isWebControlled ? '' : 'max-h-40'
           }`}
           style={isWebControlled ? { height: motorPanelHeight } : undefined}
         >
-          {isWebControlled ? (
-            <MotorDataTable
-              bus={bus}
-              busIndex={busIndex}
-              isWebControlled={isWebControlled}
-              layout="panel"
-            />
-          ) : (
-            <CameraMotorStrip bus={bus} />
-          )}
-        </div>
-      )}
-      {shouldShowMobilePaneMotorStrip && (
-        <div className="absolute bottom-0 left-0 right-0 z-40 hidden min-h-0 max-h-[34%] border-t border-border-default bg-surface-base/95 shadow-2xl backdrop-blur-sm sm:block">
-          <CameraMotorStrip bus={bus} />
+          {renderMotorStrip()}
         </div>
       )}
     </div>

--- a/software/station/clients/station-viewer/src/usbvideo/RobotCameraView.tsx
+++ b/software/station/clients/station-viewer/src/usbvideo/RobotCameraView.tsx
@@ -2,7 +2,6 @@ import { memo } from 'react';
 import { Link } from 'react-router-dom';
 import { st3215, usbvideo } from '../api/proto.js';
 import MotorDataTable from '../st3215/MotorDataTable';
-import { formatCameraName } from './camera-source';
 import CameraViewer from './CameraViewer';
 
 interface RobotCameraViewProps {
@@ -20,8 +19,6 @@ interface RobotCameraViewProps {
 }
 
 const RobotCameraView = memo(function RobotCameraView({
-  primaryVideoSource,
-  secondaryVideoSource,
   primaryVideoSourceId,
   secondaryVideoSourceId,
   cameraLayout = 'pip',
@@ -39,20 +36,17 @@ const RobotCameraView = memo(function RobotCameraView({
   const isSideBySide = cameraLayout === 'side-by-side' && Boolean(secondaryVideoSourceId);
 
   return (
-    <div className="flex flex-col w-full h-full min-h-0 overflow-hidden bg-black rounded-b-lg">
+    <div className="relative flex flex-col w-full h-full min-h-0 overflow-hidden bg-black rounded-b-lg">
       <div className="relative min-h-0" style={{ flex: '1 1 auto' }}>
         {isSideBySide && primaryVideoSourceId ? (
-          <div className="grid h-full w-full grid-cols-2">
-            <div className="relative min-h-0 min-w-0 border-r border-border-default">
+          <div className="grid h-full w-full grid-rows-2 sm:grid-cols-2 sm:grid-rows-1">
+            <div className="relative min-h-0 min-w-0 border-b border-border-default sm:border-b-0 sm:border-r">
               <CameraViewer
                 sourceId={primaryVideoSourceId}
                 className="h-full w-full"
                 imageClassName="select-none"
                 fit="contain"
               />
-              <div className="absolute bottom-0 left-0 right-0 bg-surface-secondary/70 px-2 py-1 text-xs font-mono text-text-label backdrop-blur-sm">
-                {formatCameraName(primaryVideoSource)}
-              </div>
             </div>
             <div className="relative min-h-0 min-w-0">
               <CameraViewer
@@ -61,9 +55,6 @@ const RobotCameraView = memo(function RobotCameraView({
                 imageClassName="select-none"
                 fit="contain"
               />
-              <div className="absolute bottom-0 left-0 right-0 bg-surface-secondary/70 px-2 py-1 text-xs font-mono text-text-label backdrop-blur-sm">
-                {formatCameraName(secondaryVideoSource)}
-              </div>
             </div>
           </div>
         ) : primaryVideoSourceId ? (
@@ -83,9 +74,6 @@ const RobotCameraView = memo(function RobotCameraView({
                   fit="contain"
                   overlay="none"
                 />
-                <div className="absolute bottom-0 left-0 right-0 bg-surface-secondary/70 px-2 py-1 text-xs font-mono text-text-label backdrop-blur-sm">
-                  {formatCameraName(secondaryVideoSource)}
-                </div>
               </div>
             )}
           </>
@@ -101,7 +89,7 @@ const RobotCameraView = memo(function RobotCameraView({
         )}
 
         {showCalibrateButton && needsCalibration && (
-          <div className="absolute inset-0 z-40 flex items-center justify-center pointer-events-none">
+          <div className="absolute inset-0 z-50 flex items-center justify-center pointer-events-none">
             <Link
               to="/st3215-bus-calibration"
               state={{ bus }}
@@ -113,11 +101,10 @@ const RobotCameraView = memo(function RobotCameraView({
         )}
       </div>
 
-      {/* Motor data section */}
       {showMotorData && motorCount > 0 && (
         <div
-          className="relative min-h-0 border-t border-border-default bg-surface-base"
-          style={{ flex: `0 0 ${motorPanelHeight}` }}
+          className="absolute bottom-0 left-0 right-0 z-40 min-h-0 border-t border-border-default bg-surface-base/95 shadow-2xl backdrop-blur-sm"
+          style={{ height: motorPanelHeight }}
         >
           <MotorDataTable
             bus={bus}

--- a/software/station/clients/station-viewer/src/usbvideo/RobotCameraView.tsx
+++ b/software/station/clients/station-viewer/src/usbvideo/RobotCameraView.tsx
@@ -10,6 +10,7 @@ interface RobotCameraViewProps {
   secondaryVideoSource?: usbvideo.IRxEnvelope;
   primaryVideoSourceId?: string | null;
   secondaryVideoSourceId?: string | null;
+  cameraLayout?: 'pip' | 'side-by-side';
   bus: st3215.InferenceState.IBusState;
   busIndex: number;
   isWebControlled?: boolean;
@@ -19,9 +20,11 @@ interface RobotCameraViewProps {
 }
 
 const RobotCameraView = memo(function RobotCameraView({
+  primaryVideoSource,
   secondaryVideoSource,
   primaryVideoSourceId,
   secondaryVideoSourceId,
+  cameraLayout = 'pip',
   bus,
   busIndex,
   isWebControlled,
@@ -33,17 +36,59 @@ const RobotCameraView = memo(function RobotCameraView({
   // 8-motor humanoids need room for two arm groups without crowding the camera view.
   const motorPanelHeight =
     motorCount >= 8 ? 'clamp(240px, 40%, 320px)' : 'clamp(180px, 32%, 240px)';
+  const isSideBySide = cameraLayout === 'side-by-side' && Boolean(secondaryVideoSourceId);
 
   return (
     <div className="flex flex-col w-full h-full min-h-0 overflow-hidden bg-black rounded-b-lg">
       <div className="relative min-h-0" style={{ flex: '1 1 auto' }}>
-        {primaryVideoSourceId ? (
-          <CameraViewer
-            sourceId={primaryVideoSourceId}
-            className="h-full w-full"
-            imageClassName="select-none"
-            fit="contain"
-          />
+        {isSideBySide && primaryVideoSourceId ? (
+          <div className="grid h-full w-full grid-cols-2">
+            <div className="relative min-h-0 min-w-0 border-r border-border-default">
+              <CameraViewer
+                sourceId={primaryVideoSourceId}
+                className="h-full w-full"
+                imageClassName="select-none"
+                fit="contain"
+              />
+              <div className="absolute bottom-0 left-0 right-0 bg-surface-secondary/70 px-2 py-1 text-xs font-mono text-text-label backdrop-blur-sm">
+                {formatCameraName(primaryVideoSource)}
+              </div>
+            </div>
+            <div className="relative min-h-0 min-w-0">
+              <CameraViewer
+                sourceId={secondaryVideoSourceId}
+                className="h-full w-full"
+                imageClassName="select-none"
+                fit="contain"
+              />
+              <div className="absolute bottom-0 left-0 right-0 bg-surface-secondary/70 px-2 py-1 text-xs font-mono text-text-label backdrop-blur-sm">
+                {formatCameraName(secondaryVideoSource)}
+              </div>
+            </div>
+          </div>
+        ) : primaryVideoSourceId ? (
+          <>
+            <CameraViewer
+              sourceId={primaryVideoSourceId}
+              className="h-full w-full"
+              imageClassName="select-none"
+              fit="contain"
+            />
+            {secondaryVideoSourceId && (
+              <div className="absolute bottom-4 right-4 z-30 h-[160px] w-2/5 min-w-[220px] max-w-[360px] overflow-hidden rounded-lg border-2 border-border-default bg-surface-primary shadow-2xl">
+                <CameraViewer
+                  sourceId={secondaryVideoSourceId}
+                  className="h-full w-full"
+                  imageClassName="select-none"
+                  fit="contain"
+                  overlay="none"
+                />
+                <div className="absolute bottom-0 left-0 right-0 bg-surface-secondary/70 px-2 py-1 text-xs font-mono text-text-label backdrop-blur-sm">
+                  {formatCameraName(secondaryVideoSource)}
+                </div>
+              </div>
+            )}
+          </>
         ) : (
           <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-surface-primary/30 p-6 text-center">
             <div className="text-accent-warning text-lg font-bold uppercase tracking-wide">
@@ -52,21 +97,6 @@ const RobotCameraView = memo(function RobotCameraView({
             <p className="max-w-md text-sm text-text-muted">
               Select an active USB video source in the title bar to switch this robot card into a camera-first operator view.
             </p>
-          </div>
-        )}
-
-        {secondaryVideoSourceId && (
-          <div className="absolute bottom-4 right-4 z-30 h-[160px] w-2/5 min-w-[220px] max-w-[360px] overflow-hidden rounded-lg border-2 border-border-default bg-surface-primary shadow-2xl">
-            <CameraViewer
-              sourceId={secondaryVideoSourceId}
-              className="h-full w-full"
-              imageClassName="select-none"
-              fit="contain"
-              overlay="none"
-            />
-            <div className="absolute bottom-0 left-0 right-0 bg-surface-secondary/70 px-2 py-1 text-xs font-mono text-text-label backdrop-blur-sm">
-              {formatCameraName(secondaryVideoSource)}
-            </div>
           </div>
         )}
 

--- a/software/station/clients/station-viewer/src/usbvideo/RobotCameraView.tsx
+++ b/software/station/clients/station-viewer/src/usbvideo/RobotCameraView.tsx
@@ -1,15 +1,23 @@
 import { memo } from 'react';
 import { Link } from 'react-router-dom';
+import { Scan } from 'lucide-react';
 import { st3215, usbvideo } from '../api/proto.js';
+import CameraMotorStrip from '../st3215/CameraMotorStrip';
 import MotorDataTable from '../st3215/MotorDataTable';
 import CameraViewer from './CameraViewer';
+
+type CameraFitMode = 'contain' | 'cover';
 
 interface RobotCameraViewProps {
   primaryVideoSource?: usbvideo.IRxEnvelope;
   secondaryVideoSource?: usbvideo.IRxEnvelope;
   primaryVideoSourceId?: string | null;
   secondaryVideoSourceId?: string | null;
-  cameraLayout?: 'pip' | 'side-by-side';
+  cameraLayout?: 'pip' | 'side-by-side' | 'stacked';
+  primaryCameraFit?: CameraFitMode;
+  secondaryCameraFit?: CameraFitMode;
+  onPrimaryCameraFitToggle?: () => void;
+  onSecondaryCameraFitToggle?: () => void;
   bus: st3215.InferenceState.IBusState;
   busIndex: number;
   isWebControlled?: boolean;
@@ -22,6 +30,10 @@ const RobotCameraView = memo(function RobotCameraView({
   primaryVideoSourceId,
   secondaryVideoSourceId,
   cameraLayout = 'pip',
+  primaryCameraFit = 'contain',
+  secondaryCameraFit = 'contain',
+  onPrimaryCameraFitToggle,
+  onSecondaryCameraFitToggle,
   bus,
   busIndex,
   isWebControlled,
@@ -30,31 +42,74 @@ const RobotCameraView = memo(function RobotCameraView({
   needsCalibration,
 }: RobotCameraViewProps) {
   const motorCount = bus.motors?.length ?? 0;
-  // 8-motor humanoids need room for two arm groups without crowding the camera view.
   const motorPanelHeight =
     motorCount >= 8 ? 'clamp(240px, 40%, 320px)' : 'clamp(180px, 32%, 240px)';
-  const isSideBySide = cameraLayout === 'side-by-side' && Boolean(secondaryVideoSourceId);
+  const isSplitLayout =
+    (cameraLayout === 'side-by-side' || cameraLayout === 'stacked') &&
+    Boolean(secondaryVideoSourceId);
+  const isStackedLayout = cameraLayout === 'stacked';
+  const shouldShowCompactMotorStrip = showMotorData && motorCount > 0 && !isWebControlled;
+  const shouldShowMobilePaneMotorStrip =
+    shouldShowCompactMotorStrip && isSplitLayout && !isStackedLayout;
+  const shouldShowStackedPaneMotorStrip =
+    shouldShowCompactMotorStrip && isSplitLayout && isStackedLayout;
+  const shouldLiftMobilePip = shouldShowCompactMotorStrip && !isSplitLayout;
+  const renderFitButton = (
+    fit: CameraFitMode,
+    onToggle: (() => void) | undefined,
+    label: string,
+    className = 'right-2 top-12',
+  ) => (
+    <button
+      type="button"
+      onClick={onToggle}
+      className={`absolute z-30 flex h-8 w-8 items-center justify-center rounded-md border border-border-subtle bg-surface-primary/75 text-text-muted shadow-lg backdrop-blur-sm transition-colors hover:text-text-primary ${fit === 'cover' ? 'bg-accent-data/90 text-surface-base hover:text-surface-base' : ''} ${className}`}
+      title={`${label}: ${fit}`}
+      aria-label={`Toggle ${label} fit`}
+    >
+      <Scan className="h-4 w-4" aria-hidden="true" />
+    </button>
+  );
 
   return (
     <div className="relative flex flex-col w-full h-full min-h-0 overflow-hidden bg-black rounded-b-lg">
       <div className="relative min-h-0" style={{ flex: '1 1 auto' }}>
-        {isSideBySide && primaryVideoSourceId ? (
-          <div className="grid h-full w-full grid-rows-2 sm:grid-cols-2 sm:grid-rows-1">
-            <div className="relative min-h-0 min-w-0 border-b border-border-default sm:border-b-0 sm:border-r">
+        {isSplitLayout && primaryVideoSourceId ? (
+          <div
+            className={`grid h-full w-full ${
+              isStackedLayout ? 'grid-rows-2' : 'grid-rows-2 sm:grid-cols-2 sm:grid-rows-1'
+            }`}
+          >
+            <div
+              className={`relative min-h-0 min-w-0 border-border-default ${
+                isStackedLayout ? 'border-b' : 'border-b sm:border-b-0 sm:border-r'
+              }`}
+            >
               <CameraViewer
                 sourceId={primaryVideoSourceId}
                 className="h-full w-full"
                 imageClassName="select-none"
-                fit="contain"
+                fit={primaryCameraFit}
               />
+              {renderFitButton(primaryCameraFit, onPrimaryCameraFitToggle, 'Primary camera')}
+              {(shouldShowMobilePaneMotorStrip || shouldShowStackedPaneMotorStrip) && (
+                <div
+                  className={`absolute bottom-0 left-0 right-0 z-40 max-h-[48%] min-h-0 border-t border-border-default bg-surface-base/95 shadow-2xl backdrop-blur-sm ${
+                    shouldShowMobilePaneMotorStrip ? 'sm:hidden' : ''
+                  }`}
+                >
+                  <CameraMotorStrip bus={bus} />
+                </div>
+              )}
             </div>
             <div className="relative min-h-0 min-w-0">
               <CameraViewer
                 sourceId={secondaryVideoSourceId}
                 className="h-full w-full"
                 imageClassName="select-none"
-                fit="contain"
+                fit={secondaryCameraFit}
               />
+              {renderFitButton(secondaryCameraFit, onSecondaryCameraFitToggle, 'Secondary camera')}
             </div>
           </div>
         ) : primaryVideoSourceId ? (
@@ -63,17 +118,28 @@ const RobotCameraView = memo(function RobotCameraView({
               sourceId={primaryVideoSourceId}
               className="h-full w-full"
               imageClassName="select-none"
-              fit="contain"
+              fit={primaryCameraFit}
             />
+            {renderFitButton(primaryCameraFit, onPrimaryCameraFitToggle, 'Primary camera')}
             {secondaryVideoSourceId && (
-              <div className="absolute bottom-4 right-4 z-30 h-[160px] w-2/5 min-w-[220px] max-w-[360px] overflow-hidden rounded-lg border-2 border-border-default bg-surface-primary shadow-2xl">
+              <div
+                className={`absolute right-4 z-30 h-[160px] w-2/5 min-w-[220px] max-w-[360px] overflow-hidden rounded-lg border-2 border-border-default bg-surface-primary shadow-2xl ${
+                  shouldLiftMobilePip ? 'bottom-[36%] sm:bottom-4' : 'bottom-4'
+                }`}
+              >
                 <CameraViewer
                   sourceId={secondaryVideoSourceId}
                   className="h-full w-full"
                   imageClassName="select-none"
-                  fit="contain"
+                  fit={secondaryCameraFit}
                   overlay="none"
                 />
+                {renderFitButton(
+                  secondaryCameraFit,
+                  onSecondaryCameraFitToggle,
+                  'Secondary camera',
+                  'right-2 top-2',
+                )}
               </div>
             )}
           </>
@@ -101,17 +167,31 @@ const RobotCameraView = memo(function RobotCameraView({
         )}
       </div>
 
-      {showMotorData && motorCount > 0 && (
+      {showMotorData &&
+        motorCount > 0 &&
+        !shouldShowMobilePaneMotorStrip &&
+        !shouldShowStackedPaneMotorStrip && (
         <div
-          className="absolute bottom-0 left-0 right-0 z-40 min-h-0 border-t border-border-default bg-surface-base/95 shadow-2xl backdrop-blur-sm"
-          style={{ height: motorPanelHeight }}
+          className={`absolute bottom-0 left-0 right-0 z-40 min-h-0 border-t border-border-default bg-surface-base/95 shadow-2xl backdrop-blur-sm ${
+            isWebControlled ? '' : 'max-h-[34%]'
+          }`}
+          style={isWebControlled ? { height: motorPanelHeight } : undefined}
         >
-          <MotorDataTable
-            bus={bus}
-            busIndex={busIndex}
-            isWebControlled={isWebControlled}
-            layout="panel"
-          />
+          {isWebControlled ? (
+            <MotorDataTable
+              bus={bus}
+              busIndex={busIndex}
+              isWebControlled={isWebControlled}
+              layout="panel"
+            />
+          ) : (
+            <CameraMotorStrip bus={bus} />
+          )}
+        </div>
+      )}
+      {shouldShowMobilePaneMotorStrip && (
+        <div className="absolute bottom-0 left-0 right-0 z-40 hidden min-h-0 max-h-[34%] border-t border-border-default bg-surface-base/95 shadow-2xl backdrop-blur-sm sm:block">
+          <CameraMotorStrip bus={bus} />
         </div>
       )}
     </div>


### PR DESCRIPTION
## TL;DR

Camera-first UX revamp + internal cleanup in station viewer.

## UX / feature changes
- Added dual-camera layout system: PiP, side-by-side, stacked (toggle/cycle behavior).
- Added in-video HUD controls:
  - layout switch
  - camera swap
  - motor panel toggle
  - fullscreen toggle
- Added per-camera fit control (contain / cover) for primary and secondary streams.
- Reworked camera selection to chips with MAIN/AUX semantics.
- Added fullscreen camera mode with explicit Esc handling.
- Mobile behavior improved:
  - split layout defaults to vertical stacking on small screens
  - motor strip layout tuned for narrow screens

## Demo

### Desktop

<img width="897" height="826" alt="Screenshot 2026-05-10 at 22 18 37" src="https://github.com/user-attachments/assets/13213f87-6167-4f59-adbb-ecff55f0f5f7" />
<img width="899" height="830" alt="Screenshot 2026-05-10 at 22 18 46" src="https://github.com/user-attachments/assets/520944ae-6f6f-432a-9cd8-0b22018d0ff1" />
<img width="888" height="826" alt="Screenshot 2026-05-10 at 22 18 58" src="https://github.com/user-attachments/assets/31d445dc-e4ae-4e76-a76d-7851af403d96" />
<img width="1266" height="831" alt="Screenshot 2026-05-10 at 22 19 36" src="https://github.com/user-attachments/assets/cc792468-a35d-425e-b187-a7069f2eb5c9" />
<img width="890" height="817" alt="Screenshot 2026-05-10 at 22 24 53" src="https://github.com/user-attachments/assets/83a54d19-c2bc-43f4-9b9b-31a862377942" />



### Mobile

<img width="848" height="391" alt="Screenshot 2026-05-10 at 22 21 50" src="https://github.com/user-attachments/assets/d1774536-3c4d-43a3-95c8-c12e3b3c2167" />
<img width="394" height="846" alt="Screenshot 2026-05-10 at 22 23 28" src="https://github.com/user-attachments/assets/e7cf357d-7bb3-4b4f-b035-26b13986fccd" />
