### PR TITLE
station-viewer: remove stale React Router type dependency

### DIFF
--- a/software/station/clients/station-viewer/package-lock.json
+++ b/software/station/clients/station-viewer/package-lock.json
@@ -26,7 +26,6 @@
         "@types/nosleep.js": "^0.10.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
-        "@types/react-router-dom": "^5.3.3",
         "@vitejs/plugin-react": "^5.2.0",
         "cross-env": "^10.1.0",
         "oxlint": "^1.61.0",
@@ -2049,11 +2048,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/history": {
-      "version": "4.7.11",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/linkify-it": {
       "version": "5.0.0",
       "dev": true,
@@ -2106,51 +2100,6 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
-    },
-    "node_modules/@types/react-router": {
-      "version": "5.1.20",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-router-dom": {
-      "version": "5.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router": "*"
-      }
-    },
-    "node_modules/@types/react-router-dom/node_modules/@types/react": {
-      "version": "19.2.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@types/react-router-dom/node_modules/csstype": {
-      "version": "3.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/react-router/node_modules/@types/react": {
-      "version": "19.2.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@types/react-router/node_modules/csstype": {
-      "version": "3.1.3",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/stats.js": {
       "version": "0.17.4",

--- a/software/station/clients/station-viewer/package.json
+++ b/software/station/clients/station-viewer/package.json
@@ -36,7 +36,6 @@
     "@types/nosleep.js": "^0.10.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "^5.2.0",
     "cross-env": "^10.1.0",
     "oxlint": "^1.61.0",


### PR DESCRIPTION
Removes the unused @types/react-router-dom dependency from station-viewer. The app uses react-router-dom v7, which bundles its own TypeScript declarations, so the old v5 @types/react-router-dom package is stale and unnecessary.