### PR TITLE
station-viewer: Show standalone cameras and sensor widgets on Home

### DIFF
--- a/software/station/clients/station-viewer/src/devices/LiveDeviceSurface.tsx
+++ b/software/station/clients/station-viewer/src/devices/LiveDeviceSurface.tsx
@@ -72,16 +72,22 @@ function LiveDeviceSelectionError({ error }: LiveDeviceSelectionErrorProps) {
 
 interface LiveDeviceSurfaceProps {
   plan: LiveDevicePlan;
+  summaryLayout?: 'responsive' | 'stacked';
 }
 
-const LiveDeviceSurface = memo(function LiveDeviceSurface({ plan }: LiveDeviceSurfaceProps) {
+const LiveDeviceSurface = memo(function LiveDeviceSurface({
+  plan,
+  summaryLayout = 'responsive',
+}: LiveDeviceSurfaceProps) {
   const summaryViews = plan.views.filter((view) => view.slot === 'summary');
   const primaryViews = plan.views.filter((view) => view.slot === 'primary');
 
   return (
     <>
       {summaryViews.length > 0 && (
-        <div className="grid grid-cols-1 gap-2 xl:grid-cols-2 2xl:grid-cols-4">
+        <div className={`grid grid-cols-1 gap-2 ${
+          summaryLayout === 'responsive' ? 'xl:grid-cols-2 2xl:grid-cols-4' : ''
+        }`}>
           {summaryViews.map((view) => (
             <LiveDeviceView key={`${view.moduleId}:${view.key}`} view={view} />
           ))}

--- a/software/station/clients/station-viewer/src/devices/st3215/ui/St3215LiveView.tsx
+++ b/software/station/clients/station-viewer/src/devices/st3215/ui/St3215LiveView.tsx
@@ -1,0 +1,13 @@
+import type { FrameEntry } from '@/api/frame-parser';
+import type { motors_mirroring, st3215, usbvideo } from '@/api/proto.js';
+import BusViewer from '@/st3215/BusViewer';
+
+export interface St3215LiveViewProps {
+  inferenceState: st3215.IInferenceState;
+  videoSources?: FrameEntry<usbvideo.IRxEnvelope>[];
+  mirroringState?: motors_mirroring.IInferenceState;
+}
+
+export default function St3215LiveView(props: St3215LiveViewProps) {
+  return <BusViewer {...props} />;
+}

--- a/software/station/clients/station-viewer/src/devices/yahboom-dogzilla-lite/ui/YahboomDogzillaLiteDesktopDashboard.tsx
+++ b/software/station/clients/station-viewer/src/devices/yahboom-dogzilla-lite/ui/YahboomDogzillaLiteDesktopDashboard.tsx
@@ -2,7 +2,7 @@ import { memo, useEffect, useMemo, useRef, useState, type ReactNode } from 'reac
 import { Scan } from 'lucide-react';
 import { commandManager } from '@/api/commands.js';
 import { yahboom_dogzilla_lite } from '@/api/proto.js';
-import CameraHudControls from '@/st3215/CameraHudControls';
+import CameraHudControls from '@/usbvideo/CameraHudControls';
 import YahboomDogzillaLiteDesktopActionPanel from '@/devices/yahboom-dogzilla-lite/ui/YahboomDogzillaLiteDesktopActionPanel';
 import YahboomDogzillaLiteDesktopMovementPanel from '@/devices/yahboom-dogzilla-lite/ui/YahboomDogzillaLiteDesktopMovementPanel';
 import type { YahboomDogzillaLiteViewMode } from '@/devices/yahboom-dogzilla-lite/ui/YahboomDogzillaLiteViewModeSwitch';

--- a/software/station/clients/station-viewer/src/pages/HomePage.tsx
+++ b/software/station/clients/station-viewer/src/pages/HomePage.tsx
@@ -11,6 +11,7 @@ import { defaultTag } from "@/utils/tag-phrases";
 import { getFPSColor } from '@/utils/color-utils';
 import LiveDeviceSurface from '@/devices/LiveDeviceSurface';
 import { resolveLiveDevices } from '@/devices/live-registry';
+import CameraSurface from '@/usbvideo/CameraSurface';
 
 interface TagDialogState {
   entryId: number | null;
@@ -48,6 +49,17 @@ function HomePage() {
     [inferenceState],
   );
   const hasLiveDeviceViews = !liveDevicePlan.isEmpty;
+  const videoSources = inferenceState?.videoQueues ?? [];
+  const hasConnectedArms = Boolean(inferenceState?.st3215?.data.buses?.length);
+  const hasConnectedDog = Boolean(inferenceState?.yahboom_dogzilla_lite?.data.devices?.length);
+  const shouldShowStandaloneCameras = videoSources.length > 0
+    && !hasConnectedArms
+    && !hasConnectedDog;
+  const hasOnlySummaryDeviceViews = liveDevicePlan.views.length > 0
+    && liveDevicePlan.views.every((view) => view.slot === 'summary')
+    && liveDevicePlan.errors.length === 0;
+  const shouldUseCameraSensorLayout = shouldShowStandaloneCameras
+    && hasOnlySummaryDeviceViews;
   const isDesktopApp = window.stationDesktop?.isDesktop === true;
 
   useEffect(() => {
@@ -188,9 +200,28 @@ function HomePage() {
       )}
       <div className="flex-1 min-h-0 overflow-auto p-4">
         <div className="flex min-h-full w-full flex-col gap-4">
-          {hasLiveDeviceViews ? (
-            <LiveDeviceSurface plan={liveDevicePlan} />
+          {shouldUseCameraSensorLayout ? (
+            <div className="grid w-full gap-4 xl:grid-cols-[minmax(0,2fr)_minmax(20rem,1fr)] xl:items-start">
+              <CameraSurface
+                videoSources={videoSources}
+                desktopAspectRatio
+              />
+              <LiveDeviceSurface
+                plan={liveDevicePlan}
+                summaryLayout="stacked"
+              />
+            </div>
           ) : (
+            <>
+              {shouldShowStandaloneCameras && (
+                <CameraSurface videoSources={videoSources} />
+              )}
+              {hasLiveDeviceViews && (
+                <LiveDeviceSurface plan={liveDevicePlan} />
+              )}
+            </>
+          )}
+          {!hasLiveDeviceViews && !shouldShowStandaloneCameras && (
             <div className="flex flex-1 min-h-full w-full items-center justify-center rounded-lg border border-dashed border-border-default bg-surface-primary/40 px-6">
               <AsciiRobot />
             </div>

--- a/software/station/clients/station-viewer/src/st3215/BusCard.tsx
+++ b/software/station/clients/station-viewer/src/st3215/BusCard.tsx
@@ -12,7 +12,7 @@ import { getLatencyBgColor, getLatencyTextColor } from '@/utils/color-utils';
 import CameraViewer from '@/usbvideo/CameraViewer';
 import RobotCameraView from '@/usbvideo/RobotCameraView';
 import BusWebGLRenderer from '@/st3215/BusWebGLRenderer';
-import CameraHudControls from '@/st3215/CameraHudControls';
+import CameraHudControls from '@/usbvideo/CameraHudControls';
 import MotorDataTable from '@/st3215/MotorDataTable';
 import { ADDR_GOAL_POSITION, getMotorPosition } from '@/st3215/motor-parser';
 

--- a/software/station/clients/station-viewer/src/usbvideo/CameraHudControls.tsx
+++ b/software/station/clients/station-viewer/src/usbvideo/CameraHudControls.tsx
@@ -1,6 +1,6 @@
 import { ArrowLeftRight, Maximize2, Minimize2, SlidersHorizontal } from 'lucide-react';
 
-type CameraLayoutMode = 'pip' | 'side-by-side' | 'stacked';
+export type CameraLayoutMode = 'pip' | 'side-by-side' | 'stacked';
 
 interface CameraHudControlsProps {
   cameraLayout: CameraLayoutMode;

--- a/software/station/clients/station-viewer/src/usbvideo/CameraSurface.tsx
+++ b/software/station/clients/station-viewer/src/usbvideo/CameraSurface.tsx
@@ -1,0 +1,108 @@
+import { useRef, useState } from 'react';
+import type { FrameEntry } from '@/api/frame-parser';
+import type { usbvideo } from '@/api/proto.js';
+import { useElementFullscreen } from '@/hooks';
+import CameraHudControls, { type CameraLayoutMode } from '@/usbvideo/CameraHudControls';
+import CameraViewer from '@/usbvideo/CameraViewer';
+import { getVideoSourceId, getVideoSourceLabel } from '@/usbvideo/camera-source';
+
+interface CameraSurfaceProps {
+  videoSources: readonly FrameEntry<usbvideo.IRxEnvelope>[];
+  desktopAspectRatio?: boolean;
+}
+
+const CameraSurface: React.FC<CameraSurfaceProps> = ({
+  videoSources,
+  desktopAspectRatio = false,
+}) => {
+  const [cameraLayout, setCameraLayout] = useState<CameraLayoutMode>('pip');
+  const [areCamerasSwapped, setAreCamerasSwapped] = useState(false);
+  const surfaceRef = useRef<HTMLElement>(null);
+  const { isFullscreen, toggleFullscreen } = useElementFullscreen(surfaceRef);
+  const hasCameraPair = videoSources.length === 2;
+  const hasCameraGrid = videoSources.length > 2;
+  const orderedVideoSources = areCamerasSwapped && hasCameraPair
+    ? [videoSources[1], videoSources[0], ...videoSources.slice(2)]
+    : videoSources;
+  const primaryVideoSource = orderedVideoSources[0];
+  const secondaryVideoSource = orderedVideoSources[1];
+  const isSplitLayout = hasCameraPair && cameraLayout !== 'pip';
+  const isStackedLayout = cameraLayout === 'stacked';
+  const contentHeightClass = desktopAspectRatio
+    ? 'min-h-[28rem] xl:min-h-0'
+    : 'min-h-[28rem]';
+
+  const renderCamera = (
+    videoSource: FrameEntry<usbvideo.IRxEnvelope>,
+    overlay: 'none' | 'fps' = 'fps',
+  ) => (
+    <figure
+      key={videoSource.queueId}
+      className="relative h-full min-h-0 min-w-0 overflow-hidden bg-surface-primary"
+    >
+      <CameraViewer
+        sourceId={getVideoSourceId(videoSource)}
+        className="h-full w-full"
+        overlay={overlay}
+      />
+      <figcaption className="absolute bottom-0 left-0 max-w-full rounded-tr-lg bg-surface-secondary/80 px-3 py-2 text-xs font-medium text-text-primary backdrop-blur-sm">
+        <span className="block truncate">{getVideoSourceLabel(videoSource)}</span>
+      </figcaption>
+    </figure>
+  );
+
+  return (
+    <section
+      ref={surfaceRef}
+      aria-label="Cameras"
+      className={`relative flex-1 overflow-hidden rounded-lg border border-border-default bg-black ${
+        desktopAspectRatio ? 'min-h-[28rem] xl:aspect-video xl:min-h-0' : 'min-h-[28rem]'
+      } ${
+        isFullscreen ? 'h-screen' : ''
+      }`}
+    >
+      {hasCameraGrid ? (
+        <div className={`grid h-full w-full grid-cols-1 gap-px bg-border-default lg:grid-cols-2 ${contentHeightClass}`}>
+          {orderedVideoSources.map((videoSource) => renderCamera(videoSource))}
+        </div>
+      ) : isSplitLayout && secondaryVideoSource ? (
+        <div className={`grid h-full w-full ${contentHeightClass} ${
+          isStackedLayout ? 'grid-rows-2' : 'grid-rows-2 sm:grid-cols-2 sm:grid-rows-1'
+        }`}>
+          <div className={`min-h-0 min-w-0 border-border-default ${
+            isStackedLayout ? 'border-b' : 'border-b sm:border-b-0 sm:border-r'
+          }`}>
+            {renderCamera(primaryVideoSource)}
+          </div>
+          {renderCamera(secondaryVideoSource)}
+        </div>
+      ) : (
+        <div className={`h-full w-full ${contentHeightClass}`}>
+          {renderCamera(primaryVideoSource)}
+          {secondaryVideoSource && (
+            <div className="absolute bottom-4 right-4 z-30 h-[34%] min-h-[9rem] w-[36%] min-w-[16rem] max-w-[26rem] overflow-hidden rounded-lg border-2 border-border-default bg-surface-primary shadow-2xl">
+              {renderCamera(secondaryVideoSource, 'none')}
+            </div>
+          )}
+        </div>
+      )}
+      <CameraHudControls
+        cameraLayout={cameraLayout}
+        showMultiCameraControls={hasCameraPair}
+        hasMotors={false}
+        showMotorData={false}
+        isFullscreen={isFullscreen}
+        canSwapCameras={hasCameraPair}
+        onSetPipLayout={() => setCameraLayout('pip')}
+        onToggleSplitLayout={() => setCameraLayout((layout) => (
+          layout === 'side-by-side' ? 'stacked' : 'side-by-side'
+        ))}
+        onSwapCameras={() => setAreCamerasSwapped((swapped) => !swapped)}
+        onToggleMotorData={() => undefined}
+        onToggleFullscreen={() => void toggleFullscreen()}
+      />
+    </section>
+  );
+};
+
+export default CameraSurface;


### PR DESCRIPTION
## Summary

- Show connected cameras on Home when no ST3215 arms or Dogzilla devices are present.
- Add PiP, split, swap, and fullscreen controls for standalone camera views.
- Move shared camera controls from st3215 into usbvideo.
- Use a dedicated desktop layout for camera-and-sensor configurations:
  - camera in the wide left column;
  - sensor widgets stacked in the right column;
  - vertical layout on smaller screens.
- Preserve the existing Home layout for arms, Dogzilla, and primary device views.

## Demo

<img width="394" height="845" alt="Screenshot 2026-07-10 at 23 31 38" src="https://github.com/user-attachments/assets/b18e6c16-7019-468b-8f25-2c88860c816c" />
<img width="1232" height="1356" alt="Screenshot 2026-07-10 at 23 31 09" src="https://github.com/user-attachments/assets/4769abc9-6f98-4c92-b953-fb06aa74cd96" />
<img width="2512" height="1360" alt="Screenshot 2026-07-10 at 23 30 58" src="https://github.com/user-attachments/assets/c945e3aa-51aa-4b3d-a780-a54b4707eca4" />
