### PR TITLE
Added tailscale network interface into yahboom dogzilla lite monitor

### DIFF
--- a/software/station/examples/yahboom-dogzilla-lite-monitor/src/yahboom_dogzilla_lite_monitor/app.py
+++ b/software/station/examples/yahboom-dogzilla-lite-monitor/src/yahboom_dogzilla_lite_monitor/app.py
@@ -97,9 +97,12 @@ def run(
                         logger.warning(error)
                         last_system_error = error
                 else:
-                    state = system_state.parse_state(frame.payload)
-                    current_ip_addresses = state.wlan_ip_addresses()
-                    current_connected = state.has_wlan_ip()
+                    sys_state = system_state.parse_state(frame.payload)
+                    current_ip_addresses = [
+                        *sys_state.wlan_ip_addresses(),
+                        *sys_state.tailscale_ip_addresses(),
+                    ]
+                    current_connected = sys_state.has_wlan_ip()
                     last_system_error = ""
             except system_state.NoSystemStateDataError as exc:
                 if str(exc) != last_system_error:

--- a/software/station/examples/yahboom-dogzilla-lite-monitor/src/yahboom_dogzilla_lite_monitor/system_state.py
+++ b/software/station/examples/yahboom-dogzilla-lite-monitor/src/yahboom_dogzilla_lite_monitor/system_state.py
@@ -26,11 +26,11 @@ class NetworkStatus:
 class State:
     networks: list[NetworkStatus] = dataclass_field(default_factory=list)
 
-    def wlan_ip_addresses(self) -> list[str]:
+    def _ip_addresses_for_prefix(self, iface_prefix: str) -> list[str]:
         seen: set[str] = set()
         out: list[str] = []
         for network in self.networks:
-            if not network.iface.startswith("wlan"):
+            if not network.iface.startswith(iface_prefix):
                 continue
             for raw_addr in network.ip_addresses:
                 addr = normalize_ipv4_address(raw_addr)
@@ -38,6 +38,12 @@ class State:
                     seen.add(addr)
                     out.append(addr)
         return out
+
+    def wlan_ip_addresses(self) -> list[str]:
+        return self._ip_addresses_for_prefix("wlan")
+
+    def tailscale_ip_addresses(self) -> list[str]:
+        return self._ip_addresses_for_prefix("tailscale")
 
     def has_wlan_ip(self) -> bool:
         return bool(self.wlan_ip_addresses())

--- a/software/station/examples/yahboom-dogzilla-lite-monitor/tests/test_system_state.py
+++ b/software/station/examples/yahboom-dogzilla-lite-monitor/tests/test_system_state.py
@@ -43,6 +43,36 @@ def test_parse_state_requires_wlan_interface_for_connectivity() -> None:
     assert not state.has_wlan_ip()
 
 
+def test_parse_state_extracts_tailscale_ipv4_addresses() -> None:
+    payload = sysinfo_pb.Envelope(
+        data=sysinfo_pb.EnvelopeData(
+            networks=[
+                network_state("eth0", ["10.42.0.10"]),
+                network_state("wlan0", ["192.168.12.34/24"]),
+                network_state("tailscale0", ["100.64.0.5/32", "bad", "127.0.0.1"]),
+            ],
+        ),
+    ).encode()
+
+    state = system_state.parse_state(payload)
+
+    assert state.tailscale_ip_addresses() == ["100.64.0.5"]
+    # The wlan accessor is unaffected by the tailscale interface.
+    assert state.wlan_ip_addresses() == ["192.168.12.34"]
+
+
+def test_tailscale_ip_addresses_empty_without_tailscale_interface() -> None:
+    payload = sysinfo_pb.Envelope(
+        data=sysinfo_pb.EnvelopeData(
+            networks=[network_state("wlan0", ["192.168.12.34"])],
+        ),
+    ).encode()
+
+    state = system_state.parse_state(payload)
+
+    assert state.tailscale_ip_addresses() == []
+
+
 def test_parse_state_empty_payload() -> None:
     assert system_state.parse_state(b"") == system_state.State()
 


### PR DESCRIPTION
The monitor's status footer only displayed IPs from wlan* interfaces, so the device's Tailscale address (tailscale0, e.g. 100.64.0.177) was never shown.

This adds a dedicated tailscale_ip_addresses() accessor and includes it in the on-screen IP footer alongside the WLAN IP.