### PR TITLE
ci(station-viewer): add PR typecheck/build workflow scoped to station-viewer

### DIFF
--- a/.github/workflows/station-viewer-pr-check.yml
+++ b/.github/workflows/station-viewer-pr-check.yml
@@ -1,0 +1,36 @@
+name: Station Viewer PR Check
+
+env:
+  NODE_VERSION: "22"
+
+on:
+  pull_request:
+    paths:
+      - "software/station/clients/station-viewer/**"
+
+jobs:
+  typecheck-and-build:
+    name: Typecheck and Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: software/station/clients/station-viewer
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "yarn"
+          cache-dependency-path: software/station/clients/station-viewer/yarn.lock
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Typecheck
+        run: yarn type-check
+
+      - name: Build
+        run: yarn build


### PR DESCRIPTION
## Summary
Adds a dedicated GitHub Actions workflow for `station-viewer` pull requests.

## What changed
- Added `.github/workflows/station-viewer-pr-check.yml`
- Triggered on `pull_request` only when files under:
  - `software/station/clients/station-viewer/**`
- Configured job to run in:
  - `software/station/clients/station-viewer`
- Added Node version env variable for easy updates:
  - `env.NODE_VERSION: "22"`
- CI steps order:
  1. `yarn install --frozen-lockfile`
  2. `yarn type-check`
  3. `yarn build`

## Why
- Ensures new PRs touching `station-viewer` always pass typecheck before build.
- Keeps CI isolated to this directory to avoid unnecessary runs.
- Makes Node version maintenance simpler via a single env variable.
