### PR TITLE
station-app: fix tag dialog behavior

### DIFF
--- a/software/station/clients/station-viewer/src/components/TagDialog.tsx
+++ b/software/station/clients/station-viewer/src/components/TagDialog.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useRef, useState, type FormEvent, type MouseEvent, type SyntheticEvent } from 'react';
+
+interface TagDialogProps {
+  entryId: number | null;
+  defaultValue: string;
+  error: string | null;
+  isSubmitting: boolean;
+  onClose: () => void;
+  onSubmit: (tag: string) => void | Promise<void>;
+}
+
+function TagDialog({ entryId, defaultValue, error, isSubmitting, onClose, onSubmit }: TagDialogProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [value, setValue] = useState(defaultValue);
+  const canSubmit = entryId !== null && value.trim().length > 0 && !isSubmitting;
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog || dialog.open) return;
+
+    dialog.showModal();
+
+    return () => {
+      if (dialog.open) {
+        dialog.close();
+      }
+    };
+  }, []);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canSubmit) return;
+    void onSubmit(value.trim());
+  };
+
+  const handleDialogClick = (event: MouseEvent<HTMLDialogElement>) => {
+    if (event.target === event.currentTarget && !isSubmitting) {
+      onClose();
+    }
+  };
+
+  const handleCancel = (event: SyntheticEvent<HTMLDialogElement, Event>) => {
+    if (isSubmitting) {
+      event.preventDefault();
+      return;
+    }
+    onClose();
+  };
+
+  return (
+    <dialog
+      ref={dialogRef}
+      aria-labelledby="tag-dialog-title"
+      onCancel={handleCancel}
+      onClick={handleDialogClick}
+      className="m-auto w-[calc(100vw-2rem)] max-w-lg border-0 bg-transparent p-0 text-text-primary backdrop:bg-surface-overlay"
+    >
+      <form
+        onSubmit={handleSubmit}
+        className="rounded-lg border border-border-default bg-surface-secondary p-5 shadow-2xl"
+      >
+        <div className="mb-4 flex items-center justify-between gap-3">
+          <h2 id="tag-dialog-title" className="text-sm font-bold uppercase tracking-wide text-accent-secondary">
+            Tag Current Pointer
+          </h2>
+          <span className="shrink-0 rounded border border-border-subtle bg-surface-primary px-2 py-1 text-xs font-mono text-accent-warning">
+            {entryId?.toLocaleString() ?? 'N/A'}
+          </span>
+        </div>
+        <label htmlFor="tag-input" className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-text-label">
+          Tag
+        </label>
+        <input
+          id="tag-input"
+          type="text"
+          value={value}
+          onChange={(event) => setValue(event.currentTarget.value)}
+          onFocus={(event) => event.currentTarget.select()}
+          disabled={isSubmitting}
+          autoComplete="off"
+          autoFocus
+          className="w-full rounded border border-border-subtle bg-surface-primary px-3 py-2 text-sm font-mono text-text-primary outline-none transition-colors placeholder:text-text-muted focus:border-accent-secondary disabled:cursor-wait disabled:text-text-muted"
+        />
+        {error && (
+          <p role="alert" className="mt-3 text-xs font-semibold text-accent-critical">
+            {error}
+          </p>
+        )}
+        <div className="mt-5 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isSubmitting}
+            className="cursor-pointer rounded border border-border-subtle bg-surface-elevated px-4 py-2 text-sm font-medium text-text-primary transition-colors hover:bg-surface-active disabled:cursor-wait disabled:text-text-muted"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            title={entryId === null ? 'No inference pointer available' : undefined}
+            className="cursor-pointer rounded border border-accent-secondary bg-accent-secondary-bg px-4 py-2 text-sm font-bold text-text-primary transition-colors hover:bg-accent-secondary-deep disabled:cursor-not-allowed disabled:border-border-subtle disabled:bg-surface-elevated disabled:text-text-muted"
+          >
+            {isSubmitting ? 'Saving...' : 'Save'}
+          </button>
+        </div>
+      </form>
+    </dialog>
+  );
+}
+
+export default TagDialog;

--- a/software/station/clients/station-viewer/src/pages/HomePage.tsx
+++ b/software/station/clients/station-viewer/src/pages/HomePage.tsx
@@ -1,14 +1,21 @@
 import { useState, useEffect, useCallback } from 'react';
 import Long from 'long';
+import { Tag as TagIcon } from 'lucide-react';
 import { useInferenceState, useConnectionStatsWithUptime, useLatestEntryId, useWakeLock, invalidateTagsCache } from "@/hooks";
 import BusViewer from "@/st3215/BusViewer";
 import YahboomDogzillaLiteDeviceViewer from "@/yahboom_dogzilla_lite/YahboomDogzillaLiteDeviceViewer";
 import AsciiRobot from "@/components/AsciiRobot";
+import TagDialog from "@/components/TagDialog";
 import { copyToClipboard } from "@/api/clipboard-utils";
 import { commandManager } from "@/api/commands";
 import { inference_tags } from "@/api/proto.js";
 import { defaultTag } from "@/utils/tag-phrases";
 import { getFPSColor } from '@/utils/color-utils';
+
+interface TagDialogState {
+  entryId: number | null;
+  defaultValue: string;
+}
 
 function formatBytes(bytes: number): string {
   if (bytes === 0) return '0 B';
@@ -33,6 +40,9 @@ function HomePage() {
   const latestEntryId = useLatestEntryId();
   const connectionStats = useConnectionStatsWithUptime();
   const [copied, setCopied] = useState(false);
+  const [tagDialog, setTagDialog] = useState<TagDialogState | null>(null);
+  const [isTagSubmitting, setIsTagSubmitting] = useState(false);
+  const [tagError, setTagError] = useState<string | null>(null);
   const hasRobotData = Boolean(inferenceState?.st3215?.data?.buses?.length);
   const hasYahboomDogzillaLiteData = Boolean(inferenceState?.yahboom_dogzilla_lite?.data?.devices?.length);
   const isDesktopApp = window.stationDesktop?.isDesktop === true;
@@ -52,11 +62,31 @@ function HomePage() {
     }
   };
 
-  const handleAddTag = useCallback(async () => {
-    if (latestEntryId === null) return;
-    const tag = window.prompt('Tag for current pointer:', defaultTag());
-    if (!tag) return;
-    const ptrBytes = new Uint8Array(Long.fromNumber(latestEntryId).toBytesLE());
+  const handleAddTag = useCallback(() => {
+    setTagDialog({
+      entryId: latestEntryId,
+      defaultValue: defaultTag(),
+    });
+    setTagError(null);
+  }, [latestEntryId]);
+
+  const handleCloseTagDialog = useCallback(() => {
+    if (isTagSubmitting) return;
+    setTagDialog(null);
+    setTagError(null);
+  }, [isTagSubmitting]);
+
+  const handleSubmitTag = useCallback(async (tag: string) => {
+    if (tagDialog === null || isTagSubmitting) return;
+    if (tagDialog.entryId === null) {
+      setTagError('No inference pointer available');
+      return;
+    }
+
+    const ptrBytes = new Uint8Array(Long.fromNumber(tagDialog.entryId).toBytesLE());
+    setIsTagSubmitting(true);
+    setTagError(null);
+
     try {
       await commandManager.sendInferenceTagCommand({
         type: inference_tags.CommandType.CT_ADD_TAG,
@@ -64,10 +94,15 @@ function HomePage() {
         inferenceQueuePtr: ptrBytes,
       });
       invalidateTagsCache();
+      setTagDialog(null);
     } catch (err) {
       console.error('Failed to send tag command:', err);
+      setTagError('Failed to save tag');
+    } finally {
+      setIsTagSubmitting(false);
     }
-  }, [latestEntryId]);
+  }, [isTagSubmitting, tagDialog]);
+
   return (
     <div className="flex-1 flex flex-col">
       <div className="relative z-20 bg-surface-primary border-b-2 border-border-default">
@@ -106,12 +141,14 @@ function HomePage() {
                   </div>
                 </div>
                 <button
+                  type="button"
                   onClick={handleAddTag}
-                  disabled={latestEntryId === null}
-                  className="px-3 py-1 bg-accent-secondary-bg hover:bg-accent-secondary-deep disabled:bg-surface-elevated disabled:text-text-muted disabled:cursor-not-allowed text-text-primary text-xs font-bold uppercase tracking-wide rounded border border-accent-secondary"
+                  className="inline-flex h-7 cursor-pointer items-center gap-1.5 px-3 py-1 bg-accent-secondary-bg hover:bg-accent-secondary-deep disabled:bg-surface-elevated disabled:text-text-muted disabled:cursor-not-allowed text-text-primary text-xs font-bold uppercase tracking-wide rounded border border-accent-secondary"
                   title="Tag the current inference queue pointer"
+                  aria-label="Tag the current inference queue pointer"
                 >
-                  TAG
+                  <TagIcon size={13} aria-hidden />
+                  <span>TAG</span>
                 </button>
               </div>
               <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs font-mono">
@@ -136,6 +173,16 @@ function HomePage() {
           )}
         </div>
       </div>
+      {tagDialog && (
+        <TagDialog
+          entryId={tagDialog.entryId}
+          defaultValue={tagDialog.defaultValue}
+          error={tagError}
+          isSubmitting={isTagSubmitting}
+          onClose={handleCloseTagDialog}
+          onSubmit={handleSubmitTag}
+        />
+      )}
       <div className="flex-1 min-h-0 overflow-auto p-4">
         <div className="flex min-h-full w-full flex-col gap-4">
           {hasYahboomDogzillaLiteData && inferenceState?.yahboom_dogzilla_lite?.data && (


### PR DESCRIPTION
## Summary
- Replace the native `window.prompt` tag flow with a React `TagDialog` built on `<dialog>`.
- Keep the `TAG` button always available so the dialog can be tested without a connected robot.
- Disable `Save` when there is no inference pointer, while preserving the current pointer when one exists.
- Add inline save error handling, submitting state, default tag text selection, and explicit pointer display.

## Demo

<img width="596" height="543" alt="Screenshot 2026-06-27 at 08 50 37" src="https://github.com/user-attachments/assets/19a26676-9b86-4c27-8af4-ac855fdfe17f" />
<img width="601" height="651" alt="Screenshot 2026-06-27 at 08 50 23" src="https://github.com/user-attachments/assets/19811724-324d-460a-be74-e3dff6b43cf4" />
