### PR TITLE
Fix missing device_id argument in AirGradient Open Air O-1PST firmware config

### DIFF
--- a/device-support/airgradient-open-air-o1-pst/o-1pst-serial.yaml
+++ b/device-support/airgradient-open-air-o1-pst/o-1pst-serial.yaml
@@ -79,6 +79,7 @@ interval:
           # Format the output as a clean JSON string
           format: '{"device_id": "%s", "pm1_0": %.0f, "pm2_5": %.0f, "pm10_0": %.0f, "temp_c": %.1f, "humidity": %.1f, "co2": %.0f, "voc_index": %.0f, "nox_index": %.0f}'
           args: 
+            - esphome::get_mac_address_pretty().c_str()
             - id(pm1_0).state
             - id(pm2_5).state
             - id(pm10_0).state


### PR DESCRIPTION
The JSON log line in `o-1pst-serial.yaml` declares a `"device_id": "%s"` field in its format string, but no matching entry was ever passed in `args`.

Adds `esphome::get_mac_address_pretty().c_str()` as the first argument, so the emitted JSON matches the format string and the shape documented in the device README