### PR TITLE
chore: upgrade TypeScript to 6.0.3 for station-viewer and station-app

### DIFF
--- a/software/station/clients/station-app/package-lock.json
+++ b/software/station/clients/station-app/package-lock.json
@@ -15,7 +15,7 @@
         "electron": "^41.5.0",
         "electron-builder": "^26.0.0",
         "oxlint": "^1.50.0",
-        "typescript": "5.9.3"
+        "typescript": "6.0.3"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -409,6 +409,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -430,6 +431,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -446,6 +448,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -460,6 +463,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -1055,7 +1059,6 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1736,7 +1739,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1937,7 +1941,6 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -2245,6 +2248,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -2265,6 +2269,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -3573,7 +3578,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3603,6 +3607,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -3620,6 +3625,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -3782,6 +3788,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -4080,6 +4087,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -4219,9 +4227,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/software/station/clients/station-app/package.json
+++ b/software/station/clients/station-app/package.json
@@ -32,7 +32,7 @@
     "electron": "^41.5.0",
     "electron-builder": "^26.0.0",
     "oxlint": "^1.50.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/software/station/clients/station-app/tsconfig.json
+++ b/software/station/clients/station-app/tsconfig.json
@@ -12,7 +12,8 @@
     "resolveJsonModule": true,
     "declaration": false,
     "sourceMap": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/software/station/clients/station-viewer/package-lock.json
+++ b/software/station/clients/station-viewer/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.4",
+        "@types/node": "22.19.19",
         "@types/nosleep.js": "^0.10.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -32,7 +33,7 @@
         "protobufjs": "^7.5.7",
         "protobufjs-cli": "^1.1.3",
         "tailwindcss": "^4.1.16",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
         "vite": "^7.2.0",
         "vite-plugin-compression": "^0.5.1"
       },
@@ -2073,11 +2074,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.10.0",
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/nosleep.js": {
@@ -3699,7 +3702,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3734,7 +3739,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/software/station/clients/station-viewer/package.json
+++ b/software/station/clients/station-viewer/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.4",
+    "@types/node": "22.19.19",
     "@types/nosleep.js": "^0.10.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
@@ -42,7 +43,7 @@
     "protobufjs": "^7.5.7",
     "protobufjs-cli": "^1.1.3",
     "tailwindcss": "^4.1.16",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vite": "^7.2.0",
     "vite-plugin-compression": "^0.5.1"
   },

--- a/software/station/clients/station-viewer/src/api/websocket.ts
+++ b/software/station/clients/station-viewer/src/api/websocket.ts
@@ -290,7 +290,7 @@ class WebSocketManager extends EventTarget {
     if (this.ws && this.ws.readyState === WebSocket.OPEN) {
       const clientRequest = normfs.ClientRequest.create(request);
       const buffer = normfs.ClientRequest.encode(clientRequest).finish();
-      this.ws.send(buffer);
+      this.ws.send(buffer as unknown as ArrayBuffer);
     } else {
       throw ErrConnectionNotOpen;
     }

--- a/software/station/clients/station-viewer/tsconfig.app.json
+++ b/software/station/clients/station-viewer/tsconfig.app.json
@@ -12,13 +12,13 @@
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",
+    "types": ["node"],
     "noEmit": true,
     "jsx": "react-jsx",
 
     /* Path Aliases */
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     },
 
     /* Linting */


### PR DESCRIPTION
- Bump typescript 5.9.3 → 6.0.3 in both packages (exact version to match previous style)
- station-viewer:
  - Removed deprecated baseUrl from tsconfig.app.json, updated paths to "./src/*"
  - Added @types/node@^22 (to satisfy NodeJS namespace in code, engines >=22)
  - Added "types": ["node"] to tsconfig.app.json
  - Fixed TS2352 cast in websocket.ts send() for Uint8Array<ArrayBufferLike> vs DOM BufferSource (stricter in TS6)
  - type-check now passes
- station-app:
  - Added "ignoreDeprecations": "6.0" to silence TS5107 (moduleResolution=node10 normalized from "node" is deprecated in TS6, removed in 7)
  - rootDir kept (required for outDir structure in this CommonJS/Electron setup)
  - type-check now passes
- Updated package-lock.json in both via npm install
- Branch created from dev after syncing main/dev with upstream
- No other station-* TS packages found

See TS 6.0 migration notes: https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/

Related to prior norma-core npm/Electron updates.