### PR TITLE
Fix overflow guard in i2c-async block reads

### DIFF
--- a/shared/i2c-async/src/lib.rs
+++ b/shared/i2c-async/src/lib.rs
@@ -137,8 +137,9 @@ fn read_smbus_i2c_block_registers_blocking(
 
     while offset < length {
         let chunk_length = (length - offset).min(MAX_I2C_BLOCK_LENGTH);
-        let register = start_register
-            .checked_add(offset as u8)
+        let register = u8::try_from(offset)
+            .ok()
+            .and_then(|offset| start_register.checked_add(offset))
             .ok_or_else(|| "I2C read range exceeds one-byte register space".to_string())?;
         let chunk = device
             .smbus_read_i2c_block_data(register, chunk_length as u8)


### PR DESCRIPTION
Fixes a latent overflow bug in `i2c-async`'s chunked block read: the overflow guard computed
`start_register.checked_add(offset as u8)`, but the `as u8` cast truncates
before the check — at `offset = 256` it wraps to `0`, so a read with
`length > 256` silently re-reads from the start register and returns a
buffer with duplicated data instead of erroring

The fix converts the offset with `u8::try_from` before `checked_add`, so
both overflow modes return the intended "I2C read range exceeds one-byte
register space" error. In-range reads are unchanged