### PR TITLE
station-viewer: hide single-camera controls for Yahboom Dogzilla

### DIFF
--- a/software/station/clients/station-viewer/src/st3215/CameraHudControls.tsx
+++ b/software/station/clients/station-viewer/src/st3215/CameraHudControls.tsx
@@ -4,6 +4,7 @@ type CameraLayoutMode = 'pip' | 'side-by-side' | 'stacked';
 
 interface CameraHudControlsProps {
   cameraLayout: CameraLayoutMode;
+  showMultiCameraControls?: boolean;
   hasMotors: boolean;
   showMotorData: boolean;
   isFullscreen: boolean;
@@ -17,6 +18,7 @@ interface CameraHudControlsProps {
 
 export default function CameraHudControls({
   cameraLayout,
+  showMultiCameraControls = true,
   hasMotors,
   showMotorData,
   isFullscreen,
@@ -29,53 +31,57 @@ export default function CameraHudControls({
 }: CameraHudControlsProps) {
   return (
     <div className="absolute left-2 top-2 z-50 flex max-w-[calc(100%-1rem)] flex-wrap gap-1.5 rounded-lg border border-border-default bg-surface-primary/75 p-1.5 shadow-lg backdrop-blur-sm sm:left-3 sm:top-3">
-      <div
-        className="flex rounded-md border border-border-subtle bg-surface-primary p-0.5"
-        role="group"
-        aria-label="Camera layout"
-      >
-        <button
-          type="button"
-          onClick={onSetPipLayout}
-          className={`flex h-8 w-8 items-center justify-center rounded transition-colors ${
-            cameraLayout === 'pip'
-              ? 'bg-accent-data text-surface-base'
-              : 'text-text-muted hover:text-text-primary'
-          }`}
-          title="PiP layout"
-          aria-label="PiP layout"
-        >
-          <span className="relative block h-4 w-4 rounded-[2px] border border-current">
-            <span className="absolute -bottom-px -right-px h-2 w-2 rounded-[1px] border border-current bg-current/20" />
-          </span>
-        </button>
-        <button
-          type="button"
-          onClick={onToggleSplitLayout}
-          className={`flex h-8 w-8 items-center justify-center rounded transition-colors ${
-            cameraLayout === 'side-by-side' || cameraLayout === 'stacked'
-              ? 'bg-accent-data text-surface-base'
-              : 'text-text-muted hover:text-text-primary'
-          }`}
-          title={cameraLayout === 'stacked' ? 'Top-bottom layout' : 'Side-by-side layout'}
-          aria-label={cameraLayout === 'stacked' ? 'Top-bottom layout' : 'Side-by-side layout'}
-        >
-          <span className={`grid h-4 w-4 grid-cols-2 gap-[2px] ${cameraLayout === 'stacked' ? 'rotate-90' : ''}`}>
-            <span className="rounded-[1px] border border-current" />
-            <span className="rounded-[1px] border border-current" />
-          </span>
-        </button>
-      </div>
-      <button
-        type="button"
-        onClick={onSwapCameras}
-        disabled={!canSwapCameras}
-        className="flex h-9 w-9 items-center justify-center rounded-md border border-border-subtle bg-surface-primary text-text-muted transition-colors hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40"
-        title="Swap cameras"
-        aria-label="Swap cameras"
-      >
-        <ArrowLeftRight className="h-4 w-4" aria-hidden="true" />
-      </button>
+      {showMultiCameraControls && (
+        <>
+          <div
+            className="flex rounded-md border border-border-subtle bg-surface-primary p-0.5"
+            role="group"
+            aria-label="Camera layout"
+          >
+            <button
+              type="button"
+              onClick={onSetPipLayout}
+              className={`flex h-8 w-8 items-center justify-center rounded transition-colors ${
+                cameraLayout === 'pip'
+                  ? 'bg-accent-data text-surface-base'
+                  : 'text-text-muted hover:text-text-primary'
+              }`}
+              title="PiP layout"
+              aria-label="PiP layout"
+            >
+              <span className="relative block h-4 w-4 rounded-[2px] border border-current">
+                <span className="absolute -bottom-px -right-px h-2 w-2 rounded-[1px] border border-current bg-current/20" />
+              </span>
+            </button>
+            <button
+              type="button"
+              onClick={onToggleSplitLayout}
+              className={`flex h-8 w-8 items-center justify-center rounded transition-colors ${
+                cameraLayout === 'side-by-side' || cameraLayout === 'stacked'
+                  ? 'bg-accent-data text-surface-base'
+                  : 'text-text-muted hover:text-text-primary'
+              }`}
+              title={cameraLayout === 'stacked' ? 'Top-bottom layout' : 'Side-by-side layout'}
+              aria-label={cameraLayout === 'stacked' ? 'Top-bottom layout' : 'Side-by-side layout'}
+            >
+              <span className={`grid h-4 w-4 grid-cols-2 gap-[2px] ${cameraLayout === 'stacked' ? 'rotate-90' : ''}`}>
+                <span className="rounded-[1px] border border-current" />
+                <span className="rounded-[1px] border border-current" />
+              </span>
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={onSwapCameras}
+            disabled={!canSwapCameras}
+            className="flex h-9 w-9 items-center justify-center rounded-md border border-border-subtle bg-surface-primary text-text-muted transition-colors hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40"
+            title="Swap cameras"
+            aria-label="Swap cameras"
+          >
+            <ArrowLeftRight className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </>
+      )}
       {hasMotors && (
         <button
           type="button"
@@ -99,8 +105,8 @@ export default function CameraHudControls({
             ? 'border-accent-data bg-accent-data text-surface-base'
             : 'border-border-subtle bg-surface-primary text-text-muted hover:text-text-primary'
         }`}
-        title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen cameras'}
-        aria-label={isFullscreen ? 'Exit fullscreen' : 'Fullscreen cameras'}
+        title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen camera view'}
+        aria-label={isFullscreen ? 'Exit fullscreen' : 'Fullscreen camera view'}
       >
         {isFullscreen ? (
           <Minimize2 className="h-4 w-4" aria-hidden="true" />

--- a/software/station/clients/station-viewer/src/yahboom_dogzilla_lite/YahboomDogzillaLiteDashboard.tsx
+++ b/software/station/clients/station-viewer/src/yahboom_dogzilla_lite/YahboomDogzillaLiteDashboard.tsx
@@ -406,7 +406,7 @@ const YahboomDogzillaLiteDashboard = memo(function YahboomDogzillaLiteDashboard(
   }, [cameraOptions, selectedVideoSourceId]);
 
   useEffect(() => {
-    if (cameraOptions.length === 0 || stageViewMode === 'fullscreenVideo') {
+    if (cameraOptions.length <= 1 || stageViewMode === 'fullscreenVideo') {
       setIsCameraPickerOpen(false);
     }
   }, [cameraOptions.length, stageViewMode]);
@@ -463,6 +463,7 @@ const YahboomDogzillaLiteDashboard = memo(function YahboomDogzillaLiteDashboard(
   const connectionLabel = isConnected ? 'Online' : 'Offline';
   const connectionTone = isConnected ? 'good' : 'danger';
   const robotDisplayName = device?.serialNumber ? `Dogzilla #${device.serialNumber}` : 'Dogzilla Lite';
+  const hasMultipleCameraOptions = cameraOptions.length > 1;
 
   const selectedLegConfig = LEG_CONFIGS.find((leg) => leg.key === selectedLeg) ?? LEG_CONFIGS[0];
   const selectedLegValues = LEG_CONTROL_KEYS.map((controlKey) => {
@@ -942,86 +943,87 @@ const YahboomDogzillaLiteDashboard = memo(function YahboomDogzillaLiteDashboard(
                   {renderCameraModeButton({ mode: 'camera', label: 'Camera', icon: Camera })}
                   {renderCameraModeButton({ mode: 'fullscreenVideo', label: 'Fullscreen camera', icon: Maximize2 })}
                 </div>
-                <div className="relative min-w-0">
-                  <button
-                    type="button"
-                    disabled={cameraOptions.length === 0}
-                    onClick={() => setIsCameraPickerOpen((current) => !current)}
-                    className={`flex h-10 w-[9.5rem] min-w-0 items-center justify-between gap-2 rounded-md border px-3 text-left text-xs font-semibold transition focus:outline-none focus:ring-1 focus:ring-accent-data disabled:cursor-not-allowed disabled:opacity-45 ${
-                      isCameraPickerOpen
-                        ? 'border-accent-data bg-surface-primary text-text-primary'
-                        : 'border-border-subtle bg-surface-secondary text-text-primary hover:border-accent-data'
-                    }`}
-                    aria-haspopup="listbox"
-                    aria-expanded={isCameraPickerOpen}
-                    aria-label="Camera source"
-                    title={selectedVideoSource?.label ?? 'No camera'}
-                  >
-                    <span className="min-w-0 truncate">
-                      {selectedVideoSource?.shortLabel ?? 'No camera'}
-                    </span>
-                    <ChevronDown
-                      className={`h-3.5 w-3.5 shrink-0 text-text-muted transition-transform ${isCameraPickerOpen ? 'rotate-180' : ''}`}
-                      strokeWidth={2.5}
-                    />
-                  </button>
-
-                  {isCameraPickerOpen && (
-                    <div
-                      className="absolute bottom-[calc(100%+0.5rem)] right-0 z-40 w-[min(19rem,calc(100vw-2rem))] overflow-hidden rounded-xl border border-border-default bg-surface-primary/95 p-1.5 shadow-2xl backdrop-blur-md"
-                      role="listbox"
+                {hasMultipleCameraOptions && (
+                  <div className="relative min-w-0">
+                    <button
+                      type="button"
+                      onClick={() => setIsCameraPickerOpen((current) => !current)}
+                      className={`flex h-10 w-[9.5rem] min-w-0 items-center justify-between gap-2 rounded-md border px-3 text-left text-xs font-semibold transition focus:outline-none focus:ring-1 focus:ring-accent-data ${
+                        isCameraPickerOpen
+                          ? 'border-accent-data bg-surface-primary text-text-primary'
+                          : 'border-border-subtle bg-surface-secondary text-text-primary hover:border-accent-data'
+                      }`}
+                      aria-haspopup="listbox"
+                      aria-expanded={isCameraPickerOpen}
                       aria-label="Camera source"
+                      title={selectedVideoSource?.label ?? 'No camera'}
                     >
-                      <div className="px-2.5 pb-1.5 pt-1 text-[10px] font-bold uppercase tracking-[0.16em] text-text-muted">
-                        Camera source
-                      </div>
-                      <div className="max-h-56 overflow-y-auto">
-                        {cameraOptions.map((option) => {
-                          const isSelected = option.id === selectedVideoSourceId;
+                      <span className="min-w-0 truncate">
+                        {selectedVideoSource?.shortLabel ?? 'No camera'}
+                      </span>
+                      <ChevronDown
+                        className={`h-3.5 w-3.5 shrink-0 text-text-muted transition-transform ${isCameraPickerOpen ? 'rotate-180' : ''}`}
+                        strokeWidth={2.5}
+                      />
+                    </button>
 
-                          return (
-                            <button
-                              key={option.id}
-                              type="button"
-                              onClick={() => {
-                                setSelectedVideoSourceId(option.id);
-                                setIsCameraPickerOpen(false);
-                              }}
-                              className={`flex w-full items-center gap-2 rounded-lg px-2.5 py-2.5 text-left transition ${
-                                isSelected
-                                  ? 'bg-accent-data text-surface-base'
-                                  : 'text-text-primary hover:bg-surface-secondary'
-                              }`}
-                              role="option"
-                              aria-selected={isSelected}
-                              title={option.label}
-                            >
-                              <span className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full border ${
-                                isSelected
-                                  ? 'border-surface-base/70 bg-surface-base/18'
-                                  : 'border-border-subtle text-transparent'
-                              }`}
+                    {isCameraPickerOpen && (
+                      <div
+                        className="absolute bottom-[calc(100%+0.5rem)] right-0 z-40 w-[min(19rem,calc(100vw-2rem))] overflow-hidden rounded-xl border border-border-default bg-surface-primary/95 p-1.5 shadow-2xl backdrop-blur-md"
+                        role="listbox"
+                        aria-label="Camera source"
+                      >
+                        <div className="px-2.5 pb-1.5 pt-1 text-[10px] font-bold uppercase tracking-[0.16em] text-text-muted">
+                          Camera source
+                        </div>
+                        <div className="max-h-56 overflow-y-auto">
+                          {cameraOptions.map((option) => {
+                            const isSelected = option.id === selectedVideoSourceId;
+
+                            return (
+                              <button
+                                key={option.id}
+                                type="button"
+                                onClick={() => {
+                                  setSelectedVideoSourceId(option.id);
+                                  setIsCameraPickerOpen(false);
+                                }}
+                                className={`flex w-full items-center gap-2 rounded-lg px-2.5 py-2.5 text-left transition ${
+                                  isSelected
+                                    ? 'bg-accent-data text-surface-base'
+                                    : 'text-text-primary hover:bg-surface-secondary'
+                                }`}
+                                role="option"
+                                aria-selected={isSelected}
+                                title={option.label}
                               >
-                                <Check className="h-3.5 w-3.5" strokeWidth={3} />
-                              </span>
-                              <span className="min-w-0 flex-1">
-                                <span className="block truncate text-sm font-bold">
-                                  {option.shortLabel}
-                                </span>
-                                <span className={`block truncate text-[11px] font-medium ${
-                                  isSelected ? 'text-surface-base/72' : 'text-text-muted'
+                                <span className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full border ${
+                                  isSelected
+                                    ? 'border-surface-base/70 bg-surface-base/18'
+                                    : 'border-border-subtle text-transparent'
                                 }`}
                                 >
-                                  {option.detail}
+                                  <Check className="h-3.5 w-3.5" strokeWidth={3} />
                                 </span>
-                              </span>
-                            </button>
-                          );
-                        })}
+                                <span className="min-w-0 flex-1">
+                                  <span className="block truncate text-sm font-bold">
+                                    {option.shortLabel}
+                                  </span>
+                                  <span className={`block truncate text-[11px] font-medium ${
+                                    isSelected ? 'text-surface-base/72' : 'text-text-muted'
+                                  }`}
+                                  >
+                                    {option.detail}
+                                  </span>
+                                </span>
+                              </button>
+                            );
+                          })}
+                        </div>
                       </div>
-                    </div>
-                  )}
-                </div>
+                    )}
+                  </div>
+                )}
               </div>
               {isCameraStageActive && (
                 <button

--- a/software/station/clients/station-viewer/src/yahboom_dogzilla_lite/YahboomDogzillaLiteDesktopCard.tsx
+++ b/software/station/clients/station-viewer/src/yahboom_dogzilla_lite/YahboomDogzillaLiteDesktopCard.tsx
@@ -274,6 +274,7 @@ const YahboomDogzillaLiteDesktopCard = memo(function YahboomDogzillaLiteDesktopC
   const latencyLabel = latencyAvg.avg < 1000
     ? `${latencyAvg.avg.toFixed(0)}ms`
     : `${(latencyAvg.avg / 1000).toFixed(1)}s`;
+  const hasMultipleVideoSources = activeVideoSources.length > 1;
   const cameraSelectValue = primaryVideoSourceId ?? '';
   const cameraSelectLabel = activeVideoSources.length === 0 ? 'No Video' : 'None';
 
@@ -298,7 +299,7 @@ const YahboomDogzillaLiteDesktopCard = memo(function YahboomDogzillaLiteDesktopC
             onChange={handleMainViewModeChange}
             photoDisabled={!primaryVideoSource}
           />
-          {mainViewMode === 'photo' || mainViewMode === 'fullscreenVideo' ? (
+          {hasMultipleVideoSources && (mainViewMode === 'photo' || mainViewMode === 'fullscreenVideo') ? (
             <div
               className="flex min-w-0 max-w-full items-center gap-1.5 overflow-x-auto py-0.5"
               role="group"
@@ -349,7 +350,7 @@ const YahboomDogzillaLiteDesktopCard = memo(function YahboomDogzillaLiteDesktopC
                 );
               })}
             </div>
-          ) : (
+          ) : hasMultipleVideoSources ? (
             <select
               value={cameraSelectValue}
               onChange={(event) => handlePrimaryVideoSourceChange(event.target.value || null)}
@@ -363,7 +364,7 @@ const YahboomDogzillaLiteDesktopCard = memo(function YahboomDogzillaLiteDesktopC
                 </option>
               ))}
             </select>
-          )}
+          ) : null}
         </div>
 
         <div className="flex items-center gap-2 text-sm">

--- a/software/station/clients/station-viewer/src/yahboom_dogzilla_lite/YahboomDogzillaLiteDesktopDashboard.tsx
+++ b/software/station/clients/station-viewer/src/yahboom_dogzilla_lite/YahboomDogzillaLiteDesktopDashboard.tsx
@@ -664,6 +664,7 @@ const YahboomDogzillaLiteDesktopDashboard = memo(function YahboomDogzillaLiteDes
   const renderCameraHudControls = () => (
     <CameraHudControls
       cameraLayout={cameraLayout}
+      showMultiCameraControls={false}
       hasMotors={false}
       showMotorData={false}
       isFullscreen={mainViewMode === 'fullscreenVideo'}


### PR DESCRIPTION
## Summary
- Hide Dogzilla camera source selection when only one camera is available.
- Disable multi-camera HUD controls for Dogzilla camera view, including split/PiP/swap controls.
- Keep multi-camera controls available for ST3215/arm robot camera views via `showMultiCameraControls`.
