### PR TITLE
Fix station_py client failing to reconnect after server restart

### DIFF
--- a/software/station/shared/station_py/client.py
+++ b/software/station/shared/station_py/client.py
@@ -96,12 +96,18 @@ class Client:
                     await asyncio.sleep(5)
                     continue
 
-            await asyncio.gather(
-                self.read_loop(),
-                self.write_loop(),
-                self.keep_alive_loop(),
-                self.process_responses()
-            )
+            tasks = [
+                asyncio.ensure_future(self.read_loop()),
+                asyncio.ensure_future(self.write_loop()),
+                asyncio.ensure_future(self.keep_alive_loop()),
+                asyncio.ensure_future(self.process_responses()),
+            ]
+            try:
+                await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+            finally:
+                for task in tasks:
+                    task.cancel()
+                await asyncio.gather(*tasks, return_exceptions=True)
             self.logger.info("Connection loops terminated, attempting to reconnect...")
             self.connected = False
             self.setup_done = False


### PR DESCRIPTION
**Problem**

After the station drops the TCP connection (e.g. a restart), the station_py client never reconnects and stays dead until the process restarts.

**Root cause**

Client.manage_connection used asyncio.gather() over the four connection loops, which waits for all to finish. On disconnect, write_loop and process_responses stay parked on await c2s.get() / s2c.get() (nothing feeds those queues once down), so gather() never returns and the reconnect code below it is never reached.

**Fix**

Use asyncio.wait(..., return_when=FIRST_COMPLETED) and cancel the still-parked loops, so teardown always completes and the client reconnects.