### PR TITLE
add NormFs max_memory_usage to station args

### DIFF
--- a/software/station/bin/station/README.md
+++ b/software/station/bin/station/README.md
@@ -175,9 +175,9 @@ Usage: station [OPTIONS]
 
 Options:
       --max-queue-disk-size <MAX_QUEUE_DISK_SIZE>
-          Maximum queue disk size in bytes [default: 2147483648]
+          Maximum queue disk size, e.g. `2G`, `512M`, or a plain byte count [default: 2G]
       --max-memory-usage <MAX_MEMORY_USAGE>
-          Maximum in-memory buffer size in bytes [default: 33554432]
+          Maximum in-memory buffer size, e.g. `256M`, `1.5G`, or a plain byte count [default: 256M]
       --normfs-base-folder <NORMFS_BASE_FOLDER>
           Base folder for normfs storage [default: ./station_data]
   -c, --config <CONFIG>
@@ -208,8 +208,8 @@ station --config my-robot.yaml
 station \
   --config robot.yaml \
   --normfs-base-folder ./data \
-  --max-queue-disk-size 5368709120 \
-  --max-memory-usage 33554432 \
+  --max-queue-disk-size 5G \
+  --max-memory-usage 256M \
   --tcp 0.0.0.0:8888 \
   --web 0.0.0.0:8889
 ```

--- a/software/station/bin/station/README.md
+++ b/software/station/bin/station/README.md
@@ -176,6 +176,8 @@ Usage: station [OPTIONS]
 Options:
       --max-queue-disk-size <MAX_QUEUE_DISK_SIZE>
           Maximum queue disk size in bytes [default: 2147483648]
+      --max-memory-usage <MAX_MEMORY_USAGE>
+          Maximum in-memory buffer size in bytes [default: 33554432]
       --normfs-base-folder <NORMFS_BASE_FOLDER>
           Base folder for normfs storage [default: ./station_data]
   -c, --config <CONFIG>
@@ -207,6 +209,7 @@ station \
   --config robot.yaml \
   --normfs-base-folder ./data \
   --max-queue-disk-size 5368709120 \
+  --max-memory-usage 33554432 \
   --tcp 0.0.0.0:8888 \
   --web 0.0.0.0:8889
 ```

--- a/software/station/bin/station/src/main.rs
+++ b/software/station/bin/station/src/main.rs
@@ -32,6 +32,7 @@ pub mod station_proto {
 
 mod inference;
 mod queues;
+mod size;
 mod tags;
 mod web;
 
@@ -41,12 +42,12 @@ const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), " (", env!("GIT_HASH"),
 #[derive(Parser, Debug)]
 #[command(name = "NormaCore.Dev station", author, version = VERSION, about, long_about = None)]
 struct Args {
-    /// Maximum queue disk size in bytes
-    #[arg(long, default_value = "2147483648")] // 2GB default
+    /// Maximum queue disk size, e.g. `2G`, `512M`, or a plain byte count
+    #[arg(long, default_value = "2G", value_parser = size::parse_size::<u64>)]
     max_queue_disk_size: u64,
 
-    /// Maximum in-memory buffer size in bytes
-    #[arg(long, default_value = "268435456")] // 256MB default
+    /// Maximum in-memory buffer size, e.g. `256M`, `1.5G`, or a plain byte count
+    #[arg(long, default_value = "256M", value_parser = size::parse_size::<usize>)]
     max_memory_usage: usize,
 
     /// Base folder for normfs storage

--- a/software/station/bin/station/src/main.rs
+++ b/software/station/bin/station/src/main.rs
@@ -45,6 +45,10 @@ struct Args {
     #[arg(long, default_value = "2147483648")] // 2GB default
     max_queue_disk_size: u64,
 
+    /// Maximum in-memory buffer size in bytes
+    #[arg(long, default_value = "33554432")] // 32MB default
+    max_memory_usage: usize,
+
     /// Base folder for normfs storage
     #[arg(long, default_value = "./station_data")]
     normfs_base_folder: PathBuf,
@@ -150,6 +154,7 @@ impl Station {
     ) -> Result<Arc<NormFS>, Box<dyn std::error::Error>> {
         let mut settings = NormFsSettings {
             max_disk_usage_per_queue: Some(args.max_queue_disk_size),
+            max_memory_usage: args.max_memory_usage,
             ..Default::default()
         };
 

--- a/software/station/bin/station/src/main.rs
+++ b/software/station/bin/station/src/main.rs
@@ -46,7 +46,7 @@ struct Args {
     max_queue_disk_size: u64,
 
     /// Maximum in-memory buffer size in bytes
-    #[arg(long, default_value = "33554432")] // 32MB default
+    #[arg(long, default_value = "268435456")] // 256MB default
     max_memory_usage: usize,
 
     /// Base folder for normfs storage

--- a/software/station/bin/station/src/size.rs
+++ b/software/station/bin/station/src/size.rs
@@ -1,0 +1,185 @@
+/// Parses a human-readable byte size such as `256M`, `1.5G`, or a plain byte count.
+///
+/// Units are binary multiples (`1K` = 1024). `K`, `M`, `G` and `T` are accepted,
+/// case-insensitively, with an optional `B` or `iB` suffix. Fractional values are
+/// allowed and floor to whole bytes.
+pub fn parse_size<T>(input: &str) -> Result<T, String>
+where
+    T: TryFrom<u64>,
+{
+    let trimmed = input.trim();
+    let split = trimmed
+        .find(|c: char| !c.is_ascii_digit() && c != '.')
+        .unwrap_or(trimmed.len());
+    let (number, unit) = trimmed.split_at(split);
+
+    let multiplier: u128 = match unit.trim().to_ascii_uppercase().as_str() {
+        "" | "B" => 1,
+        "K" | "KB" | "KIB" => 1 << 10,
+        "M" | "MB" | "MIB" => 1 << 20,
+        "G" | "GB" | "GIB" => 1 << 30,
+        "T" | "TB" | "TIB" => 1 << 40,
+        _ => return Err(invalid(input)),
+    };
+
+    // Integer math on the mantissa keeps fractions exact: `1.5G` never rounds.
+    let (digits, decimals) = match number.split_once('.') {
+        Some((whole, frac)) => {
+            if frac.is_empty() || frac.contains('.') {
+                return Err(invalid(input));
+            }
+            (format!("{whole}{frac}"), frac.len() as u32)
+        }
+        None => (number.to_string(), 0),
+    };
+
+    let mantissa: u128 = digits.parse().map_err(|_| invalid(input))?;
+
+    mantissa
+        .checked_mul(multiplier)
+        .map(|scaled| scaled / 10u128.pow(decimals))
+        .and_then(|bytes| u64::try_from(bytes).ok())
+        .and_then(|bytes| T::try_from(bytes).ok())
+        .ok_or_else(|| format!("size `{input}` is too large"))
+}
+
+fn invalid(input: &str) -> String {
+    format!("invalid size `{input}` (expected e.g. `268435456`, `256M`, `1.5G`)")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_size;
+
+    fn parse(input: &str) -> Result<u64, String> {
+        parse_size::<u64>(input)
+    }
+
+    #[test]
+    fn parses_plain_byte_count() {
+        assert_eq!(parse("268435456"), Ok(268435456));
+    }
+
+    #[test]
+    fn parses_zero() {
+        assert_eq!(parse("0"), Ok(0));
+    }
+
+    #[test]
+    fn parses_kilobytes_as_binary_multiple() {
+        assert_eq!(parse("512K"), Ok(512 * 1024));
+    }
+
+    #[test]
+    fn parses_megabytes_as_binary_multiple() {
+        assert_eq!(parse("256M"), Ok(256 * 1024 * 1024));
+    }
+
+    #[test]
+    fn parses_gigabytes_as_binary_multiple() {
+        assert_eq!(parse("1G"), Ok(1024 * 1024 * 1024));
+    }
+
+    #[test]
+    fn parses_terabytes_as_binary_multiple() {
+        assert_eq!(parse("1T"), Ok(1024u64.pow(4)));
+    }
+
+    #[test]
+    fn unit_is_case_insensitive() {
+        assert_eq!(parse("1g"), parse("1G"));
+    }
+
+    #[test]
+    fn accepts_b_suffix() {
+        assert_eq!(parse("256MB"), Ok(256 * 1024 * 1024));
+    }
+
+    #[test]
+    fn accepts_ib_suffix() {
+        assert_eq!(parse("256MiB"), Ok(256 * 1024 * 1024));
+    }
+
+    #[test]
+    fn accepts_surrounding_whitespace() {
+        assert_eq!(parse("  256M  "), Ok(256 * 1024 * 1024));
+    }
+
+    #[test]
+    fn accepts_space_between_number_and_unit() {
+        assert_eq!(parse("256 M"), Ok(256 * 1024 * 1024));
+    }
+
+    #[test]
+    fn rejects_empty_input() {
+        assert!(parse("").is_err());
+    }
+
+    #[test]
+    fn rejects_missing_number() {
+        assert!(parse("M").is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_unit() {
+        assert!(parse("12X").is_err());
+    }
+
+    #[test]
+    fn parses_fractional_value_exactly() {
+        assert_eq!(parse("1.5G"), Ok(1024 * 1024 * 1024 * 3 / 2));
+    }
+
+    #[test]
+    fn parses_fractional_value_below_one() {
+        assert_eq!(parse("0.5M"), Ok(512 * 1024));
+    }
+
+    #[test]
+    fn parses_fraction_with_many_decimal_places() {
+        assert_eq!(parse("1.250K"), Ok(1280));
+    }
+
+    #[test]
+    fn floors_fraction_that_is_not_a_whole_byte_count() {
+        // 1.1 * 1024 = 1126.4
+        assert_eq!(parse("1.1K"), Ok(1126));
+    }
+
+    #[test]
+    fn fractional_math_is_exact_at_large_scales() {
+        // f64 would be fine here, but integer math makes it exact by construction.
+        assert_eq!(parse("1.5T"), Ok(1024u64.pow(4) * 3 / 2));
+    }
+
+    #[test]
+    fn rejects_malformed_decimal() {
+        assert!(parse("1.2.3G").is_err());
+    }
+
+    #[test]
+    fn rejects_trailing_dot() {
+        assert!(parse("1.G").is_err());
+    }
+
+    #[test]
+    fn rejects_negative_values() {
+        assert!(parse("-5M").is_err());
+    }
+
+    #[test]
+    fn rejects_overflow_instead_of_panicking() {
+        assert!(parse("99999999999999999999G").is_err());
+    }
+
+    #[test]
+    fn rejects_value_that_does_not_fit_target_type() {
+        assert!(parse_size::<u32>("8G").is_err());
+    }
+
+    #[test]
+    fn error_message_names_the_bad_input() {
+        let err = parse("12X").unwrap_err();
+        assert!(err.contains("12X"), "unhelpful error: {err}");
+    }
+}


### PR DESCRIPTION
# Expose normfs memory buffer as a CLI parameter, allow human-readable strings for station size arguments

## Summary

Makes it configurable normfs in-memory buffer via a new `--max-memory-usage` flag.

Station was never setting `max_memory_usage` at all. The 256MB was not a value in this repo — it's the `NormFsSettings::default()` in the external `normfs` crate (`normfs-0.1.0-beta.1/src/lib.rs:128`, `256 * 1024 * 1024`), silently inherited via `..Default::default()`. This MR takes explicit ownership of it.

Updates `max_memory_usage` and `max_queue_disk_size` to accept human-readable values (e.g., "2GB", "500MB") in addition to raw byte integers. Added a utility to parse these strings into bytes automatically.

## Changes

- `src/main.rs`: new `--max-memory-usage` arg (default `256M`), passed into `NormFsSettings` alongside `max_disk_usage_per_queue`.
- `README.md`: flag added to the `--help` block and the full-example invocation.

The flag takes **bytes** and human readable format.

## The limit is per-queue, not global

Worth knowing before picking a value. `MemStore::start_queue` computes each queue's budget at creation time and freezes it:

```rust
let queue_max_memory = self.max_memory_usage / queues.len().max(1);
```

`queues.len()` is the count *before* insertion, and budgets never rebalance as queues come and go. So the 1st queue gets the full `M`, the 2nd also gets `M` (len=1), the 3rd gets `M/2`, the 4th `M/3`, and so on. Worst-case total footprint is roughly `M · (1 + H₍N₋₁₎)`.

Station opens `main`, `tags`, `commands`, plus one queue per video and inference stream. At ~10 queues that's about 3.8 × `M`:

| `max_memory_usage` | ~10-queue worst case |
|---|---|
| 256MB (old default) | ~1GB |
| 32MB (new default) | ~120MB |

So read the new default as "roughly 100MB worst case across all queues," not "32MB total." The ~1GB ceiling under the old default is the behavior this MR is aimed at.