### PR TITLE
station-viewer: remove unused Tailwind aspect-ratio plugin

### DIFF
--- a/software/station/clients/station-viewer/package-lock.json
+++ b/software/station/clients/station-viewer/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0-beta.1",
       "license": "MIT",
       "dependencies": {
-        "@tailwindcss/aspect-ratio": "^0.4.2",
         "@types/three": "^0.184.0",
         "long": "^5.2.3",
         "lucide-react": "^0.552.0",
@@ -1579,13 +1578,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@tailwindcss/aspect-ratio": {
-      "version": "0.4.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
-      }
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.4",
@@ -3649,6 +3641,7 @@
     },
     "node_modules/tailwindcss": {
       "version": "4.2.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {

--- a/software/station/clients/station-viewer/package.json
+++ b/software/station/clients/station-viewer/package.json
@@ -19,7 +19,6 @@
     "type-check": "tsc -b"
   },
   "dependencies": {
-    "@tailwindcss/aspect-ratio": "^0.4.2",
     "@types/three": "^0.184.0",
     "long": "^5.2.3",
     "lucide-react": "^0.552.0",

--- a/software/station/clients/station-viewer/tailwind.config.js
+++ b/software/station/clients/station-viewer/tailwind.config.js
@@ -8,8 +8,4 @@ export default {
   theme: {
     extend: {},
   },
-  plugins: [
-    require('@tailwindcss/aspect-ratio'),
-  ],
 }
-


### PR DESCRIPTION
Removes the unused @tailwindcss/aspect-ratio dependency from station-viewer and drops its Tailwind config plugin registration. The codebase has no aspect-* utility usages, and Tailwind 4 ships aspect-ratio utilities natively, so we do not need to keep the separate plugin installed.