### PR TITLE
refactor(station-viewer): harden state synchronization and document architecture

### DIFF
--- a/.github/workflows/station-viewer-pr-check.yml
+++ b/.github/workflows/station-viewer-pr-check.yml
@@ -43,5 +43,8 @@ jobs:
       - name: Typecheck
         run: npm run type-check
 
+      - name: Test
+        run: npm test
+
       - name: Build
         run: npm run build

--- a/software/station/clients/station-viewer/AGENTS.md
+++ b/software/station/clients/station-viewer/AGENTS.md
@@ -339,6 +339,8 @@ export { useInferenceTags, invalidateTagsCache } from "./useInferenceTags";
 export { useKeyboardNavigation } from "./useKeyboardNavigation";
 export { useWakeLock } from "./useWakeLock";
 export { useBusMonitor } from "./useBusMonitor";
+export { useElementFullscreen } from "./useElementFullscreen";
+export { ThemeProvider, useTheme } from "./useTheme";
 // Plus hook-owned type exports: Theme, TimelineControlsRef, UseWakeLockReturn, BusStatus, ErrorPacketDump
 ```
 

--- a/software/station/clients/station-viewer/AGENTS.md
+++ b/software/station/clients/station-viewer/AGENTS.md
@@ -299,23 +299,28 @@ export function useTimelineState(): UseTimelineStateReturn {
 
 Simpler hooks return plain values or flat objects (e.g., `useInferenceState` returns `Frame | null`, `useFrameData` returns `{ currentFrame, parsedFrame, isLoading, ... }`).
 
-### useEffect Cleanup
-Always clean up event listeners, timers, and subscriptions:
+### External Stores and Effect Cleanup
+
+Use `useSyncExternalStore` for state owned by long-lived managers. Snapshot getters must return the same object reference until the underlying state changes, and related values must be published atomically. `WebSocketManager` exposes the canonical live and connection-statistics snapshots; do not mirror them into hook-local `useState`.
+
+For component-owned effects, always clean up event listeners, timers, and subscriptions:
 
 ```typescript
 useEffect(() => {
-  const handler = () => setStats(webSocketManager.getConnectionStats());
-  webSocketManager.addEventListener(WS_EVENTS.STATS, handler);
-  return () => webSocketManager.removeEventListener(WS_EVENTS.STATS, handler);
+  const handler = () => setIsFullscreen(document.fullscreenElement === elementRef.current);
+  document.addEventListener('fullscreenchange', handler);
+  return () => document.removeEventListener('fullscreenchange', handler);
 }, []);
 ```
 
 ### Hook Exports
-All hooks are re-exported from `src/hooks/index.ts` (11 hooks + 3 types):
+All hooks are re-exported from `src/hooks/index.ts`:
 ```typescript
 export { useInferenceState } from "./useInferenceState";
 export { useLatestEntryId } from "./useLatestEntryId";
-export { useConnectionStats, useConnectionStatsWithUptime } from "./useConnectionStats";
+export { useLiveSnapshot } from "./useLiveSnapshot";
+export { useConnectionStats } from "./useConnectionStats";
+export { useElapsedSeconds } from "./useElapsedSeconds";
 export { useFrameData } from "./useFrameData";
 export { useQueueEntries } from "./useQueueEntries";
 export { useTimelineState } from "./useTimelineState";
@@ -366,12 +371,14 @@ Run `npm run build:proto` after modifying .proto files.
 
 ## State Management
 
-State is managed through custom hooks, not global state libraries. WebSocket events drive state updates via EventTarget. Global managers are exported as default singletons:
+State is managed through custom hooks, not global state libraries. WebSocket events drive stable immutable snapshots exposed to React through `useSyncExternalStore`. Global managers are exported as default singletons:
 
 ```typescript
 const webSocketManager = new WebSocketManager(`ws://${host}/api`);
 export default webSocketManager;
 ```
+
+The live snapshot contains the frame and latest entry ID as one atomic observation. Connection statistics use a separate snapshot. Keep local UI state in the owning page or device view; do not turn these transport snapshots into a general application store. See `docs/adr/README.md` for the accepted decisions and invariants.
 
 The WebSocket manager is initialized at app startup via side-effect import in `main.tsx`:
 ```typescript

--- a/software/station/clients/station-viewer/AGENTS.md
+++ b/software/station/clients/station-viewer/AGENTS.md
@@ -10,10 +10,20 @@ npm run build        # Full build: hashes, proto, type-check, and Vite build
 npm run build:proto  # Regenerate protobuf bindings from ../../../../../protobufs
 npm run lint         # Run oxlint (Rust-based linter)
 npm run type-check   # Run TypeScript compiler without emitting
+npm test             # Run Vitest once
+npm run test:watch   # Run Vitest in watch mode
 npm run preview      # Preview production build locally
 ```
 
-**Testing:** Not configured. No test runner exists in this project.
+## Testing
+
+Vitest runs in the Node environment. Keep tests beside the module as `*.test.ts`.
+
+Tests are regression guards, not a coverage target. Before adding a test, name the plausible bug it should catch. Prioritize behavior with a history of failure, async races, ownership or cleanup boundaries, atomic external-store updates, and non-trivial domain rules. A small set of tests around these risks is preferable to exhaustive coverage of trivial branches.
+
+Exercise behavior through public interfaces and assert caller-visible outcomes. Tests must survive an internal refactor that preserves behavior. Mock only true system boundaries when necessary, such as WebSocket, browser APIs, or time; use real Station Viewer modules together whenever practical. Avoid tests that mirror implementation steps, test private helpers, merely restate types, or assert mock call counts unless the count itself is part of the public contract.
+
+For a bug fix, first demonstrate that the test fails for the broken behavior, then make it pass. If a test cannot be connected to a realistic regression, do not add it.
 
 ## Tech Stack
 
@@ -297,7 +307,7 @@ export function useTimelineState(): UseTimelineStateReturn {
 }
 ```
 
-Simpler hooks return plain values or flat objects (e.g., `useInferenceState` returns `Frame | null`, `useFrameData` returns `{ currentFrame, parsedFrame, isLoading, ... }`).
+Simpler hooks return plain values or flat objects. For example, `useInferenceState` returns `Frame | null`, while `useFrameData({ frameNumber, immediate })` returns `{ parsedFrame, isLoading, error }`; timeline state is the sole owner of the selected frame number.
 
 ### External Stores and Effect Cleanup
 
@@ -329,8 +339,10 @@ export { useInferenceTags, invalidateTagsCache } from "./useInferenceTags";
 export { useKeyboardNavigation } from "./useKeyboardNavigation";
 export { useWakeLock } from "./useWakeLock";
 export { useBusMonitor } from "./useBusMonitor";
-// Plus type exports: TimelineControlsRef, UseWakeLockReturn, BusStatus, ErrorPacketDump
+// Plus hook-owned type exports: Theme, TimelineControlsRef, UseWakeLockReturn, BusStatus, ErrorPacketDump
 ```
+
+Modules outside `src/hooks/` import hooks through `@/hooks`. Hook implementations import sibling hooks directly rather than through the barrel, which avoids a cycle from `index.ts` back into the implementation being exported.
 
 ## Error Handling
 

--- a/software/station/clients/station-viewer/docs/adr/0001-stable-websocket-snapshots.md
+++ b/software/station/clients/station-viewer/docs/adr/0001-stable-websocket-snapshots.md
@@ -1,0 +1,40 @@
+# ADR 0001: Publish stable, atomic WebSocket snapshots
+
+- Date: 2026-07-12
+
+## Context
+
+`WebSocketManager` owns the current inference frame, its entry ID, and connection statistics. React hooks previously copied those values into local state by listening to `EventTarget` events and calling separate getters.
+
+The frame and entry ID describe one logical observation, but separate getters did not express that invariant. Connection statistics were also returned as a fresh object on every getter call. That makes the manager unsuitable as a React external store because a snapshot must retain object identity until the underlying state changes.
+
+## Decision
+
+`WebSocketManager` publishes two immutable snapshots:
+
+- `LiveSnapshot`, containing the current `frame` and `latestEntryId`.
+- `ConnectionStats`, containing the current connection and transport statistics.
+
+Each snapshot has a stable getter and a matching subscription method. A getter returns the same object reference until its state changes. When state changes, the manager replaces the complete snapshot before dispatching exactly one corresponding event.
+
+The live frame and entry ID are updated atomically after frame parsing succeeds. Failed or incomplete parsing does not publish a partial snapshot.
+
+`WebSocketManager` remains the owner of transport, polling, NormFS access, decoding, and reconnect behavior. The snapshot interface does not move those responsibilities into React.
+
+## Consequences
+
+- Callers can observe a frame and its entry ID without a transient mismatch.
+- React can consume manager state through the external-store seam.
+- Snapshot updates require immutable replacement rather than field mutation.
+- High-frequency frame data remains in the existing manager; this decision does not introduce a general application store.
+- Compatibility getters may delegate to the snapshots while existing callers migrate.
+
+## Rejected alternatives
+
+### Add Zustand as the owner of WebSocket state
+
+This would create a second owner for data already owned by `WebSocketManager` and would not remove the need to adapt transport events. The existing manager only needs a stronger interface.
+
+### Keep independent mutable fields
+
+This leaves atomicity as an ordering convention that every caller must understand and preserve.

--- a/software/station/clients/station-viewer/docs/adr/0001-stable-websocket-snapshots.md
+++ b/software/station/clients/station-viewer/docs/adr/0001-stable-websocket-snapshots.md
@@ -19,7 +19,7 @@ Each snapshot has a stable getter and a matching subscription method. A getter r
 
 The live frame and entry ID are updated atomically after frame parsing succeeds. Failed or incomplete parsing does not publish a partial snapshot.
 
-The last successfully published live snapshot remains available during a transient disconnect so the UI can present last-observed device data alongside disconnected connection statistics. Entry IDs are not treated as globally unique across connections: the manager resets its internal processed-entry cursor on close, forcing the first poll after reconnect to parse and publish the backend's current entry even when its numeric ID matches the retained snapshot.
+The last successfully published live snapshot remains available during a transient disconnect so the UI can present last-observed device data alongside disconnected connection statistics. Entry IDs are not treated as globally unique across connections: the manager resets its internal processed-entry cursor on close, forcing the first poll after reconnect to parse and publish the backend's current entry even when its numeric ID matches the retained snapshot. The retained frame is presentation-only across that connection boundary and is not used for pointer-based decoding reuse until the new connection publishes its first frame.
 
 `WebSocketManager` remains the owner of transport, polling, NormFS access, decoding, and reconnect behavior. The snapshot interface does not move those responsibilities into React.
 

--- a/software/station/clients/station-viewer/docs/adr/0001-stable-websocket-snapshots.md
+++ b/software/station/clients/station-viewer/docs/adr/0001-stable-websocket-snapshots.md
@@ -19,6 +19,8 @@ Each snapshot has a stable getter and a matching subscription method. A getter r
 
 The live frame and entry ID are updated atomically after frame parsing succeeds. Failed or incomplete parsing does not publish a partial snapshot.
 
+The last successfully published live snapshot remains available during a transient disconnect so the UI can present last-observed device data alongside disconnected connection statistics. Entry IDs are not treated as globally unique across connections: the manager resets its internal processed-entry cursor on close, forcing the first poll after reconnect to parse and publish the backend's current entry even when its numeric ID matches the retained snapshot.
+
 `WebSocketManager` remains the owner of transport, polling, NormFS access, decoding, and reconnect behavior. The snapshot interface does not move those responsibilities into React.
 
 ## Consequences
@@ -27,7 +29,7 @@ The live frame and entry ID are updated atomically after frame parsing succeeds.
 - React can consume manager state through the external-store seam.
 - Snapshot updates require immutable replacement rather than field mutation.
 - High-frequency frame data remains in the existing manager; this decision does not introduce a general application store.
-- Compatibility getters may delegate to the snapshots while existing callers migrate.
+- Connection lifecycle and live-data freshness remain distinct: connection statistics report connectivity while the live snapshot represents the last successful observation.
 
 ## Rejected alternatives
 

--- a/software/station/clients/station-viewer/docs/adr/0001-stable-websocket-snapshots.md
+++ b/software/station/clients/station-viewer/docs/adr/0001-stable-websocket-snapshots.md
@@ -33,7 +33,7 @@ The last successfully published live snapshot remains available during a transie
 
 ## Rejected alternatives
 
-### Add Zustand as the owner of WebSocket state
+### Add a general-purpose state manager as the owner of WebSocket state
 
 This would create a second owner for data already owned by `WebSocketManager` and would not remove the need to adapt transport events. The existing manager only needs a stronger interface.
 

--- a/software/station/clients/station-viewer/docs/adr/0002-react-external-store-hooks.md
+++ b/software/station/clients/station-viewer/docs/adr/0002-react-external-store-hooks.md
@@ -1,0 +1,35 @@
+# ADR 0002: Adapt WebSocket state to React with `useSyncExternalStore`
+
+- Date: 2026-07-12
+
+## Context
+
+The live frame, latest entry ID, and connection statistics are external state owned by `WebSocketManager`. Hooks implemented with `useState` and `useEffect` duplicated external state inside React and repeated listener setup and cleanup.
+
+React 19 provides `useSyncExternalStore` for this seam. It defines how React reads a snapshot, subscribes to changes, and avoids tearing during concurrent rendering.
+
+## Decision
+
+React hooks consume the stable snapshots from ADR 0001 with `useSyncExternalStore`.
+
+`useLiveSnapshot()` is the primary interface for callers that need both the frame and entry ID. Narrow compatibility hooks may select `frame` or `latestEntryId` for callers that need only one value. A caller that needs both values uses one `useLiveSnapshot()` call rather than two independent subscriptions.
+
+`useConnectionStats()` consumes the connection snapshot directly. Hooks do not copy external snapshots into local React state.
+
+## Consequences
+
+- Subscription behavior and cleanup are localized in the manager and external-store hooks.
+- A single render observes a consistent snapshot.
+- Snapshot getters must obey the referential-stability invariant from ADR 0001.
+- Specialized hooks remain small interfaces for existing pages, while `HomePage` uses the combined live snapshot.
+- This decision does not globalize local UI, form, timeline, drag, or camera-layout state.
+
+## Rejected alternatives
+
+### Continue using `useState` plus `useEffect`
+
+That pattern mirrors external state into every consumer and relies on effect timing rather than React's external-store contract.
+
+### Introduce a single application-wide state module
+
+Most state in Station Viewer is local to a page or device view. A broad store would expose more interface than its implementation hides and reduce locality.

--- a/software/station/clients/station-viewer/docs/adr/0003-isolate-uptime-rendering.md
+++ b/software/station/clients/station-viewer/docs/adr/0003-isolate-uptime-rendering.md
@@ -12,9 +12,9 @@ The previous `useConnectionStatsWithUptime()` refreshed the complete statistics 
 
 Connection statistics update only in response to `WebSocketManager` events.
 
-A dedicated `useElapsedSeconds(startedAt)` hook owns the timer and cleanup needed to derive elapsed seconds. Each large consumer places that hook inside a small local uptime-rendering module, so the one-second tick stops at that module's seam.
+A dedicated `useElapsedSeconds(startedAt)` hook owns the timer and cleanup needed to derive elapsed seconds. The shared `ConnectionUptime` leaf component uses that hook, so large consumers render a stable subtree and the one-second tick stops at the leaf module's seam.
 
-Formatting remains local to the view because Home and device dashboards intentionally use different presentation formats.
+`ConnectionUptime` also owns the shared `HH:MM:SS` presentation used by Home and device dashboards. A view that later needs a different presentation can use `useElapsedSeconds` directly without moving the timer back into connection statistics.
 
 ## Consequences
 
@@ -29,6 +29,6 @@ Formatting remains local to the view because Home and device dashboards intentio
 
 Uptime is presentation-derived wall-clock state, not transport state. Putting a timer in the transport manager would mix unrelated responsibilities.
 
-### Use one shared uptime formatter
+### Keep separate uptime components and formatters in each view
 
-The views have different formatting requirements. Sharing timer behavior provides leverage without forcing presentation policy into the hook.
+This duplicates identical presentation code and makes future timer or formatting fixes easy to apply inconsistently. The shared leaf component keeps both the timer-driven render and common presentation isolated.

--- a/software/station/clients/station-viewer/docs/adr/0003-isolate-uptime-rendering.md
+++ b/software/station/clients/station-viewer/docs/adr/0003-isolate-uptime-rendering.md
@@ -1,0 +1,34 @@
+# ADR 0003: Isolate uptime ticking from connection statistics
+
+- Date: 2026-07-12
+
+## Context
+
+Connection statistics change when transport events arrive. Uptime is derived from `connectedAt` and wall-clock time, so its displayed value changes once per second even when the connection snapshot does not.
+
+The previous `useConnectionStatsWithUptime()` refreshed the complete statistics value every second. Large consumers such as `HomePage` and the Dogzilla dashboard therefore rendered on a timer for a change that affected one text value.
+
+## Decision
+
+Connection statistics update only in response to `WebSocketManager` events.
+
+A dedicated `useElapsedSeconds(startedAt)` hook owns the timer and cleanup needed to derive elapsed seconds. Each large consumer places that hook inside a small local uptime-rendering module, so the one-second tick stops at that module's seam.
+
+Formatting remains local to the view because Home and device dashboards intentionally use different presentation formats.
+
+## Consequences
+
+- A clock tick no longer fabricates a new connection snapshot.
+- Only the small uptime-rendering subtree renders once per second.
+- Timer lifecycle and non-negative elapsed-time behavior are implemented once.
+- Connection events still replace `connectedAt`, which restarts the elapsed-time calculation.
+
+## Rejected alternatives
+
+### Store uptime in WebSocketManager
+
+Uptime is presentation-derived wall-clock state, not transport state. Putting a timer in the transport manager would mix unrelated responsibilities.
+
+### Use one shared uptime formatter
+
+The views have different formatting requirements. Sharing timer behavior provides leverage without forcing presentation policy into the hook.

--- a/software/station/clients/station-viewer/docs/adr/0004-history-frame-ownership-and-request-ordering.md
+++ b/software/station/clients/station-viewer/docs/adr/0004-history-frame-ownership-and-request-ordering.md
@@ -1,0 +1,41 @@
+# ADR 0004: Give the timeline ownership of frame selection and make latest history requests win
+
+- Date: 2026-07-12
+
+## Context
+
+`HistoryPage` previously had two owners for the selected frame number: `useTimelineState` and `useFrameData`. An effect copied selection from the timeline into the frame reader.
+
+The frame reader also allowed multiple asynchronous NormFS reads to overlap. A slow response for an older selection could arrive after a newer response and replace the displayed frame, error, or loading state.
+
+## Decision
+
+`useTimelineState` is the only owner of the selected frame number.
+
+`useFrameData` accepts the selected frame as input and owns only the derived asynchronous state: parsed frame, loading status, and error. A `null` frame means that timeline initialization is incomplete and no read should start.
+
+The hook preserves debounced navigation and immediate navigation. Every selection receives a monotonically increasing request generation. Only the latest generation may publish a frame, error, or loading completion. Cleanup invalidates the active generation and cancels pending debounce timers.
+
+Physical request cancellation is not required because `NormFsClient` has no cancellation interface. Obsolete results are ignored.
+
+## Consequences
+
+- History has one source of truth for selection.
+- `HistoryPage` no longer contains a synchronization effect.
+- Slow or failed obsolete requests cannot overwrite the latest selection.
+- The previously parsed frame can remain visible while a new frame loads.
+- The frame reader's interface hides debounce and request-ordering behavior from callers.
+
+## Rejected alternatives
+
+### Keep synchronized frame numbers in both hooks
+
+This duplicates ownership and requires every caller to preserve ordering through an effect.
+
+### Serialize all reads
+
+Waiting for an obsolete read before starting the latest selection would make navigation unnecessarily slow.
+
+### Add cancellation to NormFsClient in this change
+
+Cancellation would expand the transport interface and is unnecessary to guarantee correct visible state. It can be considered separately if resource usage becomes a measured problem.

--- a/software/station/clients/station-viewer/docs/adr/0005-live-device-modules-as-vertical-slices.md
+++ b/software/station/clients/station-viewer/docs/adr/0005-live-device-modules-as-vertical-slices.md
@@ -1,0 +1,49 @@
+# ADR 0005: Organize live device presentation as vertical modules
+
+- Date: 2026-07-12
+
+## Context
+
+Station Viewer presents data from multiple concrete devices. Adding each device directly to `HomePage` would make the page depend on every protocol-specific view, spread device knowledge across shared layout code, and require a central registration edit for every extension.
+
+Live presentation also needs deterministic ordering, stable React keys, lazy UI loading, layout slots, realtime capability reporting, and isolation when one device fails to select or render.
+
+## Decision
+
+Each concrete live device is a vertical module under `src/devices/<device-id>/`. Its `module.ts` exports one `LiveDeviceAdapter`. Device-only views, commands, parsing helpers, formatting, and labels remain beside that manifest.
+
+The live catalog discovers `src/devices/*/module.ts` with Vite's bundled `import.meta.glob`. Manifests are loaded eagerly so catalog validation happens at startup; their React views are loaded lazily.
+
+The normal authoring interface is `live()`. It selects one `FrameEntry` field, normalizes single and repeated entries, uses `queueId` as the stable view key, and supplies a typed `{ data }` prop. `customLive()` is reserved for views whose props require more than one frame field.
+
+Selection is pure. A selector does not use hooks, JSX, I/O, timers, mutation, or subscriptions. It returns stable keys and props; the factory owns React element creation and lazy loading.
+
+Module IDs and display orders are globally unique. View keys are non-empty and unique within a module. Shared layout is expressed through the closed `summary` and `primary` slots rather than arbitrary layout strings. Selection failures are reported for the affected module without preventing other modules from resolving.
+
+`HomePage` depends only on `resolveLiveDevices(frame)` and `LiveDeviceSurface`; it never imports a concrete device.
+
+## Consequences
+
+- A device can add or change live presentation without editing `HomePage` or a central registry.
+- Device-specific knowledge has locality inside one vertical module.
+- Shared code owns ordering, validation, lazy loading, layout slots, and error isolation once.
+- The authoring interface deliberately covers live presentation only; it is not a general plugin contract.
+- Adding a new layout slot changes the shared interface and requires evidence that multiple modules need it.
+
+## Rejected alternatives
+
+### Import every concrete device from `HomePage`
+
+This couples shared layout to device growth and spreads device-selection conditions through the page.
+
+### Maintain a central registration list
+
+That adds a second edit location for every module and permits the list to drift from the filesystem.
+
+### Put hooks or side effects in selectors
+
+Selectors run during plan resolution and must remain deterministic, synchronous, and testable through `resolveLiveDevices(frame)`.
+
+### Create a universal device plugin manifest
+
+Live presentation, history rendering, decoding, configuration, actions, and physical models vary independently. Combining them would produce a wide interface dominated by optional fields.

--- a/software/station/clients/station-viewer/docs/adr/0006-keep-live-and-physical-model-registries-separate.md
+++ b/software/station/clients/station-viewer/docs/adr/0006-keep-live-and-physical-model-registries-separate.md
@@ -1,0 +1,46 @@
+# ADR 0006: Keep live presentation and physical-model registries separate
+
+- Date: 2026-07-12
+
+## Context
+
+An ST3215 bus has two independent concerns:
+
+- live presentation of bus state, video, mirroring, and controls;
+- resolution of a physical robot model, its URDF, kinematics, joint mapping, transforms, and renderer.
+
+A physical model may reuse the shared ST3215 live UI, while the live module must remain usable for unsupported or newly attached buses. Treating both concerns as one plugin would force live presentation and model identity to evolve together.
+
+## Decision
+
+Live device resolution and ST3215 physical-model resolution use separate catalogs and interfaces.
+
+The live catalog follows ADR 0005. The model catalog independently discovers `src/devices/*/st3215-model.ts` through `import.meta.glob`. A model is authored through `st3215Model()` and owns its concrete URDF path, base transform, joint names, optional joint-value mapping, and lazy renderer.
+
+The normalized-joint renderer currently identifies a model by positive integer `motorCount`. Model IDs and motor counts are globally unique. An optional `matchesBus` predicate may further restrict a model but cannot bypass the motor-count match.
+
+Resolution has no implicit first-model fallback. An unsupported or ambiguous bus resolves to `null` and the UI presents an explicit unsupported state. Registering a second model with the same motor count fails at startup until the model interface gains an explicit identity discriminator.
+
+Shared ST3215 modules may query the model catalog, but they do not import concrete model implementations.
+
+## Consequences
+
+- Shared ST3215 live UI can support buses independently of available physical renderers.
+- Concrete kinematic quirks remain local to the physical model.
+- Unsupported hardware is visible instead of silently rendered as the wrong robot.
+- Adding two physical models with the same motor count requires a deliberate extension of the model identity interface.
+- Live presentation and physical rendering can be tested through their own seams.
+
+## Rejected alternatives
+
+### Add model fields to the live device manifest
+
+This couples two independently varying concerns and turns the live interface into a collection of optional capabilities.
+
+### Select the first registered model as a fallback
+
+Registration order is not hardware identity. A fallback could show incorrect geometry or apply incorrect kinematics.
+
+### Keep concrete robot configuration in shared ST3215 code
+
+This would make the shared module depend on every physical product and spread model-specific changes across common rendering code.

--- a/software/station/clients/station-viewer/docs/adr/0007-route-live-camera-payloads-outside-react-frame-state.md
+++ b/software/station/clients/station-viewer/docs/adr/0007-route-live-camera-payloads-outside-react-frame-state.md
@@ -12,13 +12,13 @@ Camera consumers need the newest image for one source, while device selection an
 
 Live parsing separates camera payload delivery from the normalized React frame.
 
-When `parseFrame` runs with `publishVideoFrames: true`, it publishes the encoded image bytes to `live-camera-store` under a stable source ID derived from camera `uniqueId`, falling back to `queueId`. The `Frame.videoQueues` entry receives a metadata-only envelope with the large image buffers removed.
+When `parseFrame` receives a `shouldPublishVideoFrames` predicate and it still returns `true` immediately before delivery, parsing publishes the encoded image bytes to `live-camera-store` under a stable source ID derived from camera `uniqueId`, falling back to `queueId`. The `Frame.videoQueues` entry receives a metadata-only envelope with the large image buffers removed.
 
 `live-camera-store` retains the latest frame per source and maintains listeners per source. A subscriber immediately receives the retained current frame when one exists. Removing the last listener also removes the listener set, while the latest frame remains available for the next subscriber.
 
 `CameraViewer` subscribes only to its selected source. It owns Blob URL creation and revocation, duplicate-index suppression, image load ordering, and display FPS. Camera bytes are not added to `LiveSnapshot`, React Context, or a general state manager.
 
-Historical parsing may retain complete decoded camera envelopes because history reads are selected, lower-frequency operations and may need the original entry contents. Payload publication is explicitly controlled by `ParseFrameOptions`.
+Historical parsing may retain complete decoded camera envelopes because history reads are selected, lower-frequency operations and may need the original entry contents. Payload publication is explicitly controlled by the `ParseFrameOptions` predicate; omitting it keeps camera payloads out of the live store.
 
 ## Consequences
 

--- a/software/station/clients/station-viewer/docs/adr/0007-route-live-camera-payloads-outside-react-frame-state.md
+++ b/software/station/clients/station-viewer/docs/adr/0007-route-live-camera-payloads-outside-react-frame-state.md
@@ -1,0 +1,48 @@
+# ADR 0007: Route live camera payloads outside React frame state
+
+- Date: 2026-07-12
+
+## Context
+
+USB camera envelopes can contain large encoded frame buffers and update independently at high frequency. The live inference snapshot is consumed by `HomePage` and all resolved device views. Retaining camera bytes in that snapshot would propagate large payloads through React and make unrelated live UI participate in camera-rate updates.
+
+Camera consumers need the newest image for one source, while device selection and layout need only camera identity, format, timestamps, errors, and queue metadata.
+
+## Decision
+
+Live parsing separates camera payload delivery from the normalized React frame.
+
+When `parseFrame` runs with `publishVideoFrames: true`, it publishes the encoded image bytes to `live-camera-store` under a stable source ID derived from camera `uniqueId`, falling back to `queueId`. The `Frame.videoQueues` entry receives a metadata-only envelope with the large image buffers removed.
+
+`live-camera-store` retains the latest frame per source and maintains listeners per source. A subscriber immediately receives the retained current frame when one exists. Removing the last listener also removes the listener set, while the latest frame remains available for the next subscriber.
+
+`CameraViewer` subscribes only to its selected source. It owns Blob URL creation and revocation, duplicate-index suppression, image load ordering, and display FPS. Camera bytes are not added to `LiveSnapshot`, React Context, or a general state manager.
+
+Historical parsing may retain complete decoded camera envelopes because history reads are selected, lower-frequency operations and may need the original entry contents. Payload publication is explicitly controlled by `ParseFrameOptions`.
+
+## Consequences
+
+- Camera-rate payload updates do not force the full live device tree to carry image buffers.
+- Each viewer receives only the source it displays.
+- The normalized live frame remains useful for camera discovery and layout.
+- The camera store is a specialized external module, not an application-wide state manager.
+- Consumers must clean up subscriptions and Blob URLs.
+- Retained latest frames consume memory per observed source; eviction policy can be added if measured source churn makes it necessary.
+
+## Rejected alternatives
+
+### Store encoded images in `LiveSnapshot`
+
+Every live snapshot consumer would observe camera payload churn even when it does not render a camera.
+
+### Pass image buffers through device-view props
+
+This would couple camera delivery frequency to device plan resolution and create large prop graphs.
+
+### Use one global camera listener
+
+Consumers would need to filter unrelated frames and would lose per-source subscription locality.
+
+### Put camera payloads in a general state library
+
+The specialized store already provides the narrower source-keyed interface and avoids introducing a second owner for the same data.

--- a/software/station/clients/station-viewer/docs/adr/0008-make-live-and-history-acquisition-modes-explicit.md
+++ b/software/station/clients/station-viewer/docs/adr/0008-make-live-and-history-acquisition-modes-explicit.md
@@ -1,0 +1,47 @@
+# ADR 0008: Make live and history acquisition modes explicit
+
+- Date: 2026-07-12
+
+## Context
+
+Station Viewer has two data-acquisition modes with different behavior:
+
+- live mode polls the latest `inference-states` entry at up to 50 Hz, reuses the previous parsed frame, publishes camera frames, and updates the live snapshot;
+- history mode selects immutable NormFS entries, retains data needed for inspection, debounces navigation, and applies the latest-request-wins rule from ADR 0004.
+
+`HistoryPage` currently enters history behavior by calling `webSocketManager.stopUpdating()` on mount and `resumeUpdating()` on cleanup. The manager stores this as one boolean. This works for the current route tree but exposes polling mechanics to the page and cannot represent nested or overlapping consumers.
+
+## Decision
+
+Expose acquisition intent rather than polling mechanics.
+
+The transport module provides a disposable history lease whose public concepts are `live` and `history`. Acquiring the first history lease suspends latest-frame polling but keeps the WebSocket and NormFS client available for selected reads. Releasing the last history lease resumes live polling immediately if the connection is open.
+
+Mode transitions must be idempotent and safe under React Strict Mode mount-cleanup-mount behavior. Reconnect must restore the active acquisition mode rather than always assuming live mode. Only live mode publishes camera payloads and advances `LiveSnapshot`; history reads return their results to their requesting history module.
+
+The manager tracks active leases by identity and returns an idempotent release function. This makes acquisition reference-counted without exposing a mutable counter. A plain boolean controlled by unrelated callers is not part of the interface.
+
+Station Viewer has one process-wide acquisition mode. Simultaneous live and historical panes are outside the current interface and require a new decision if that product requirement appears. Outstanding history requests do not delay live resumption; ADR 0004 prevents their obsolete results from replacing newer history state.
+
+## Consequences
+
+- Pages express intent without knowing polling implementation details.
+- Nested history consumers cannot accidentally resume live polling while another consumer still needs it suspended.
+- Reconnect behavior becomes a documented invariant.
+- Mode transitions become testable through one transport interface.
+- Implementing the decision requires replacing `stopUpdating()` and `resumeUpdating()` callers and adding lifecycle tests.
+- Connection statistics should expose whether live polling is active or suspended so acquisition behavior is observable.
+
+## Rejected alternatives
+
+### Keep public `stopUpdating()` and `resumeUpdating()` methods
+
+They expose mechanism, permit unbalanced calls, and cannot identify which caller owns suspension.
+
+### Close the WebSocket in history mode
+
+History reads use the same NormFS transport, so closing the connection would disable the requested mode.
+
+### Run live polling and history parsing without coordination
+
+This spends transport and decoding capacity on live data while the user has explicitly selected historical inspection, and it continues publishing camera frames that are not part of the historical view.

--- a/software/station/clients/station-viewer/docs/adr/0008-make-live-and-history-acquisition-modes-explicit.md
+++ b/software/station/clients/station-viewer/docs/adr/0008-make-live-and-history-acquisition-modes-explicit.md
@@ -9,7 +9,7 @@ Station Viewer has two data-acquisition modes with different behavior:
 - live mode polls the latest `inference-states` entry at up to 50 Hz, reuses the previous parsed frame, publishes camera frames, and updates the live snapshot;
 - history mode selects immutable NormFS entries, retains data needed for inspection, debounces navigation, and applies the latest-request-wins rule from ADR 0004.
 
-`HistoryPage` currently enters history behavior by calling `webSocketManager.stopUpdating()` on mount and `resumeUpdating()` on cleanup. The manager stores this as one boolean. This works for the current route tree but exposes polling mechanics to the page and cannot represent nested or overlapping consumers.
+`HistoryPage` enters history behavior by acquiring a disposable lease from `WebSocketManager` and releasing it on cleanup. The manager tracks leases by identity so nested or overlapping consumers cannot resume live polling prematurely.
 
 ## Decision
 
@@ -29,8 +29,9 @@ Station Viewer has one process-wide acquisition mode. Simultaneous live and hist
 - Nested history consumers cannot accidentally resume live polling while another consumer still needs it suspended.
 - Reconnect behavior becomes a documented invariant.
 - Mode transitions become testable through one transport interface.
-- Implementing the decision requires replacing `stopUpdating()` and `resumeUpdating()` callers and adding lifecycle tests.
-- Connection statistics should expose whether live polling is active or suspended so acquisition behavior is observable.
+- `HistoryPage` no longer calls polling-mechanism methods directly.
+- Connection statistics expose `acquisitionMode`, making live polling intent observable.
+- A deferred polling resume prevents React Strict Mode's cleanup-remount probe from starting an in-flight live poll between leases.
 
 ## Rejected alternatives
 

--- a/software/station/clients/station-viewer/docs/adr/0008-make-live-and-history-acquisition-modes-explicit.md
+++ b/software/station/clients/station-viewer/docs/adr/0008-make-live-and-history-acquisition-modes-explicit.md
@@ -15,7 +15,7 @@ Station Viewer has two data-acquisition modes with different behavior:
 
 Expose acquisition intent rather than polling mechanics.
 
-The transport module provides a disposable history lease whose public concepts are `live` and `history`. Acquiring the first history lease suspends latest-frame polling but keeps the WebSocket and NormFS client available for selected reads. Releasing the last history lease resumes live polling immediately if the connection is open.
+The transport module provides a disposable history lease whose public concepts are `live` and `history`. Acquiring the first history lease suspends latest-frame polling but keeps the WebSocket and NormFS client available for selected reads. Releasing the last history lease switches acquisition intent back to `live` immediately and schedules polling to resume on the next task if the connection is open.
 
 Mode transitions must be idempotent and safe under React Strict Mode mount-cleanup-mount behavior. Reconnect must restore the active acquisition mode rather than always assuming live mode. Only live mode publishes camera payloads and advances `LiveSnapshot`; history reads return their results to their requesting history module.
 

--- a/software/station/clients/station-viewer/docs/adr/0009-arbitrate-st3215-control-authority.md
+++ b/software/station/clients/station-viewer/docs/adr/0009-arbitrate-st3215-control-authority.md
@@ -20,6 +20,10 @@ Web authority is a renewable lease with backend-enforced expiry. Disconnect, bus
 
 Transition grace periods and confirmation windows may remain adapter implementation details, but their purpose and bounds are defined by the backend authority state machine. `sessionStorage` may restore recent user intent for the same bus; the viewer must reacquire authority before enabling control.
 
+## Implementation
+
+This cross-stack decision is accepted but not implemented yet. The current viewer still uses `sessionStorage` and observed-mirroring timing heuristics as a transitional UI policy. Those heuristics do not provide authoritative exclusion and must not be treated as the backend contract described above. Implementation requires coordinated backend command-protocol and frontend changes.
+
 ## Consequences
 
 - UI controls can be enabled from one explicit authority state rather than several timing conditions.

--- a/software/station/clients/station-viewer/docs/adr/0009-arbitrate-st3215-control-authority.md
+++ b/software/station/clients/station-viewer/docs/adr/0009-arbitrate-st3215-control-authority.md
@@ -1,0 +1,44 @@
+# ADR 0009: Arbitrate ST3215 control authority explicitly
+
+- Date: 2026-07-12
+
+## Context
+
+An ST3215 bus can receive goals from web controls while motor mirroring may also target the same physical bus. Concurrent writers can issue conflicting positions, create unexpected motion, and make the UI's displayed authority differ from the backend's effective authority.
+
+`BusCard` currently treats a local web command as enabling web control, stores that preference in `sessionStorage` for 60 seconds, ignores observed mirroring briefly after a local request, and disables web control when mirroring remains visible for a confirmation period. These timings protect against transient observation lag, but they are UI-local policy rather than an explicit control-authority contract.
+
+## Decision
+
+Represent ST3215 control authority as an explicit state machine scoped by stable bus identity.
+
+At most one authority may be active for a bus: `none`, `web`, or `mirroring`. The Station backend command path owns and enforces this state machine for every stable bus identity, including competing browser and non-browser clients. Authority is based on backend-observed state and acknowledged transitions, never solely on a browser preference. A web command may be sent only while web authority is active or as part of an explicit acquisition request that the backend acknowledges.
+
+Loss of connection, loss of stable bus identity, expired authority, malformed persisted state, or conflicting observations must fail closed to `none` in the UI. Persisted browser state may remember recent user intent, but it must not by itself prove authority after reload or reconnect.
+
+Web authority is a renewable lease with backend-enforced expiry. Disconnect, bus identity loss, lease expiry, explicit release, or conflicting backend state transitions the viewer to `none`. Page close and visibility loss trigger best-effort release, while expiry provides the fail-safe when release cannot be delivered. Commands received during an authority transition or without the matching active lease are rejected.
+
+Transition grace periods and confirmation windows may remain adapter implementation details, but their purpose and bounds are defined by the backend authority state machine. `sessionStorage` may restore recent user intent for the same bus; the viewer must reacquire authority before enabling control.
+
+## Consequences
+
+- UI controls can be enabled from one explicit authority state rather than several timing conditions.
+- Mirroring and web control cannot be presented as simultaneously authoritative.
+- Reconnect, reload, and stale persistence behavior become fail-safe and testable.
+- The backend command protocol requires authority acquisition, acknowledgement, renewal, expiry, and release operations.
+- Existing `sessionStorage` TTL and mirror timing heuristics must be reviewed as adapters to the state machine, not treated as proof of ownership.
+- Lease duration and whether release also stops motors are safety parameters owned by the backend/driver contract and must be validated against the physical system before rollout.
+
+## Rejected alternatives
+
+### Treat a recent `sessionStorage` value as authority
+
+Browser storage records local intent and can outlive the connection or backend state that made it valid.
+
+### Allow both writers and rely on last command wins
+
+This makes motion depend on timing and transport latency rather than an explicit invariant.
+
+### Hide the conflict only in the UI
+
+Disabling controls in one browser does not prevent another client or backend path from issuing commands.

--- a/software/station/clients/station-viewer/docs/adr/0010-centralize-frame-decoding-before-device-presentation.md
+++ b/software/station/clients/station-viewer/docs/adr/0010-centralize-frame-decoding-before-device-presentation.md
@@ -1,0 +1,53 @@
+# ADR 0010: Centralize frame decoding before device presentation
+
+- Date: 2026-07-12
+
+## Context
+
+An inference entry references multiple typed NormFS queues. Presenters need decoded values, queue identity, pointers, timestamps, raw bytes for history, reuse of unchanged entries, and consistent error handling. If every live device module decoded its own queue, transport knowledge would leak into React modules and live and history paths could interpret the same entry differently.
+
+The live-device interface from ADR 0005 is intentionally a presentation seam. It receives a normalized `Frame`; it does not own protobuf or NormFS decoding.
+
+## Decision
+
+`frame-parser.ts` owns conversion from an inference entry and referenced NormFS entries into the normalized `Frame` model.
+
+The parser:
+
+- reads changed queue entries in parallel;
+- reuses a previous decoded entry when queue and pointer are unchanged;
+- decodes known `QueueDataType` values with the corresponding protobuf type;
+- preserves queue ID, pointer, queue type, timestamps, and optional raw bytes;
+- stores unknown entries as raw bytes when raw-data retention is enabled;
+- applies the camera payload routing decision from ADR 0007;
+- returns partial frame data when individual referenced entries fail, while reporting those failures.
+
+Live and history callers select parsing options appropriate to their mode. Device manifests select from the resulting `Frame` and remain pure. A new device queue type is added to protobuf/backend definitions and the shared parser before its live presentation module is registered.
+
+History rendering remains separate from live manifests. A future decoder or history extension seam requires a deliberate migration with multiple concrete adapters; it is not added as speculative optional fields to `LiveDeviceAdapter`.
+
+## Consequences
+
+- Live and history use one interpretation of queue data.
+- React device modules do not depend on NormFS request ordering or protobuf decoding mechanics.
+- Previous-frame reuse and parallel fetching are implemented once.
+- Adding a new queue type currently requires editing the central normalized `Frame` and parser.
+- The parser is a substantial module and should be deepened internally as its implementation grows without widening the presentation interface.
+
+## Rejected alternatives
+
+### Decode inside each live device module
+
+This would mix I/O and presentation, make selectors asynchronous or effectful, and duplicate behavior in history.
+
+### Add decoder callbacks to `LiveDeviceAdapter`
+
+The live interface would gain transport responsibilities and optional methods unrelated to many adapters.
+
+### Pass raw inference entries directly to React views
+
+Every view would need to understand pointers, queue types, protobuf decoding, reuse, and partial failures.
+
+### Build a general decoder plugin framework now
+
+There is one shared parser implementation today. A new seam is justified only when multiple real decoder adapters or independently deployable decoders exist.

--- a/software/station/clients/station-viewer/docs/adr/README.md
+++ b/software/station/clients/station-viewer/docs/adr/README.md
@@ -1,0 +1,18 @@
+# Architecture Decision Records
+
+This directory records accepted architecture decisions for Station Viewer.
+
+## Index
+
+| ADR | Decision |
+| --- | --- |
+| [0001](0001-stable-websocket-snapshots.md) | Publish stable, atomic WebSocket snapshots |
+| [0002](0002-react-external-store-hooks.md) | Adapt WebSocket state to React with `useSyncExternalStore` |
+| [0003](0003-isolate-uptime-rendering.md) | Isolate uptime ticking from connection statistics |
+| [0004](0004-history-frame-ownership-and-request-ordering.md) | Give the timeline ownership of frame selection and make latest history requests win |
+| [0005](0005-live-device-modules-as-vertical-slices.md) | Organize live device presentation as vertical modules |
+| [0006](0006-keep-live-and-physical-model-registries-separate.md) | Keep live presentation and physical-model registries separate |
+| [0007](0007-route-live-camera-payloads-outside-react-frame-state.md) | Route live camera payloads outside React frame state |
+| [0008](0008-make-live-and-history-acquisition-modes-explicit.md) | Make live and history acquisition modes explicit |
+| [0009](0009-arbitrate-st3215-control-authority.md) | Arbitrate ST3215 control authority explicitly |
+| [0010](0010-centralize-frame-decoding-before-device-presentation.md) | Centralize frame decoding before device presentation |

--- a/software/station/clients/station-viewer/package-lock.json
+++ b/software/station/clients/station-viewer/package-lock.json
@@ -27,6 +27,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.2.0",
         "cross-env": "^10.1.0",
+        "happy-dom": "20.10.6",
         "oxlint": "^1.61.0",
         "protobufjs": "^7.5.7",
         "protobufjs-cli": "^1.1.3",
@@ -2139,6 +2140,23 @@
       "version": "0.5.24",
       "license": "MIT"
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
@@ -2379,6 +2397,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/caniuse-lite": {
@@ -2809,6 +2840,38 @@
       "version": "4.2.11",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.10.6",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.6.tgz",
+      "integrity": "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -4164,6 +4227,16 @@
         }
       }
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "dev": true,
@@ -4207,6 +4280,28 @@
       "version": "1.0.2",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xmlcreate": {
       "version": "2.0.4",

--- a/software/station/clients/station-viewer/package-lock.json
+++ b/software/station/clients/station-viewer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@normacore/station-viewer",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@normacore/station-viewer",
-      "version": "0.1.0-beta.1",
+      "version": "0.1.0-beta.9",
       "license": "MIT",
       "dependencies": {
         "@types/three": "^0.184.0",
@@ -33,7 +33,8 @@
         "tailwindcss": "^4.1.16",
         "typescript": "6.0.3",
         "vite": "^7.2.0",
-        "vite-plugin-compression": "^0.5.1"
+        "vite-plugin-compression": "^0.5.1",
+        "vitest": "4.1.10"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -1578,6 +1579,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.4",
       "dev": true,
@@ -2035,6 +2043,24 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "dev": true,
@@ -2134,6 +2160,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "dev": true,
@@ -2171,6 +2310,16 @@
       "version": "2.0.1",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -2260,6 +2409,16 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -2396,6 +2555,13 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
@@ -2530,12 +2696,32 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-levenshtein": {
@@ -3200,6 +3386,20 @@
       "version": "0.12.0",
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "dev": true,
@@ -3274,6 +3474,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3549,6 +3756,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "dev": true,
@@ -3565,6 +3779,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -3609,6 +3837,23 @@
       "version": "0.184.0",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "dev": true,
@@ -3622,6 +3867,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tmp": {
@@ -3819,6 +4074,96 @@
         "vite": ">=2.0.0"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "dev": true,
@@ -3831,6 +4176,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/software/station/clients/station-viewer/package.json
+++ b/software/station/clients/station-viewer/package.json
@@ -16,6 +16,8 @@
     "lint": "oxlint",
     "preview": "vite preview",
     "build:proto": "cross-env sh scripts/protobuf.sh",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "type-check": "tsc -b"
   },
   "dependencies": {
@@ -43,7 +45,8 @@
     "tailwindcss": "^4.1.16",
     "typescript": "6.0.3",
     "vite": "^7.2.0",
-    "vite-plugin-compression": "^0.5.1"
+    "vite-plugin-compression": "^0.5.1",
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/software/station/clients/station-viewer/package.json
+++ b/software/station/clients/station-viewer/package.json
@@ -39,6 +39,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.2.0",
     "cross-env": "^10.1.0",
+    "happy-dom": "20.10.6",
     "oxlint": "^1.61.0",
     "protobufjs": "^7.5.7",
     "protobufjs-cli": "^1.1.3",

--- a/software/station/clients/station-viewer/src/api/frame-parser.ts
+++ b/software/station/clients/station-viewer/src/api/frame-parser.ts
@@ -52,6 +52,7 @@ type DecodedEntry = st3215.IInferenceState | st3215.ITxEnvelope | usbvideo.IRxEn
 interface ParseFrameOptions {
   retainRawData?: boolean;
   publishVideoFrames?: boolean;
+  shouldPublishVideoFrames?: () => boolean;
 }
 
 function findPreviousEntry(
@@ -382,20 +383,23 @@ export async function parseFrame(
               queueType: result.type
             };
             break;
-          case drivers.QueueDataType.QDT_USB_VIDEO_FRAMES:
-            if (publishVideoFrames) {
+          case drivers.QueueDataType.QDT_USB_VIDEO_FRAMES: {
+            const publishCurrentVideoFrame = publishVideoFrames
+              && (options.shouldPublishVideoFrames?.() ?? true);
+            if (publishCurrentVideoFrame) {
               publishLiveCameraFrame(result.queue, result.decoded as usbvideo.IRxEnvelope);
             }
             frame.videoQueues!.push({
               queueId: result.queue,
               ptr: result.ptr,
-              data: publishVideoFrames
+              data: publishCurrentVideoFrame
                 ? createLiveCameraMetadataEnvelope(result.decoded as usbvideo.IRxEnvelope)
                 : result.decoded as usbvideo.IRxEnvelope,
               rawData: retainRawData ? result.rawData ?? null : null,
               queueType: result.type
             });
             break;
+          }
           case drivers.QueueDataType.QDT_MOTOR_MIRRORING_RX:
             frame.mirroring = {
               queueId: result.queue,

--- a/software/station/clients/station-viewer/src/api/frame-parser.ts
+++ b/software/station/clients/station-viewer/src/api/frame-parser.ts
@@ -51,7 +51,6 @@ type DecodedEntry = st3215.IInferenceState | st3215.ITxEnvelope | usbvideo.IRxEn
 
 interface ParseFrameOptions {
   retainRawData?: boolean;
-  publishVideoFrames?: boolean;
   shouldPublishVideoFrames?: () => boolean;
 }
 
@@ -192,7 +191,6 @@ export async function parseFrame(
   options: ParseFrameOptions = {},
 ): Promise<Frame> {
   const retainRawData = options.retainRawData ?? true;
-  const publishVideoFrames = options.publishVideoFrames ?? false;
   const frame: Frame = {
     stateId: new Uint8Array(Array.from(entryIdBytes)),
     videoQueues: [],
@@ -384,8 +382,7 @@ export async function parseFrame(
             };
             break;
           case drivers.QueueDataType.QDT_USB_VIDEO_FRAMES: {
-            const publishCurrentVideoFrame = publishVideoFrames
-              && (options.shouldPublishVideoFrames?.() ?? true);
+            const publishCurrentVideoFrame = options.shouldPublishVideoFrames?.() ?? false;
             if (publishCurrentVideoFrame) {
               publishLiveCameraFrame(result.queue, result.decoded as usbvideo.IRxEnvelope);
             }

--- a/software/station/clients/station-viewer/src/api/websocket.test.ts
+++ b/software/station/clients/station-viewer/src/api/websocket.test.ts
@@ -1,13 +1,20 @@
 import Long from 'long';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { inference, normfs } from './proto.js';
+import { drivers, inference, normfs, sysinfo } from '@/api/proto.js';
 
+type WebSocketManager = (typeof import('@/api/websocket'))['default'];
 type MessageHandler = (event: MessageEvent<ArrayBuffer>) => void | Promise<void>;
+
+interface QueuedReadResponse {
+  entryId: number;
+  data: Uint8Array;
+}
 
 const sockets: FakeWebSocket[] = [];
 
 class FakeWebSocket {
   static readonly OPEN = 1;
+  static readonly CLOSED = 3;
 
   readyState = 0;
   binaryType: BinaryType = 'arraybuffer';
@@ -16,12 +23,42 @@ class FakeWebSocket {
   onclose: (() => void) | null = null;
   onerror: (() => void) | null = null;
 
+  private queuedReadResponses = new Map<string, QueuedReadResponse[]>();
+
   constructor() {
     sockets.push(this);
   }
 
   close() {}
-  send() {}
+
+  send(data: ArrayBuffer | Uint8Array) {
+    const request = normfs.ClientRequest.decode(
+      data instanceof Uint8Array ? data : new Uint8Array(data),
+    );
+    const read = request.read;
+    const queueId = read?.queueId;
+    const readIdValue = read?.readId;
+    if (!queueId || readIdValue == null) {
+      return;
+    }
+
+    const responses = this.queuedReadResponses.get(queueId);
+    if (!responses || responses.length === 0) {
+      return;
+    }
+    const response = responses.shift();
+    if (!response) {
+      return;
+    }
+    if (responses.length === 0) {
+      this.queuedReadResponses.delete(queueId);
+    }
+
+    const readId = Long.fromValue(readIdValue).toNumber();
+    queueMicrotask(() => {
+      void this.receive(createReadResponse(readId, response.entryId, response.data));
+    });
+  }
 
   open() {
     this.readyState = FakeWebSocket.OPEN;
@@ -29,8 +66,14 @@ class FakeWebSocket {
   }
 
   disconnect() {
-    this.readyState = 3;
+    this.readyState = FakeWebSocket.CLOSED;
     this.onclose?.();
+  }
+
+  queueReadResponse(queueId: string, response: QueuedReadResponse) {
+    const responses = this.queuedReadResponses.get(queueId) ?? [];
+    responses.push(response);
+    this.queuedReadResponses.set(queueId, responses);
   }
 
   async receive(data: Uint8Array) {
@@ -49,21 +92,44 @@ function getSocket(): FakeWebSocket {
   return socket;
 }
 
-function createFrameResponse(readId: number, entryId: number): Uint8Array {
-  const inferenceData = inference.InferenceRx.encode({ entries: [] }).finish();
+function createReadResponse(readId: number, entryId: number, data: Uint8Array): Uint8Array {
   return normfs.ServerResponse.encode({
     read: {
       readId: Long.fromNumber(readId),
       result: normfs.ReadResponse.Result.RR_ENTRY,
       id: { raw: Uint8Array.of(entryId) },
-      data: inferenceData,
+      data,
     },
   }).finish();
 }
 
-async function finishFrameProcessing(): Promise<void> {
-  await Promise.resolve();
-  await Promise.resolve();
+function createFrameData(entries: inference.InferenceRx.IEntry[] = []): Uint8Array {
+  return inference.InferenceRx.encode({ entries }).finish();
+}
+
+function createSysinfoData(hostname: string): Uint8Array {
+  return sysinfo.Envelope.encode({ data: { hostname } }).finish();
+}
+
+function waitForNextLiveSnapshot(webSocketManager: WebSocketManager) {
+  return new Promise<ReturnType<WebSocketManager['getLiveSnapshot']>>((resolve) => {
+    const unsubscribe = webSocketManager.subscribeLive(() => {
+      const snapshot = webSocketManager.getLiveSnapshot();
+      unsubscribe();
+      resolve(snapshot);
+    });
+  });
+}
+
+function queueFrame(
+  socket: FakeWebSocket,
+  frameId: number,
+  entries: inference.InferenceRx.IEntry[] = [],
+) {
+  socket.queueReadResponse('inference-states', {
+    entryId: frameId,
+    data: createFrameData(entries),
+  });
 }
 
 describe('WebSocketManager state', () => {
@@ -88,7 +154,7 @@ describe('WebSocketManager state', () => {
 
   it('reports a malformed packet as one atomic statistics update', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
-    const { default: webSocketManager } = await import('./websocket');
+    const { default: webSocketManager } = await import('@/api/websocket');
     const publishedSnapshots: ReturnType<typeof webSocketManager.getConnectionStats>[] = [];
     const unsubscribe = webSocketManager.subscribeConnectionStats(() => {
       publishedSnapshots.push(webSocketManager.getConnectionStats());
@@ -108,7 +174,7 @@ describe('WebSocketManager state', () => {
   });
 
   it('does not resume live acquisition while another history lease is active', async () => {
-    const { default: webSocketManager } = await import('./websocket');
+    const { default: webSocketManager } = await import('@/api/websocket');
     const publishedModes: string[] = [];
     const unsubscribe = webSocketManager.subscribeConnectionStats(() => {
       publishedModes.push(webSocketManager.getConnectionStats().acquisitionMode);
@@ -135,50 +201,91 @@ describe('WebSocketManager state', () => {
   it('does not publish an in-flight frame after the connection closes', async () => {
     vi.useFakeTimers();
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    const { default: webSocketManager } = await import('./websocket');
-    const socket = getSocket();
-    const before = webSocketManager.getLiveSnapshot();
-    const publishedSnapshots: ReturnType<typeof webSocketManager.getLiveSnapshot>[] = [];
+    const { default: webSocketManager } = await import('@/api/websocket');
+    const publishedEntryIds: Array<number | null> = [];
     const unsubscribe = webSocketManager.subscribeLive(() => {
-      publishedSnapshots.push(webSocketManager.getLiveSnapshot());
+      publishedEntryIds.push(webSocketManager.getLiveSnapshot().latestEntryId);
     });
 
-    socket.open();
-    const responseDelivery = socket.receive(createFrameResponse(1, 7));
-    socket.disconnect();
-    await responseDelivery;
-    await finishFrameProcessing();
+    const firstSocket = getSocket();
+    firstSocket.open();
+    const staleResponseDelivery = firstSocket.receive(
+      createReadResponse(1, 7, createFrameData()),
+    );
+    firstSocket.disconnect();
+    await staleResponseDelivery;
+
+    await vi.advanceTimersByTimeAsync(100);
+    const secondSocket = getSocket();
+    queueFrame(secondSocket, 8);
+    const nextSnapshot = waitForNextLiveSnapshot(webSocketManager);
+    secondSocket.open();
+    await nextSnapshot;
     unsubscribe();
 
-    expect(webSocketManager.getConnectionStats().status).toBe('disconnected');
-    expect(webSocketManager.getLiveSnapshot()).toBe(before);
-    expect(publishedSnapshots).toEqual([]);
+    expect(publishedEntryIds).toEqual([8]);
   });
 
   it('publishes the current frame after reconnect when its entry ID is unchanged', async () => {
     vi.useFakeTimers();
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    const { default: webSocketManager } = await import('./websocket');
+    const { default: webSocketManager } = await import('@/api/websocket');
     const publishedSnapshots: ReturnType<typeof webSocketManager.getLiveSnapshot>[] = [];
     const unsubscribe = webSocketManager.subscribeLive(() => {
       publishedSnapshots.push(webSocketManager.getLiveSnapshot());
     });
 
     const firstSocket = getSocket();
+    queueFrame(firstSocket, 7);
+    const firstSnapshot = waitForNextLiveSnapshot(webSocketManager);
     firstSocket.open();
-    await firstSocket.receive(createFrameResponse(1, 7));
-    await finishFrameProcessing();
+    await firstSnapshot;
     firstSocket.disconnect();
 
     await vi.advanceTimersByTimeAsync(100);
     const secondSocket = getSocket();
+    queueFrame(secondSocket, 7);
+    const secondSnapshot = waitForNextLiveSnapshot(webSocketManager);
     secondSocket.open();
-    await secondSocket.receive(createFrameResponse(2, 7));
-    await finishFrameProcessing();
+    await secondSnapshot;
     unsubscribe();
 
     expect(secondSocket).not.toBe(firstSocket);
     expect(publishedSnapshots.map(({ latestEntryId }) => latestEntryId)).toEqual([7, 7]);
     expect(publishedSnapshots[1]).not.toBe(publishedSnapshots[0]);
+  });
+
+  it('does not reuse decoded queue data across connections', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const { default: webSocketManager } = await import('@/api/websocket');
+    const sysinfoEntry: inference.InferenceRx.IEntry = {
+      queue: 'system',
+      ptr: Uint8Array.of(3),
+      type: drivers.QueueDataType.QDT_SYSTEM,
+    };
+
+    const firstSocket = getSocket();
+    queueFrame(firstSocket, 7, [sysinfoEntry]);
+    firstSocket.queueReadResponse('system', {
+      entryId: 3,
+      data: createSysinfoData('old-backend'),
+    });
+    const firstSnapshot = waitForNextLiveSnapshot(webSocketManager);
+    firstSocket.open();
+    expect((await firstSnapshot).frame?.sysinfo?.data.data?.hostname).toBe('old-backend');
+    firstSocket.disconnect();
+
+    await vi.advanceTimersByTimeAsync(100);
+    const secondSocket = getSocket();
+    queueFrame(secondSocket, 7, [sysinfoEntry]);
+    secondSocket.queueReadResponse('system', {
+      entryId: 3,
+      data: createSysinfoData('new-backend'),
+    });
+    const secondSnapshot = waitForNextLiveSnapshot(webSocketManager);
+    secondSocket.open();
+
+    expect((await secondSnapshot).frame?.sysinfo?.data.data?.hostname).toBe('new-backend');
   });
 });

--- a/software/station/clients/station-viewer/src/api/websocket.test.ts
+++ b/software/station/clients/station-viewer/src/api/websocket.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type MessageHandler = (event: MessageEvent<ArrayBuffer>) => void | Promise<void>;
+
+const sockets: FakeWebSocket[] = [];
+
+class FakeWebSocket {
+  static readonly OPEN = 1;
+
+  readyState = 0;
+  binaryType: BinaryType = 'arraybuffer';
+  onopen: (() => void) | null = null;
+  onmessage: MessageHandler | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor() {
+    sockets.push(this);
+  }
+
+  close() {}
+  send() {}
+
+  async receive(data: Uint8Array) {
+    if (!this.onmessage) {
+      throw new Error('WebSocket message handler is not registered');
+    }
+    await this.onmessage({ data: data.buffer } as MessageEvent<ArrayBuffer>);
+  }
+}
+
+function getSocket(): FakeWebSocket {
+  const socket = sockets.at(-1);
+  if (!socket) {
+    throw new Error('WebSocketManager did not create a WebSocket');
+  }
+  return socket;
+}
+
+describe('WebSocketManager state', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    sockets.length = 0;
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+    vi.stubGlobal('window', {
+      location: { host: 'station.test' },
+      stationDesktop: undefined,
+      setInterval,
+      clearInterval,
+      setTimeout,
+      clearTimeout,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('reports a malformed packet as one atomic statistics update', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { default: webSocketManager } = await import('./websocket');
+    const publishedSnapshots: ReturnType<typeof webSocketManager.getConnectionStats>[] = [];
+    const unsubscribe = webSocketManager.subscribeConnectionStats(() => {
+      publishedSnapshots.push(webSocketManager.getConnectionStats());
+    });
+    const before = webSocketManager.getConnectionStats();
+
+    await getSocket().receive(Uint8Array.of(0x80));
+
+    const after = webSocketManager.getConnectionStats();
+    unsubscribe();
+
+    expect(publishedSnapshots).toHaveLength(1);
+    expect(publishedSnapshots[0]).toBe(after);
+    expect(after).not.toBe(before);
+    expect(after.packetsReceived).toBe(before.packetsReceived + 1);
+    expect(after.bytesReceived).toBe(before.bytesReceived + 1);
+  });
+
+  it('does not resume live acquisition while another history lease is active', async () => {
+    const { default: webSocketManager } = await import('./websocket');
+    const publishedModes: string[] = [];
+    const unsubscribe = webSocketManager.subscribeConnectionStats(() => {
+      publishedModes.push(webSocketManager.getConnectionStats().acquisitionMode);
+    });
+
+    const releaseFirstLease = webSocketManager.acquireHistoryMode();
+    const releaseSecondLease = webSocketManager.acquireHistoryMode();
+
+    expect(webSocketManager.getConnectionStats().acquisitionMode).toBe('history');
+    expect(publishedModes).toEqual(['history']);
+
+    releaseFirstLease();
+    releaseFirstLease();
+    expect(webSocketManager.getConnectionStats().acquisitionMode).toBe('history');
+    expect(publishedModes).toEqual(['history']);
+
+    releaseSecondLease();
+    expect(webSocketManager.getConnectionStats().acquisitionMode).toBe('live');
+    expect(publishedModes).toEqual(['history', 'live']);
+
+    unsubscribe();
+  });
+});

--- a/software/station/clients/station-viewer/src/api/websocket.test.ts
+++ b/software/station/clients/station-viewer/src/api/websocket.test.ts
@@ -1,4 +1,6 @@
+import Long from 'long';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { inference, normfs } from './proto.js';
 
 type MessageHandler = (event: MessageEvent<ArrayBuffer>) => void | Promise<void>;
 
@@ -21,11 +23,21 @@ class FakeWebSocket {
   close() {}
   send() {}
 
+  open() {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  disconnect() {
+    this.readyState = 3;
+    this.onclose?.();
+  }
+
   async receive(data: Uint8Array) {
     if (!this.onmessage) {
       throw new Error('WebSocket message handler is not registered');
     }
-    await this.onmessage({ data: data.buffer } as MessageEvent<ArrayBuffer>);
+    await this.onmessage({ data: Uint8Array.from(data).buffer } as MessageEvent<ArrayBuffer>);
   }
 }
 
@@ -35,6 +47,23 @@ function getSocket(): FakeWebSocket {
     throw new Error('WebSocketManager did not create a WebSocket');
   }
   return socket;
+}
+
+function createFrameResponse(readId: number, entryId: number): Uint8Array {
+  const inferenceData = inference.InferenceRx.encode({ entries: [] }).finish();
+  return normfs.ServerResponse.encode({
+    read: {
+      readId: Long.fromNumber(readId),
+      result: normfs.ReadResponse.Result.RR_ENTRY,
+      id: { raw: Uint8Array.of(entryId) },
+      data: inferenceData,
+    },
+  }).finish();
+}
+
+async function finishFrameProcessing(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 describe('WebSocketManager state', () => {
@@ -53,6 +82,7 @@ describe('WebSocketManager state', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -100,5 +130,55 @@ describe('WebSocketManager state', () => {
     expect(publishedModes).toEqual(['history', 'live']);
 
     unsubscribe();
+  });
+
+  it('does not publish an in-flight frame after the connection closes', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const { default: webSocketManager } = await import('./websocket');
+    const socket = getSocket();
+    const before = webSocketManager.getLiveSnapshot();
+    const publishedSnapshots: ReturnType<typeof webSocketManager.getLiveSnapshot>[] = [];
+    const unsubscribe = webSocketManager.subscribeLive(() => {
+      publishedSnapshots.push(webSocketManager.getLiveSnapshot());
+    });
+
+    socket.open();
+    const responseDelivery = socket.receive(createFrameResponse(1, 7));
+    socket.disconnect();
+    await responseDelivery;
+    await finishFrameProcessing();
+    unsubscribe();
+
+    expect(webSocketManager.getConnectionStats().status).toBe('disconnected');
+    expect(webSocketManager.getLiveSnapshot()).toBe(before);
+    expect(publishedSnapshots).toEqual([]);
+  });
+
+  it('publishes the current frame after reconnect when its entry ID is unchanged', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const { default: webSocketManager } = await import('./websocket');
+    const publishedSnapshots: ReturnType<typeof webSocketManager.getLiveSnapshot>[] = [];
+    const unsubscribe = webSocketManager.subscribeLive(() => {
+      publishedSnapshots.push(webSocketManager.getLiveSnapshot());
+    });
+
+    const firstSocket = getSocket();
+    firstSocket.open();
+    await firstSocket.receive(createFrameResponse(1, 7));
+    await finishFrameProcessing();
+    firstSocket.disconnect();
+
+    await vi.advanceTimersByTimeAsync(100);
+    const secondSocket = getSocket();
+    secondSocket.open();
+    await secondSocket.receive(createFrameResponse(2, 7));
+    await finishFrameProcessing();
+    unsubscribe();
+
+    expect(secondSocket).not.toBe(firstSocket);
+    expect(publishedSnapshots.map(({ latestEntryId }) => latestEntryId)).toEqual([7, 7]);
+    expect(publishedSnapshots[1]).not.toBe(publishedSnapshots[0]);
   });
 });

--- a/software/station/clients/station-viewer/src/api/websocket.ts
+++ b/software/station/clients/station-viewer/src/api/websocket.ts
@@ -1,10 +1,10 @@
+import Long from "long";
 import { normfs, inference } from "./proto.js";
-import { Frame, parseFrame } from "./frame-parser.js";
+import { parseFrame, type Frame } from "./frame-parser.js";
 import { timeSyncManager } from "./time-sync.js";
 import { NormFsClient } from "./normfs.js";
-import { commandManager, CommandManager } from "./commands.js";
+import { commandManager, type CommandManager } from "./commands.js";
 import { WS_EVENTS } from "./websocket-events.js";
-import Long from "long";
 
 export const ErrConnectionNotOpen = new Error("WebSocket: Connection not open.");
 
@@ -17,6 +17,7 @@ export interface ConnectionStats {
   connectedAt: number | null;
   fps: number;
   isFpsReady: boolean;
+  acquisitionMode: 'live' | 'history';
   timeSync?: {
     isActive: boolean;
     adjustmentNs: number;
@@ -34,7 +35,10 @@ class WebSocketManager extends EventTarget {
   private ws: WebSocket | null = null;
   private url: string;
   private reconnectInterval: number = 100; // 100ms
-  private isUpdating = true;
+  private historyModeLeases = new Set<symbol>();
+  private acquisitionGeneration = 0;
+  private pollingResumeTimeout: number | null = null;
+  private lastProcessedEntryId: number | null = null;
 
   private liveSnapshot: LiveSnapshot = {
     frame: null,
@@ -56,6 +60,7 @@ class WebSocketManager extends EventTarget {
     connectedAt: null,
     fps: 0,
     isFpsReady: false,
+    acquisitionMode: 'live',
   };
 
   constructor(url: string) {
@@ -95,11 +100,12 @@ class WebSocketManager extends EventTarget {
   };
 
   private async pollLatestFrame() {
-    if (this.isPolling) {
+    if (!this.isLiveMode() || this.isPolling) {
       return; // Already polling
     }
 
     this.isPolling = true;
+    const acquisitionGeneration = this.acquisitionGeneration;
 
     try {
       // Read the latest entry directly: backward from offset 1, limit 1
@@ -107,15 +113,22 @@ class WebSocketManager extends EventTarget {
       const entryId = Long.fromBytesLE(Array.from(entry.id)).toNumber();
 
       // Only process if ID changed
-      if (entryId !== this.liveSnapshot.latestEntryId) {
+      if (entryId !== this.lastProcessedEntryId) {
         // Decode as InferenceRx and parse frame
         const inferenceRx = inference.InferenceRx.decode(entry.data);
         const frame = await parseFrame(inferenceRx, entry.id, this.normFs, this.liveSnapshot.frame || undefined, {
           retainRawData: false,
           publishVideoFrames: true,
+          shouldPublishVideoFrames: () =>
+            this.isLiveMode() && acquisitionGeneration === this.acquisitionGeneration,
         });
 
+        if (!this.isLiveMode() || acquisitionGeneration !== this.acquisitionGeneration) {
+          return;
+        }
+
         // Update and dispatch
+        this.lastProcessedEntryId = entryId;
         this.liveSnapshot = { frame, latestEntryId: entryId };
         this.frameTimestamps.push(Date.now());
         this.dispatchEvent(new Event(WS_EVENTS.INFERENCE_STATE));
@@ -128,6 +141,10 @@ class WebSocketManager extends EventTarget {
   }
 
   private startPolling() {
+    if (!this.isLiveMode() || !this.isConnected()) {
+      return;
+    }
+
     this.stopPolling();
 
     console.log("WebSocket: Starting frame polling at 50Hz...");
@@ -137,7 +154,7 @@ class WebSocketManager extends EventTarget {
 
     // Then poll every 20ms (50Hz)
     this.pollingInterval = window.setInterval(() => {
-      if (this.isUpdating && this.isConnected()) {
+      if (this.isLiveMode() && this.isConnected()) {
         this.pollLatestFrame();
       }
     }, 20);
@@ -155,24 +172,59 @@ class WebSocketManager extends EventTarget {
     return this.ws?.readyState === WebSocket.OPEN;
   }
 
-  public stopUpdating() {
-    if (!this.isUpdating) {
-      return;
-    }
-    console.log("WebSocket: Stopping state updates.");
-    this.isUpdating = false;
-    this.stopPolling();
+  private isLiveMode(): boolean {
+    return this.historyModeLeases.size === 0;
   }
 
-  public resumeUpdating() {
-    if (this.isUpdating) {
+  private cancelScheduledPollingResume(): void {
+    if (this.pollingResumeTimeout === null) {
       return;
     }
-    console.log("WebSocket: Resuming state updates.");
-    this.isUpdating = true;
-    if (this.isConnected()) {
+
+    window.clearTimeout(this.pollingResumeTimeout);
+    this.pollingResumeTimeout = null;
+  }
+
+  private schedulePollingResume(): void {
+    this.cancelScheduledPollingResume();
+    this.pollingResumeTimeout = window.setTimeout(() => {
+      this.pollingResumeTimeout = null;
       this.startPolling();
+    }, 0);
+  }
+
+  public acquireHistoryMode(): () => void {
+    const lease = Symbol('history-mode');
+    const entersHistoryMode = this.isLiveMode();
+    this.historyModeLeases.add(lease);
+
+    if (entersHistoryMode) {
+      console.log("WebSocket: Suspending live state updates.");
+      this.acquisitionGeneration += 1;
+      this.cancelScheduledPollingResume();
+      this.stopPolling();
+      this.emitStats();
     }
+
+    let isReleased = false;
+    return () => {
+      if (isReleased) {
+        return;
+      }
+      isReleased = true;
+
+      this.historyModeLeases.delete(lease);
+      if (!this.isLiveMode()) {
+        return;
+      }
+
+      console.log("WebSocket: Resuming live state updates.");
+      this.acquisitionGeneration += 1;
+      this.emitStats();
+      if (this.isConnected()) {
+        this.schedulePollingResume();
+      }
+    };
   }
 
   private calculateFPS(): { fps: number; isReady: boolean } {
@@ -196,13 +248,15 @@ class WebSocketManager extends EventTarget {
     return { fps: Number.isFinite(fps) ? fps : 0, isReady: true };
   }
 
-  private emitStats() {
+  private emitStats(patch: Partial<ConnectionStats> = {}) {
     const fpsStats = this.calculateFPS();
     const timeSyncState = timeSyncManager.getState();
     this.stats = {
       ...this.stats,
+      ...patch,
       fps: fpsStats.fps,
       isFpsReady: fpsStats.isReady,
+      acquisitionMode: this.isLiveMode() ? 'live' : 'history',
       timeSync: {
         isActive: timeSyncState.isActive,
         adjustmentNs: timeSyncState.timeAdjustmentNs,
@@ -215,26 +269,21 @@ class WebSocketManager extends EventTarget {
   }
 
   public connect() {
-    this.stats = { ...this.stats, status: 'connecting' };
-    this.emitStats();
+    this.emitStats({ status: 'connecting' });
     
     this.ws = new WebSocket(this.url);
     this.ws.binaryType = "arraybuffer";
 
     this.ws.onopen = () => {
       console.log("WebSocket: Connection established.");
-      this.stats = {
-        ...this.stats,
+      this.emitStats({
         status: 'connected',
         connectedAt: Date.now(),
-        fps: 0,
-        isFpsReady: false,
-      };
-      this.emitStats();
+      });
 
       this.normFs.onOpen();
 
-      if (this.isUpdating) {
+      if (this.isLiveMode()) {
         this.startPolling();
       }
 
@@ -249,13 +298,6 @@ class WebSocketManager extends EventTarget {
 
     this.ws.onmessage = async (event) => {
       try {
-        // Update stats
-        this.stats = {
-          ...this.stats,
-          packetsReceived: this.stats.packetsReceived + 1,
-          bytesReceived: this.stats.bytesReceived + event.data.byteLength,
-        };
-
         const normFsResponse = normfs.ServerResponse.decode(new Uint8Array(event.data));
 
         // Handle ping response for time sync
@@ -264,20 +306,19 @@ class WebSocketManager extends EventTarget {
         }
 
         this.normFs.processStreamFsResponse(normFsResponse);
-
-        this.emitStats();
       } catch (error) {
         console.error("WebSocket: Error processing message:", error);
+      } finally {
+        this.emitStats({
+          packetsReceived: this.stats.packetsReceived + 1,
+          bytesReceived: this.stats.bytesReceived + event.data.byteLength,
+        });
       }
     };
 
     this.ws.onclose = (event) => {
       console.log("WebSocket: Connection closed.", event);
-      this.stats = {
-        ...this.stats,
-        status: 'disconnected',
-        connectedAt: null,
-      };
+      this.lastProcessedEntryId = null;
       this.frameTimestamps = [];
       this.normFs.onClose();
 
@@ -285,9 +326,10 @@ class WebSocketManager extends EventTarget {
       timeSyncManager.stop();
 
       // Stop polling
+      this.cancelScheduledPollingResume();
       this.stopPolling();
 
-      this.emitStats();
+      this.emitStats({ status: 'disconnected', connectedAt: null });
       this.reconnect();
     };
 

--- a/software/station/clients/station-viewer/src/api/websocket.ts
+++ b/software/station/clients/station-viewer/src/api/websocket.ts
@@ -3,6 +3,7 @@ import { Frame, parseFrame } from "./frame-parser.js";
 import { timeSyncManager } from "./time-sync.js";
 import { NormFsClient } from "./normfs.js";
 import { commandManager, CommandManager } from "./commands.js";
+import { WS_EVENTS } from "./websocket-events.js";
 import Long from "long";
 
 export const ErrConnectionNotOpen = new Error("WebSocket: Connection not open.");
@@ -24,14 +25,21 @@ export interface ConnectionStats {
   };
 }
 
+export interface LiveSnapshot {
+  frame: Frame | null;
+  latestEntryId: number | null;
+}
+
 class WebSocketManager extends EventTarget {
   private ws: WebSocket | null = null;
   private url: string;
   private reconnectInterval: number = 100; // 100ms
   private isUpdating = true;
 
-  private currentFrame: Frame | null = null;
-  private latestEntryId: number | null = null;
+  private liveSnapshot: LiveSnapshot = {
+    frame: null,
+    latestEntryId: null,
+  };
   public readonly normFs: NormFsClient;
   public readonly commands: CommandManager;
 
@@ -53,15 +61,18 @@ class WebSocketManager extends EventTarget {
   constructor(url: string) {
     super();
     this.url = url;
-    this.stats.endpoint = url;
+    this.stats = { ...this.stats, endpoint: url };
     this.normFs = new NormFsClient();
     this.commands = commandManager;
     this.connect();
   }
 
-  public getCurrentFrame(): Frame | null {
-    return this.currentFrame;
-  }
+  public getLiveSnapshot = (): LiveSnapshot => this.liveSnapshot;
+
+  public subscribeLive = (listener: () => void): (() => void) => {
+    this.addEventListener(WS_EVENTS.INFERENCE_STATE, listener);
+    return () => this.removeEventListener(WS_EVENTS.INFERENCE_STATE, listener);
+  };
 
   public async getFrame(entryId: Uint8Array, previousFrame?: Frame): Promise<Frame> {
     // Read the inference-states entry
@@ -76,13 +87,12 @@ class WebSocketManager extends EventTarget {
     return frame;
   }
 
-  public getLatestEntryId(): number | null {
-    return this.latestEntryId;
-  }
+  public getConnectionStats = (): ConnectionStats => this.stats;
 
-  public getConnectionStats(): ConnectionStats {
-    return { ...this.stats };
-  }
+  public subscribeConnectionStats = (listener: () => void): (() => void) => {
+    this.addEventListener(WS_EVENTS.STATS, listener);
+    return () => this.removeEventListener(WS_EVENTS.STATS, listener);
+  };
 
   private async pollLatestFrame() {
     if (this.isPolling) {
@@ -97,20 +107,18 @@ class WebSocketManager extends EventTarget {
       const entryId = Long.fromBytesLE(Array.from(entry.id)).toNumber();
 
       // Only process if ID changed
-      if (entryId !== this.latestEntryId) {
-        this.latestEntryId = entryId;
-
+      if (entryId !== this.liveSnapshot.latestEntryId) {
         // Decode as InferenceRx and parse frame
         const inferenceRx = inference.InferenceRx.decode(entry.data);
-        const frame = await parseFrame(inferenceRx, entry.id, this.normFs, this.currentFrame || undefined, {
+        const frame = await parseFrame(inferenceRx, entry.id, this.normFs, this.liveSnapshot.frame || undefined, {
           retainRawData: false,
           publishVideoFrames: true,
         });
 
         // Update and dispatch
-        this.currentFrame = frame;
+        this.liveSnapshot = { frame, latestEntryId: entryId };
         this.frameTimestamps.push(Date.now());
-        this.dispatchEvent(new Event('inferenceState'));
+        this.dispatchEvent(new Event(WS_EVENTS.INFERENCE_STATE));
       }
     } catch {
       // Silently ignore if queue is empty (not yet populated)
@@ -190,23 +198,24 @@ class WebSocketManager extends EventTarget {
 
   private emitStats() {
     const fpsStats = this.calculateFPS();
-    this.stats.fps = fpsStats.fps;
-    this.stats.isFpsReady = fpsStats.isReady;
-    
-    // Add time sync information
     const timeSyncState = timeSyncManager.getState();
-    this.stats.timeSync = {
-      isActive: timeSyncState.isActive,
-      adjustmentNs: timeSyncState.timeAdjustmentNs,
-      pingMs: timeSyncState.pingTimeMs,
-      syncCount: timeSyncState.syncCount,
+    this.stats = {
+      ...this.stats,
+      fps: fpsStats.fps,
+      isFpsReady: fpsStats.isReady,
+      timeSync: {
+        isActive: timeSyncState.isActive,
+        adjustmentNs: timeSyncState.timeAdjustmentNs,
+        pingMs: timeSyncState.pingTimeMs,
+        syncCount: timeSyncState.syncCount,
+      },
     };
-    
-    this.dispatchEvent(new Event('stats'));
+
+    this.dispatchEvent(new Event(WS_EVENTS.STATS));
   }
 
   public connect() {
-    this.stats.status = 'connecting';
+    this.stats = { ...this.stats, status: 'connecting' };
     this.emitStats();
     
     this.ws = new WebSocket(this.url);
@@ -214,10 +223,13 @@ class WebSocketManager extends EventTarget {
 
     this.ws.onopen = () => {
       console.log("WebSocket: Connection established.");
-      this.stats.status = 'connected';
-      this.stats.connectedAt = Date.now();
-      this.stats.fps = 0;
-      this.stats.isFpsReady = false;
+      this.stats = {
+        ...this.stats,
+        status: 'connected',
+        connectedAt: Date.now(),
+        fps: 0,
+        isFpsReady: false,
+      };
       this.emitStats();
 
       this.normFs.onOpen();
@@ -238,8 +250,11 @@ class WebSocketManager extends EventTarget {
     this.ws.onmessage = async (event) => {
       try {
         // Update stats
-        this.stats.packetsReceived++;
-        this.stats.bytesReceived += event.data.byteLength;
+        this.stats = {
+          ...this.stats,
+          packetsReceived: this.stats.packetsReceived + 1,
+          bytesReceived: this.stats.bytesReceived + event.data.byteLength,
+        };
 
         const normFsResponse = normfs.ServerResponse.decode(new Uint8Array(event.data));
 
@@ -258,8 +273,11 @@ class WebSocketManager extends EventTarget {
 
     this.ws.onclose = (event) => {
       console.log("WebSocket: Connection closed.", event);
-      this.stats.status = 'disconnected';
-      this.stats.connectedAt = null;
+      this.stats = {
+        ...this.stats,
+        status: 'disconnected',
+        connectedAt: null,
+      };
       this.frameTimestamps = [];
       this.normFs.onClose();
 

--- a/software/station/clients/station-viewer/src/api/websocket.ts
+++ b/software/station/clients/station-viewer/src/api/websocket.ts
@@ -1,10 +1,10 @@
 import Long from "long";
-import { normfs, inference } from "./proto.js";
-import { parseFrame, type Frame } from "./frame-parser.js";
-import { timeSyncManager } from "./time-sync.js";
-import { NormFsClient } from "./normfs.js";
-import { commandManager, type CommandManager } from "./commands.js";
-import { WS_EVENTS } from "./websocket-events.js";
+import { commandManager, type CommandManager } from "@/api/commands.js";
+import { parseFrame, type Frame } from "@/api/frame-parser.js";
+import { NormFsClient } from "@/api/normfs.js";
+import { normfs, inference } from "@/api/proto.js";
+import { timeSyncManager } from "@/api/time-sync.js";
+import { WS_EVENTS } from "@/api/websocket-events.js";
 
 export const ErrConnectionNotOpen = new Error("WebSocket: Connection not open.");
 
@@ -116,7 +116,11 @@ class WebSocketManager extends EventTarget {
       if (entryId !== this.lastProcessedEntryId) {
         // Decode as InferenceRx and parse frame
         const inferenceRx = inference.InferenceRx.decode(entry.data);
-        const frame = await parseFrame(inferenceRx, entry.id, this.normFs, this.liveSnapshot.frame || undefined, {
+        let previousFrame: Frame | undefined;
+        if (this.lastProcessedEntryId !== null && this.liveSnapshot.frame !== null) {
+          previousFrame = this.liveSnapshot.frame;
+        }
+        const frame = await parseFrame(inferenceRx, entry.id, this.normFs, previousFrame, {
           retainRawData: false,
           shouldPublishVideoFrames: () =>
             this.isLiveMode() && acquisitionGeneration === this.acquisitionGeneration,

--- a/software/station/clients/station-viewer/src/api/websocket.ts
+++ b/software/station/clients/station-viewer/src/api/websocket.ts
@@ -118,7 +118,6 @@ class WebSocketManager extends EventTarget {
         const inferenceRx = inference.InferenceRx.decode(entry.data);
         const frame = await parseFrame(inferenceRx, entry.id, this.normFs, this.liveSnapshot.frame || undefined, {
           retainRawData: false,
-          publishVideoFrames: true,
           shouldPublishVideoFrames: () =>
             this.isLiveMode() && acquisitionGeneration === this.acquisitionGeneration,
         });
@@ -318,6 +317,7 @@ class WebSocketManager extends EventTarget {
 
     this.ws.onclose = (event) => {
       console.log("WebSocket: Connection closed.", event);
+      this.acquisitionGeneration += 1;
       this.lastProcessedEntryId = null;
       this.frameTimestamps = [];
       this.normFs.onClose();

--- a/software/station/clients/station-viewer/src/components/ConnectionUptime.tsx
+++ b/software/station/clients/station-viewer/src/components/ConnectionUptime.tsx
@@ -1,10 +1,6 @@
 import type { FC } from 'react';
 import { useElapsedSeconds } from '@/hooks';
 
-interface ConnectionUptimeProps {
-  connectedAt: number | null;
-}
-
 function formatElapsedSeconds(seconds: number | null): string {
   if (seconds === null) {
     return 'N/A';
@@ -14,6 +10,10 @@ function formatElapsedSeconds(seconds: number | null): string {
   const minutes = Math.floor((seconds % 3600) / 60);
   const secs = seconds % 60;
   return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+}
+
+interface ConnectionUptimeProps {
+  connectedAt: number | null;
 }
 
 const ConnectionUptime: FC<ConnectionUptimeProps> = ({ connectedAt }) => {

--- a/software/station/clients/station-viewer/src/components/ConnectionUptime.tsx
+++ b/software/station/clients/station-viewer/src/components/ConnectionUptime.tsx
@@ -1,0 +1,23 @@
+import type { FC } from 'react';
+import { useElapsedSeconds } from '@/hooks';
+
+interface ConnectionUptimeProps {
+  connectedAt: number | null;
+}
+
+function formatElapsedSeconds(seconds: number | null): string {
+  if (seconds === null) {
+    return 'N/A';
+  }
+
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const secs = seconds % 60;
+  return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+}
+
+const ConnectionUptime: FC<ConnectionUptimeProps> = ({ connectedAt }) => {
+  return formatElapsedSeconds(useElapsedSeconds(connectedAt));
+};
+
+export default ConnectionUptime;

--- a/software/station/clients/station-viewer/src/devices/yahboom-dogzilla-lite/ui/YahboomDogzillaLiteDashboard.tsx
+++ b/software/station/clients/station-viewer/src/devices/yahboom-dogzilla-lite/ui/YahboomDogzillaLiteDashboard.tsx
@@ -1,4 +1,5 @@
 import { memo, useEffect, useMemo, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
 import Long from 'long';
 import {
   Activity,
@@ -27,7 +28,7 @@ import { CONTROL_SLIDER_CLASS_NAME } from '@/devices/yahboom-dogzilla-lite/ui/co
 import YahboomDogzillaLiteViewer from '@/devices/yahboom-dogzilla-lite/ui/YahboomDogzillaLiteViewer';
 import MovementPanel, { type MovementPanelRef } from '@/devices/yahboom-dogzilla-lite/ui/MovementPanel';
 import { getYahboomDogzillaLiteModelLabel } from '@/devices/yahboom-dogzilla-lite/ui/model-labels';
-import { useConnectionStatsWithUptime } from '@/hooks';
+import { useConnectionStats, useElapsedSeconds } from '@/hooks';
 import UsbCameraViewer from '@/usbvideo/CameraViewer';
 import { getVideoSourceId, getVideoSourceLabel } from '@/usbvideo/camera-source';
 
@@ -120,15 +121,18 @@ function clampByte(value: number) {
   return Math.max(0, Math.min(255, Math.round(value)));
 }
 
-function formatDuration(connectedAt: number | null) {
-  if (!connectedAt) {
+function formatDuration(seconds: number | null) {
+  if (seconds === null) {
     return 'N/A';
   }
-  const seconds = Math.max(0, Math.floor((Date.now() - connectedAt) / 1000));
   const hours = Math.floor(seconds / 3600);
   const minutes = Math.floor((seconds % 3600) / 60);
   const secs = seconds % 60;
   return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+}
+
+function DashboardUptime({ connectedAt }: { connectedAt: number | null }) {
+  return formatDuration(useElapsedSeconds(connectedAt));
 }
 
 function formatBytes(bytes: number) {
@@ -339,7 +343,7 @@ function StatusSection({
 }: {
   title: string;
   icon: typeof Radar;
-  rows: Array<{ label: string; value: string }>;
+  rows: Array<{ label: string; value: ReactNode }>;
 }) {
   return (
     <section className="rounded-lg border border-border-default bg-surface-primary/80 px-4 py-4">
@@ -383,7 +387,7 @@ const YahboomDogzillaLiteDashboard = memo(function YahboomDogzillaLiteDashboard(
   const [activeAction, setActiveAction] = useState<yahboom_dogzilla_lite.ActionType | null>(null);
   const [commandLog, setCommandLog] = useState<DashboardLogEntry[]>([]);
 
-  const connectionStats = useConnectionStatsWithUptime();
+  const connectionStats = useConnectionStats();
 
   const status = deviceState?.status ?? null;
   const device = deviceState?.device ?? null;
@@ -684,7 +688,7 @@ const YahboomDogzillaLiteDashboard = memo(function YahboomDogzillaLiteDashboard(
     { label: 'Endpoint', value: connectionStats?.endpoint ?? 'N/A' },
     { label: 'Packets', value: connectionStats ? connectionStats.packetsReceived.toLocaleString() : 'N/A' },
     { label: 'Data', value: connectionStats ? formatBytes(connectionStats.bytesReceived) : 'N/A' },
-    { label: 'Uptime', value: formatDuration(connectionStats?.connectedAt ?? null) },
+    { label: 'Uptime', value: <DashboardUptime connectedAt={connectionStats.connectedAt} /> },
     { label: 'Latency', value: `${Math.round(averageLatency)} ms` }
   ];
 

--- a/software/station/clients/station-viewer/src/devices/yahboom-dogzilla-lite/ui/YahboomDogzillaLiteDashboard.tsx
+++ b/software/station/clients/station-viewer/src/devices/yahboom-dogzilla-lite/ui/YahboomDogzillaLiteDashboard.tsx
@@ -22,13 +22,14 @@ import type { FrameEntry } from '@/api/frame-parser';
 import { commandManager } from '@/api/commands.js';
 import { serverToLocal } from '@/api/timestamp-utils';
 import { yahboom_dogzilla_lite, usbvideo } from '@/api/proto.js';
+import ConnectionUptime from '@/components/ConnectionUptime';
+import { useConnectionStats } from '@/hooks';
 import ActionPanel, { QUICK_ACTIONS, type ActionDefinition } from '@/devices/yahboom-dogzilla-lite/ui/ActionPanel';
 import AttitudeIndicator from '@/devices/yahboom-dogzilla-lite/ui/AttitudeIndicator';
 import { CONTROL_SLIDER_CLASS_NAME } from '@/devices/yahboom-dogzilla-lite/ui/control-classes';
 import YahboomDogzillaLiteViewer from '@/devices/yahboom-dogzilla-lite/ui/YahboomDogzillaLiteViewer';
 import MovementPanel, { type MovementPanelRef } from '@/devices/yahboom-dogzilla-lite/ui/MovementPanel';
 import { getYahboomDogzillaLiteModelLabel } from '@/devices/yahboom-dogzilla-lite/ui/model-labels';
-import { useConnectionStats, useElapsedSeconds } from '@/hooks';
 import UsbCameraViewer from '@/usbvideo/CameraViewer';
 import { getVideoSourceId, getVideoSourceLabel } from '@/usbvideo/camera-source';
 
@@ -119,20 +120,6 @@ interface CameraOption {
 
 function clampByte(value: number) {
   return Math.max(0, Math.min(255, Math.round(value)));
-}
-
-function formatDuration(seconds: number | null) {
-  if (seconds === null) {
-    return 'N/A';
-  }
-  const hours = Math.floor(seconds / 3600);
-  const minutes = Math.floor((seconds % 3600) / 60);
-  const secs = seconds % 60;
-  return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
-}
-
-function DashboardUptime({ connectedAt }: { connectedAt: number | null }) {
-  return formatDuration(useElapsedSeconds(connectedAt));
 }
 
 function formatBytes(bytes: number) {
@@ -336,15 +323,22 @@ function SliderControlCard({
   );
 }
 
+interface StatusRow {
+  label: string;
+  value: ReactNode;
+}
+
+interface StatusSectionProps {
+  title: string;
+  icon: typeof Radar;
+  rows: StatusRow[];
+}
+
 function StatusSection({
   title,
   icon: Icon,
   rows
-}: {
-  title: string;
-  icon: typeof Radar;
-  rows: Array<{ label: string; value: ReactNode }>;
-}) {
+}: StatusSectionProps) {
   return (
     <section className="rounded-lg border border-border-default bg-surface-primary/80 px-4 py-4">
       <div className="flex items-center gap-2">
@@ -519,7 +513,7 @@ const YahboomDogzillaLiteDashboard = memo(function YahboomDogzillaLiteDashboard(
     ? latencyHistoryRef.current
     : [{ timestamp: now, latency: deviceLatency }];
   const averageLatency = latencySamples.reduce((sum, entry) => sum + entry.latency, 0) / latencySamples.length;
-  const pingValue = connectionStats?.timeSync?.isActive ? connectionStats.timeSync.pingMs : averageLatency;
+  const pingValue = connectionStats.timeSync?.isActive ? connectionStats.timeSync.pingMs : averageLatency;
   const pingTone = !isConnected ? 'danger' : pingValue < 100 ? 'good' : pingValue < 300 ? 'warn' : 'danger';
 
   const batteryPercent = status?.batteryLevel ?? null;
@@ -685,10 +679,10 @@ const YahboomDogzillaLiteDashboard = memo(function YahboomDogzillaLiteDashboard(
   ];
 
   const networkRows = [
-    { label: 'Endpoint', value: connectionStats?.endpoint ?? 'N/A' },
-    { label: 'Packets', value: connectionStats ? connectionStats.packetsReceived.toLocaleString() : 'N/A' },
-    { label: 'Data', value: connectionStats ? formatBytes(connectionStats.bytesReceived) : 'N/A' },
-    { label: 'Uptime', value: <DashboardUptime connectedAt={connectionStats.connectedAt} /> },
+    { label: 'Endpoint', value: connectionStats.endpoint },
+    { label: 'Packets', value: connectionStats.packetsReceived.toLocaleString() },
+    { label: 'Data', value: formatBytes(connectionStats.bytesReceived) },
+    { label: 'Uptime', value: <ConnectionUptime connectedAt={connectionStats.connectedAt} /> },
     { label: 'Latency', value: `${Math.round(averageLatency)} ms` }
   ];
 

--- a/software/station/clients/station-viewer/src/devices/yahboom-dogzilla-lite/ui/YahboomDogzillaLiteDashboard.tsx
+++ b/software/station/clients/station-viewer/src/devices/yahboom-dogzilla-lite/ui/YahboomDogzillaLiteDashboard.tsx
@@ -1,5 +1,4 @@
-import { memo, useEffect, useMemo, useRef, useState } from 'react';
-import type { ReactNode } from 'react';
+import { memo, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import Long from 'long';
 import {
   Activity,

--- a/software/station/clients/station-viewer/src/hooks/index.ts
+++ b/software/station/clients/station-viewer/src/hooks/index.ts
@@ -17,4 +17,3 @@ export type { Theme } from "./useTheme";
 export type { TimelineControlsRef } from "./useKeyboardNavigation";
 export type { UseWakeLockReturn } from "./useWakeLock";
 export type { BusStatus, ErrorPacketDump } from "./useBusMonitor";
-export type { LiveSnapshot } from "@/api/websocket";

--- a/software/station/clients/station-viewer/src/hooks/index.ts
+++ b/software/station/clients/station-viewer/src/hooks/index.ts
@@ -1,6 +1,8 @@
 export { useInferenceState } from "./useInferenceState";
 export { useLatestEntryId } from "./useLatestEntryId";
-export { useConnectionStats, useConnectionStatsWithUptime } from "./useConnectionStats";
+export { useLiveSnapshot } from "./useLiveSnapshot";
+export { useConnectionStats } from "./useConnectionStats";
+export { useElapsedSeconds } from "./useElapsedSeconds";
 export { useFrameData } from "./useFrameData";
 export { useQueueEntries } from "./useQueueEntries";
 export { useTimelineState } from "./useTimelineState";
@@ -15,3 +17,4 @@ export type { Theme } from "./useTheme";
 export type { TimelineControlsRef } from "./useKeyboardNavigation";
 export type { UseWakeLockReturn } from "./useWakeLock";
 export type { BusStatus, ErrorPacketDump } from "./useBusMonitor";
+export type { LiveSnapshot } from "@/api/websocket";

--- a/software/station/clients/station-viewer/src/hooks/useConnectionStats.ts
+++ b/software/station/clients/station-viewer/src/hooks/useConnectionStats.ts
@@ -1,49 +1,10 @@
-import { useState, useEffect, useCallback, useRef } from "react";
-import webSocketManager, { ConnectionStats } from "../api/websocket";
-import { WS_EVENTS } from "../api/websocket-events";
+import { useSyncExternalStore } from 'react';
+import webSocketManager, { type ConnectionStats } from '@/api/websocket';
 
-export function useConnectionStats(): ConnectionStats | null {
-  const [stats, setStats] = useState<ConnectionStats | null>(
-    () => webSocketManager.getConnectionStats()
+export function useConnectionStats(): ConnectionStats {
+  return useSyncExternalStore(
+    webSocketManager.subscribeConnectionStats,
+    webSocketManager.getConnectionStats,
+    webSocketManager.getConnectionStats,
   );
-
-  useEffect(() => {
-    const handler = () => setStats(webSocketManager.getConnectionStats());
-    webSocketManager.addEventListener(WS_EVENTS.STATS, handler);
-    return () => webSocketManager.removeEventListener(WS_EVENTS.STATS, handler);
-  }, []);
-
-  return stats;
-}
-
-export function useConnectionStatsWithUptime(): ConnectionStats | null {
-  const [stats, setStats] = useState<ConnectionStats | null>(
-    () => webSocketManager.getConnectionStats()
-  );
-  const connectedAtRef = useRef<number | null>(null);
-
-  const updateStats = useCallback(() => {
-    setStats(webSocketManager.getConnectionStats());
-  }, []);
-
-  useEffect(() => {
-    webSocketManager.addEventListener(WS_EVENTS.STATS, updateStats);
-    return () => webSocketManager.removeEventListener(WS_EVENTS.STATS, updateStats);
-  }, [updateStats]);
-
-  useEffect(() => {
-    connectedAtRef.current = stats?.connectedAt ?? null;
-  }, [stats?.connectedAt]);
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      if (connectedAtRef.current) {
-        setStats(webSocketManager.getConnectionStats());
-      }
-    }, 1000);
-
-    return () => clearInterval(interval);
-  }, []);
-
-  return stats;
 }

--- a/software/station/clients/station-viewer/src/hooks/useElapsedSeconds.ts
+++ b/software/station/clients/station-viewer/src/hooks/useElapsedSeconds.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+export function useElapsedSeconds(startedAt: number | null): number | null {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    setNow(Date.now());
+    if (startedAt === null) {
+      return;
+    }
+
+    const interval = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(interval);
+  }, [startedAt]);
+
+  if (startedAt === null) {
+    return null;
+  }
+
+  return Math.max(0, Math.floor((now - startedAt) / 1000));
+}

--- a/software/station/clients/station-viewer/src/hooks/useFrameData.test.ts
+++ b/software/station/clients/station-viewer/src/hooks/useFrameData.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment happy-dom
+
+import Long from 'long';
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { inference } from '@/api/proto.js';
+import type { StreamEntry } from '@/api/normfs.js';
+import type { UseFrameDataReturn } from '@/hooks/useFrameData';
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+class FakeWebSocket {
+  static readonly OPEN = 1;
+
+  readyState = 0;
+  binaryType: BinaryType = 'arraybuffer';
+  onopen: (() => void) | null = null;
+  onmessage: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  close() {}
+  send() {}
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+function entryIdBytes(entryId: number): Uint8Array {
+  return new Uint8Array(Long.fromNumber(entryId).toBytesLE());
+}
+
+function createFrameEntry(entryId: number): StreamEntry {
+  return {
+    id: entryIdBytes(entryId),
+    data: inference.InferenceRx.encode({ entries: [] }).finish(),
+  };
+}
+
+describe('useFrameData', () => {
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => root?.unmount());
+      root = null;
+    }
+    document.body.replaceChildren();
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps the latest frame when an older request finishes last', async () => {
+    const { default: webSocketManager } = await import('@/api/websocket');
+    const { useFrameData } = await import('@/hooks/useFrameData');
+    const firstRead = createDeferred<StreamEntry>();
+    const secondRead = createDeferred<StreamEntry>();
+    const reads = new Map([
+      [1, firstRead],
+      [2, secondRead],
+    ]);
+
+    vi.spyOn(webSocketManager.normFs, 'readSingleEntry').mockImplementation(
+      (_queueId, entryId) => {
+        const requestedId = Long.fromBytesLE(Array.from(entryId)).toNumber();
+        const read = reads.get(requestedId);
+        if (!read) {
+          return Promise.reject(new Error(`Unexpected frame ${requestedId}`));
+        }
+        return read.promise;
+      },
+    );
+
+    const renderedStates: UseFrameDataReturn[] = [];
+    function Probe({ frameNumber }: { frameNumber: number }) {
+      renderedStates.push(useFrameData({ frameNumber, immediate: true }));
+      return null;
+    }
+
+    const container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(createElement(Probe, { frameNumber: 1 }));
+    });
+    await act(async () => {
+      root?.render(createElement(Probe, { frameNumber: 2 }));
+    });
+
+    await act(async () => {
+      secondRead.resolve(createFrameEntry(2));
+      await secondRead.promise;
+    });
+    expect(Array.from(renderedStates.at(-1)?.parsedFrame?.stateId ?? [])).toEqual(
+      Array.from(entryIdBytes(2)),
+    );
+
+    await act(async () => {
+      firstRead.resolve(createFrameEntry(1));
+      await firstRead.promise;
+    });
+
+    const finalState = renderedStates.at(-1);
+    expect(Array.from(finalState?.parsedFrame?.stateId ?? [])).toEqual(
+      Array.from(entryIdBytes(2)),
+    );
+    expect(finalState?.error).toBeNull();
+    expect(finalState?.isLoading).toBe(false);
+  });
+});

--- a/software/station/clients/station-viewer/src/hooks/useFrameData.ts
+++ b/software/station/clients/station-viewer/src/hooks/useFrameData.ts
@@ -1,91 +1,100 @@
-import { useState, useRef, useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import Long from 'long';
-import webSocketManager from '../api/websocket';
-import { Frame } from '../api/frame-parser';
+import webSocketManager from '@/api/websocket';
+import type { Frame } from '@/api/frame-parser';
 
 const DEBOUNCE_DELAY_MS = 200;
 
-export interface FrameDataState {
-  currentFrame: number;
+export interface UseFrameDataOptions {
+  frameNumber: number | null;
+  immediate?: boolean;
+}
+
+export interface UseFrameDataReturn {
   parsedFrame: Frame | null;
   isLoading: boolean;
   error: string | null;
 }
 
-export interface UseFrameDataReturn extends FrameDataState {
-  selectFrame: (frame: number, immediate?: boolean) => void;
-}
-
-export function useFrameData(): UseFrameDataReturn {
-  const [currentFrame, setCurrentFrame] = useState<number>(0);
+export function useFrameData({
+  frameNumber,
+  immediate = false,
+}: UseFrameDataOptions): UseFrameDataReturn {
   const [parsedFrame, setParsedFrame] = useState<Frame | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  const debounceTimeout = useRef<number | null>(null);
   const parsedFrameRef = useRef<Frame | null>(null);
+  const requestGenerationRef = useRef(0);
 
-  // Keep ref in sync with state
-  useEffect(() => {
-    parsedFrameRef.current = parsedFrame;
-  }, [parsedFrame]);
+  const readEntryData = useCallback(async (
+    selectedFrame: number,
+    generation: number,
+  ) => {
+    if (generation !== requestGenerationRef.current) {
+      return;
+    }
 
-  const readEntryData = useCallback(async (frameNumber: number, previousFrame: Frame | null) => {
     setIsLoading(true);
     setError(null);
 
     try {
-      const entryIdBytes = new Uint8Array(Long.fromNumber(frameNumber).toBytesLE());
+      const entryIdBytes = new Uint8Array(Long.fromNumber(selectedFrame).toBytesLE());
+      const frame = await webSocketManager.getFrame(
+        entryIdBytes,
+        parsedFrameRef.current ?? undefined,
+      );
 
-      // Parse full frame using getFrame, pass previous frame for optimization
-      try {
-        const frame = await webSocketManager.getFrame(entryIdBytes, previousFrame || undefined);
-        setParsedFrame(frame);
-      } catch (frameError) {
-        console.error('Failed to parse frame:', frameError);
-        setError(`Failed to parse frame: ${frameError instanceof Error ? frameError.message : 'Unknown error'}`);
+      if (generation !== requestGenerationRef.current) {
+        return;
       }
+
+      parsedFrameRef.current = frame;
+      setParsedFrame(frame);
     } catch (err) {
-      console.error('Error reading entry:', err);
-      setError(err instanceof Error ? err.message : 'Unknown error reading entry');
+      if (generation !== requestGenerationRef.current) {
+        return;
+      }
+
+      console.error('Failed to parse frame:', err);
+      setError(
+        `Failed to parse frame: ${err instanceof Error ? err.message : 'Unknown error'}`,
+      );
     } finally {
-      setIsLoading(false);
+      if (generation === requestGenerationRef.current) {
+        setIsLoading(false);
+      }
     }
   }, []);
 
-  const selectFrame = useCallback((frameNumber: number, immediate?: boolean) => {
-    setCurrentFrame((prev) => {
-      if (frameNumber === prev) return prev;
-
-      if (debounceTimeout.current) {
-        clearTimeout(debounceTimeout.current);
-      }
-
-      if (immediate) {
-        readEntryData(frameNumber, parsedFrameRef.current);
-      } else {
-        debounceTimeout.current = window.setTimeout(() => {
-          readEntryData(frameNumber, parsedFrameRef.current);
-        }, DEBOUNCE_DELAY_MS);
-      }
-
-      return frameNumber;
-    });
-  }, [readEntryData]);
-
   useEffect(() => {
+    const generation = ++requestGenerationRef.current;
+
+    if (frameNumber === null) {
+      setIsLoading(false);
+      setError(null);
+      return;
+    }
+
+    if (immediate) {
+      void readEntryData(frameNumber, generation);
+      return () => {
+        requestGenerationRef.current += 1;
+      };
+    }
+
+    const debounceTimeout = window.setTimeout(() => {
+      void readEntryData(frameNumber, generation);
+    }, DEBOUNCE_DELAY_MS);
+
     return () => {
-      if (debounceTimeout.current) {
-        clearTimeout(debounceTimeout.current);
-      }
+      window.clearTimeout(debounceTimeout);
+      requestGenerationRef.current += 1;
     };
-  }, []);
+  }, [frameNumber, immediate, readEntryData]);
 
   return {
-    currentFrame,
     parsedFrame,
     isLoading,
     error,
-    selectFrame,
   };
 }

--- a/software/station/clients/station-viewer/src/hooks/useInferenceState.ts
+++ b/software/station/clients/station-viewer/src/hooks/useInferenceState.ts
@@ -1,18 +1,6 @@
-import { useState, useEffect } from "react";
-import webSocketManager from "../api/websocket";
-import { Frame } from "../api/frame-parser";
-import { WS_EVENTS } from "../api/websocket-events";
+import type { Frame } from '@/api/frame-parser';
+import { useLiveSnapshot } from '@/hooks/useLiveSnapshot';
 
 export function useInferenceState(): Frame | null {
-  const [state, setState] = useState<Frame | null>(
-    () => webSocketManager.getCurrentFrame()
-  );
-
-  useEffect(() => {
-    const handler = () => setState(webSocketManager.getCurrentFrame());
-    webSocketManager.addEventListener(WS_EVENTS.INFERENCE_STATE, handler);
-    return () => webSocketManager.removeEventListener(WS_EVENTS.INFERENCE_STATE, handler);
-  }, []);
-
-  return state;
+  return useLiveSnapshot().frame;
 }

--- a/software/station/clients/station-viewer/src/hooks/useInferenceState.ts
+++ b/software/station/clients/station-viewer/src/hooks/useInferenceState.ts
@@ -1,5 +1,5 @@
 import type { Frame } from '@/api/frame-parser';
-import { useLiveSnapshot } from '@/hooks/useLiveSnapshot';
+import { useLiveSnapshot } from './useLiveSnapshot';
 
 export function useInferenceState(): Frame | null {
   return useLiveSnapshot().frame;

--- a/software/station/clients/station-viewer/src/hooks/useLatestEntryId.ts
+++ b/software/station/clients/station-viewer/src/hooks/useLatestEntryId.ts
@@ -1,4 +1,4 @@
-import { useLiveSnapshot } from '@/hooks/useLiveSnapshot';
+import { useLiveSnapshot } from './useLiveSnapshot';
 
 export function useLatestEntryId(): number | null {
   return useLiveSnapshot().latestEntryId;

--- a/software/station/clients/station-viewer/src/hooks/useLatestEntryId.ts
+++ b/software/station/clients/station-viewer/src/hooks/useLatestEntryId.ts
@@ -1,17 +1,5 @@
-import { useState, useEffect } from "react";
-import webSocketManager from "../api/websocket";
-import { WS_EVENTS } from "../api/websocket-events";
+import { useLiveSnapshot } from '@/hooks/useLiveSnapshot';
 
 export function useLatestEntryId(): number | null {
-  const [entryId, setEntryId] = useState<number | null>(
-    () => webSocketManager.getLatestEntryId()
-  );
-
-  useEffect(() => {
-    const handler = () => setEntryId(webSocketManager.getLatestEntryId());
-    webSocketManager.addEventListener(WS_EVENTS.INFERENCE_STATE, handler);
-    return () => webSocketManager.removeEventListener(WS_EVENTS.INFERENCE_STATE, handler);
-  }, []);
-
-  return entryId;
+  return useLiveSnapshot().latestEntryId;
 }

--- a/software/station/clients/station-viewer/src/hooks/useLiveSnapshot.ts
+++ b/software/station/clients/station-viewer/src/hooks/useLiveSnapshot.ts
@@ -1,0 +1,10 @@
+import { useSyncExternalStore } from 'react';
+import webSocketManager, { type LiveSnapshot } from '@/api/websocket';
+
+export function useLiveSnapshot(): LiveSnapshot {
+  return useSyncExternalStore(
+    webSocketManager.subscribeLive,
+    webSocketManager.getLiveSnapshot,
+    webSocketManager.getLiveSnapshot,
+  );
+}

--- a/software/station/clients/station-viewer/src/pages/HistoryPage.tsx
+++ b/software/station/clients/station-viewer/src/pages/HistoryPage.tsx
@@ -30,18 +30,15 @@ function HistoryPage() {
   const timelineControlsRef = useRef<TimelineControlsRef>(null);
 
   const {
-    currentFrame,
     parsedFrame,
     isLoading: isReadingEntry,
     error: entryError,
-    selectFrame: selectFrameData,
-  } = useFrameData();
-
-  useEffect(() => {
-    if (timelineState.currentFrame !== currentFrame) {
-      selectFrameData(timelineState.currentFrame, timelineState.isNavigationImmediate);
-    }
-  }, [timelineState.currentFrame, currentFrame, selectFrameData, timelineState.isNavigationImmediate]);
+  } = useFrameData({
+    frameNumber: timelineState.isLoading || timelineState.error
+      ? null
+      : timelineState.currentFrame,
+    immediate: timelineState.isNavigationImmediate,
+  });
 
   useKeyboardNavigation(timelineActions, timelineState, { gotoInputRef: timelineControlsRef });
 
@@ -126,7 +123,7 @@ function HistoryPage() {
               {isReadingEntry && (
                 <div className="flex items-center gap-2 text-accent-info">
                   <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-accent-info"></div>
-                  <span>Reading entry {currentFrame.toLocaleString()}...</span>
+                  <span>Reading entry {timelineState.currentFrame.toLocaleString()}...</span>
                 </div>
               )}
 

--- a/software/station/clients/station-viewer/src/pages/HistoryPage.tsx
+++ b/software/station/clients/station-viewer/src/pages/HistoryPage.tsx
@@ -42,12 +42,7 @@ function HistoryPage() {
 
   useKeyboardNavigation(timelineActions, timelineState, { gotoInputRef: timelineControlsRef });
 
-  useEffect(() => {
-    webSocketManager.stopUpdating();
-    return () => {
-      webSocketManager.resumeUpdating();
-    };
-  }, []);
+  useEffect(() => webSocketManager.acquireHistoryMode(), []);
 
   const videoQueueCount = parsedFrame?.videoQueues?.length ?? 0;
   const st3215Count = parsedFrame?.st3215 ? 1 : 0;

--- a/software/station/clients/station-viewer/src/pages/HomePage.tsx
+++ b/software/station/clients/station-viewer/src/pages/HomePage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import Long from 'long';
 import { Tag as TagIcon } from 'lucide-react';
-import { useInferenceState, useConnectionStatsWithUptime, useLatestEntryId, useWakeLock, invalidateTagsCache } from "@/hooks";
+import { useConnectionStats, useElapsedSeconds, useLiveSnapshot, useWakeLock, invalidateTagsCache } from "@/hooks";
 import AsciiRobot from "@/components/AsciiRobot";
 import TagDialog from "@/components/TagDialog";
 import { copyToClipboard } from "@/api/clipboard-utils";
@@ -26,20 +26,22 @@ function formatBytes(bytes: number): string {
   return `${(bytes / Math.pow(k, i)).toFixed(2)} ${sizes[i]}`;
 }
 
-function formatUptime(connectedAt: number | null): string {
-  if (!connectedAt) return 'N/A';
-  const seconds = Math.floor((Date.now() - connectedAt) / 1000);
+function formatUptime(seconds: number | null): string {
+  if (seconds === null) return 'N/A';
   const hours = Math.floor(seconds / 3600);
   const minutes = Math.floor((seconds % 3600) / 60);
   const secs = seconds % 60;
   return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
 }
 
+function HomeUptime({ connectedAt }: { connectedAt: number | null }) {
+  return formatUptime(useElapsedSeconds(connectedAt));
+}
+
 function HomePage() {
   useWakeLock();
-  const inferenceState = useInferenceState();
-  const latestEntryId = useLatestEntryId();
-  const connectionStats = useConnectionStatsWithUptime();
+  const { frame: inferenceState, latestEntryId } = useLiveSnapshot();
+  const connectionStats = useConnectionStats();
   const [copied, setCopied] = useState(false);
   const [tagDialog, setTagDialog] = useState<TagDialogState | null>(null);
   const [isTagSubmitting, setIsTagSubmitting] = useState(false);
@@ -181,7 +183,9 @@ function HomePage() {
                 </div>
                 <div className="flex items-center gap-1.5">
                   <span className="text-text-muted">Uptime:</span>
-                  <span className="text-accent-success font-semibold">{formatUptime(connectionStats.connectedAt)}</span>
+                  <span className="text-accent-success font-semibold">
+                    <HomeUptime connectedAt={connectionStats.connectedAt} />
+                  </span>
                 </div>
               </div>
             </>

--- a/software/station/clients/station-viewer/src/pages/HomePage.tsx
+++ b/software/station/clients/station-viewer/src/pages/HomePage.tsx
@@ -1,17 +1,18 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import Long from 'long';
 import { Tag as TagIcon } from 'lucide-react';
-import { useConnectionStats, useElapsedSeconds, useLiveSnapshot, useWakeLock, invalidateTagsCache } from "@/hooks";
-import AsciiRobot from "@/components/AsciiRobot";
-import TagDialog from "@/components/TagDialog";
-import { copyToClipboard } from "@/api/clipboard-utils";
-import { commandManager } from "@/api/commands";
-import { inference_tags } from "@/api/proto.js";
-import { defaultTag } from "@/utils/tag-phrases";
-import { getFPSColor } from '@/utils/color-utils';
+import { copyToClipboard } from '@/api/clipboard-utils';
+import { commandManager } from '@/api/commands';
+import { inference_tags } from '@/api/proto.js';
+import AsciiRobot from '@/components/AsciiRobot';
+import ConnectionUptime from '@/components/ConnectionUptime';
+import TagDialog from '@/components/TagDialog';
+import { useConnectionStats, useLiveSnapshot, useWakeLock, invalidateTagsCache } from '@/hooks';
 import LiveDeviceSurface from '@/devices/LiveDeviceSurface';
 import { resolveLiveDevices } from '@/devices/live-registry';
 import CameraSurface from '@/usbvideo/CameraSurface';
+import { getFPSColor } from '@/utils/color-utils';
+import { defaultTag } from '@/utils/tag-phrases';
 
 interface TagDialogState {
   entryId: number | null;
@@ -24,18 +25,6 @@ function formatBytes(bytes: number): string {
   const sizes = ['B', 'KB', 'MB', 'GB'];
   const i = Math.floor(Math.log(bytes) / Math.log(k));
   return `${(bytes / Math.pow(k, i)).toFixed(2)} ${sizes[i]}`;
-}
-
-function formatUptime(seconds: number | null): string {
-  if (seconds === null) return 'N/A';
-  const hours = Math.floor(seconds / 3600);
-  const minutes = Math.floor((seconds % 3600) / 60);
-  const secs = seconds % 60;
-  return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
-}
-
-function HomeUptime({ connectedAt }: { connectedAt: number | null }) {
-  return formatUptime(useElapsedSeconds(connectedAt));
 }
 
 function HomePage() {
@@ -184,7 +173,7 @@ function HomePage() {
                 <div className="flex items-center gap-1.5">
                   <span className="text-text-muted">Uptime:</span>
                   <span className="text-accent-success font-semibold">
-                    <HomeUptime connectedAt={connectionStats.connectedAt} />
+                    <ConnectionUptime connectedAt={connectionStats.connectedAt} />
                   </span>
                 </div>
               </div>

--- a/software/station/clients/station-viewer/tsconfig.node.json
+++ b/software/station/clients/station-viewer/tsconfig.node.json
@@ -20,5 +20,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts"]
 }

--- a/software/station/clients/station-viewer/vitest.config.ts
+++ b/software/station/clients/station-viewer/vitest.config.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath, URL } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    restoreMocks: true,
+    unstubGlobals: true,
+  },
+});


### PR DESCRIPTION
## Summary

This PR strengthens Station Viewer’s existing state-management boundaries without introducing a general-purpose state library.

- Publish stable, immutable WebSocket snapshots for live frames and connection statistics.
- Consume transport-owned state through `useSyncExternalStore`.
- Keep the live frame and latest entry ID as one atomic observation.
- Make the timeline the sole owner of historical frame selection.
- Replace the live/history boolean with reference-counted history leases.
- Prevent stale async work from publishing after navigation, mode changes, disconnects, or reconnects.
- Preserve the last live snapshot during transient disconnects while invalidating cross-connection decoding caches.
- Isolate uptime ticking in a small shared leaf component.
- Add focused Vitest regression coverage and run it in CI.
- Document the resulting frontend architecture through Station Viewer ADRs.

## Motivation

Station Viewer already owns transport state inside `WebSocketManager`. Mirroring that state in hook-local React state introduced redundant subscriptions, unstable snapshots, unnecessary renders, and race-prone history reads.

This change keeps ownership in the existing manager and deepens its interface instead of adding Zustand or another state owner.

## Notable behavior

- Malformed WebSocket packets still publish one atomic statistics update.
- Overlapping history consumers cannot resume live polling prematurely.
- Only the latest historical frame request may update React state.
- In-flight live parsing is discarded after disconnect or acquisition-mode changes.
- Reconnects republish the backend’s current frame even when entry IDs restart.
- Retained frames are not reused as decoding caches across connection boundaries.
- Live camera payloads are published only while the originating live acquisition remains valid.

## Documentation

The new ADR set records the accepted Station Viewer architecture decisions. ADR 0009 documents the future ST3215 control-authority design but explicitly notes that its cross-stack implementation is not part of this PR.