### PR TITLE
chore(station-app): harden Electron packaging

### DIFF
--- a/software/station/clients/station-app/README.md
+++ b/software/station/clients/station-app/README.md
@@ -70,7 +70,7 @@ Backend defaults to `ws://127.0.0.1:8889/api` and NormFS TCP to `127.0.0.1:8888`
 
 ## Stack
 
-- Electron 40
+- Electron 41
 - TypeScript 5.9
 - electron-builder
 - Rust station backend

--- a/software/station/clients/station-app/electron-builder.yml
+++ b/software/station/clients/station-app/electron-builder.yml
@@ -1,5 +1,7 @@
 appId: dev.normacore.station-app
 productName: NormaCore Station
+electronLanguages:
+  - en
 directories:
   output: release
 files:
@@ -25,7 +27,9 @@ linux:
     entry:
       Name: NormaCore Station
       Comment: Physical Operations Platform
-      StartupWMClass: normacore-station
+      StartupWMClass: "NormaCore Station"
+      Type: Application
+      Categories: Development;
   target:
     - AppImage
     - deb

--- a/software/station/clients/station-app/src/main.ts
+++ b/software/station/clients/station-app/src/main.ts
@@ -307,7 +307,7 @@ function createWindow(): void {
 
   if (!fs.existsSync(viewerDist)) {
     console.error(`station-viewer dist not found at: ${viewerDist}`);
-    win.loadURL('data:text/html,<h1>station-viewer/dist not found</h1><p>Run yarn build:viewer before loading production mode.</p>');
+    win.loadURL('data:text/html,<h1>station-viewer/dist not found</h1><p>Run npm run build:viewer before loading production mode.</p>');
     return;
   }
 


### PR DESCRIPTION
### Summary
Updates `electron-builder.yml`:
  - `electronLanguages: ["en"]` — ships only the English locale from Electron (removes ~40 other language packs).
  - Fixes the Linux `.desktop` entry: adds required `Type: Application`, sets correct `StartupWMClass: "NormaCore Station"`, and adds `Categories: Development;`.

### Background

The Linux desktop entry was also invalid/mismatched (missing `Type`, wrong `StartupWMClass`), which would cause the app icon to not associate correctly with the window on Linux desktops.