### PR TITLE
Add gravity compensation for the ElRobot leader arm

### DIFF
--- a/GRAVITY_COMPENSATION.md
+++ b/GRAVITY_COMPENSATION.md
@@ -1,0 +1,331 @@
+# Gravity Compensation (ElRobot leader arm)
+
+Lets an operator hold the leader arm's pose against gravity by hand-feel
+instead of it always going fully limp, without adding any new hardware. It's
+opt-in per bus, toggled from a UI button, and today only implemented for
+ElRobot (7-DOF arm + gripper, Feetech ST3215 servos) — SO101 has no mass/CoM
+data checked into the repo, so it isn't supported.
+
+Code lives in `software/drivers/motors-mirroring/src/gravity_comp/` (see the
+sibling `CLAUDE.md` there for the terse agent-facing version of this doc).
+This file is the fuller writeup: the math, the architecture, what we learned
+tuning it on real hardware, and how it's wired into the UI.
+
+## The constraint that shapes everything
+
+Feetech ST3215 servos have **no native torque/current-setpoint register** —
+only a position-control loop plus a `TorqueLimit` effort clamp
+(register `0x30`, `software/drivers/st3215/src/protocol/memory.rs`). You
+cannot tell the servo "push with 0.4 Nm"; you can only tell it "go to
+position X" and "don't push harder than Y%". So gravity compensation here is
+*approximated*: every 20ms, compute how hard gravity is pulling on each
+joint right now, then nudge `GoalPosition` a little further in that
+direction. The servo's own internal position gain supplies a restoring
+torque roughly proportional to that offset — a virtual spring, not a real
+torque source. It only approximates *static* holding torque (no inertia
+terms, no velocity feedback) — adequate for slow manual posing, not for
+fighting fast motion.
+
+## The math
+
+### 1. Forward kinematics
+
+`elrobot_dynamics::forward_kinematics()` walks the arm as a serial chain of
+7 revolute joints, using per-link translation offsets, joint origins/axes,
+and joint limits hand-extracted from
+`hardware/elrobot/simulation/elrobot_follower.urdf`. For a joint-angle
+vector `theta: [f64; 7]`, it returns, all expressed in the `base_link`
+frame:
+
+- each joint's pivot position and rotation axis
+- the center-of-mass (CoM) of every gravity-relevant link (14 of them —
+  see "known approximations" below for what's excluded/lumped)
+
+Rotation is accumulated with a hand-rolled `Mat3`/`Vec3` (Rodrigues'
+rotation formula) in `kinematics.rs` — no `nalgebra`/`urdf-rs` dependency;
+the chain is fixed at 7 joints and the math is small enough to hand-roll,
+matching this codebase's existing low-level style.
+
+### 2. Gravity torque via virtual work / Jacobian transpose
+
+`elrobot_dynamics::gravity_torques(theta) -> [f64; 7]` computes the static
+gravity torque felt at each joint without ever building an explicit
+Jacobian matrix. For every link, its weight `(0, 0, -m·g)` (g = 9.81 m/s²)
+exerts a moment about every joint it is outboard of:
+
+```
+for each link L (mass m_L, CoM position com_L):
+    weight = (0, 0, -m_L * g)
+    for each joint J that L is outboard of (J's index <= L's last actuating joint):
+        arm    = com_L - joint_pos_J
+        moment = arm × weight
+        tau[J] += moment · joint_axis_J        // component along J's own axis
+```
+
+This is summed over all 14 links for all 7 joints in one pass
+(`LINK_LAST_JOINT_INDEX` records, per link, the index of the last/most
+distal joint whose rotation actually moves it — e.g. the housing for joint 2
+is itself only moved by joint 1, so it must not contribute to joint 2's own
+torque sum). The result, `tau: [f64; 7]`, is each joint's instantaneous
+static holding torque in Nm.
+
+Sanity checks living in `elrobot_dynamics.rs`'s unit tests: joint 1's axis
+is near-vertical (~`(0, 0, 1)`), so gravity (along -Z) should produce almost
+no torque about it regardless of pose; the shoulder (joint 2) should see
+more torque extended horizontally than folded straight up. Both hold.
+
+### 3. Torque → servo goal offset
+
+`control::gravity_torque_to_goal_offset_ticks()` turns a torque into a
+clamped tick offset to add to the servo's current measured position:
+
+```
+delta_theta_rad = gain_rad_per_nm * tau_nm
+delta_ticks     = -(delta_theta_rad * ticks_per_radian)      // sign flip, see below
+offset_ticks    = clamp(delta_ticks, -max_offset_ticks, +max_offset_ticks)
+goal            = clamp(present_position + offset_ticks,
+                         range_min + safety_margin, range_max - safety_margin)
+```
+
+- `gain_rad_per_nm` is the empirically-tuned lever (see "what we learned"
+  below) — there's no way to derive it analytically from the servo's
+  internal (undocumented, firmware-only) PID coefficients.
+- `ticks_per_radian` is derived per-motor from its *live calibrated* range
+  divided by its URDF joint-angle span (`control::ticks_per_radian`), not a
+  fixed global constant — a real unit's calibrated range rarely matches the
+  servo's full 4096-tick sweep exactly.
+- The sign flip matches `raw_to_joint_angle`'s own `joint_upper -
+  joint_position` inversion, which mirrors the exact convention the
+  frontend already uses in `devices/elrobot/config.ts`'s
+  `resolveElrobotJointValue` — both sides of the wire must agree on which
+  tick direction is "more positive angle."
+- `goal` is additionally wrapped into tick-space (`rem_euclid` against the
+  4096-step servo range) before the range clamp, and if a motor's
+  calibrated range is too narrow (`< safety_margin * 2`) or wraps across the
+  0/4096 boundary, that motor is skipped for the cycle (holds position)
+  rather than risking a bad clamp.
+
+## Implementation
+
+### Module layout
+
+- `elrobot_dynamics.rs` — the static data tables + `forward_kinematics`/
+  `gravity_torques` above.
+- `kinematics.rs` — minimal `Vec3`/`Mat3` primitives.
+- `control.rs` — tick ↔ angle conversion and the torque→offset control law.
+- `mod.rs` — task orchestration: per-bus background `tokio` task lifecycle
+  (`GravityComp::start`/`stop`), the 20ms control loop
+  (`run_control_loop`), and the safety cutoffs.
+
+### Per-bus task lifecycle
+
+`GravityComp` (in `mod.rs`) holds a `HashMap<BusKey, GravityCompTask>`. Each
+running task owns:
+
+- `gains: Arc<RwLock<[f64; 7]>>` — one gain per arm motor (index 0 = motor
+  1 … index 6 = motor 7), read fresh every 20ms cycle so it can be tuned
+  live without restarting the loop.
+- `torque_limit: Arc<RwLock<u16>>` — also live-tunable, but semantically
+  different: it's real servo register state (the `TorqueLimit` effort
+  clamp), not a pure software multiplier, so changing it immediately
+  re-sends a `TorqueLimit` write rather than just updating a value the loop
+  reads.
+- `stop_flag` / `JoinHandle` for shutdown.
+
+`start()` does a one-shot setup (write `TorqueLimit`, then enable torque,
+for arm motors 1–7 only — motor 8, the gripper, is never touched in either
+direction) before spawning the 20ms loop. `stop()` flips the stop flag,
+aborts the task, disables torque, and restores the servo's normal
+`TorqueLimit` (`st3215::presets::DEFAULT_TORQUE_LIMIT = 500`) for hygiene.
+Both the setup and teardown sends are deferred onto their own `tokio::spawn`
+rather than called inline, because `start`/`stop` are themselves invoked
+synchronously from within the "commands" normfs queue's own subscription
+callback (`lib.rs::process_command_pack`) — calling something that enqueues
+onto that same queue inline would re-enter its own callback stack.
+
+### The 20ms control loop (`run_control_loop`)
+
+Per cycle, per arm motor: read present position/current from the latest
+`st3215/inference` broadcast, convert to a joint angle
+(`control::raw_to_joint_angle`), and check two safety conditions before
+computing anything:
+
+- **Staleness** — if the bus's motor data hasn't updated within
+  `MAX_DATA_AGE_NS` for `stale_cutoff_cycles` (default 5) consecutive
+  cycles, hard torque-off, not "hold last goal."
+- **Overcurrent** — if any arm motor's current exceeds `current_cutoff`
+  (default 60, raw units) for `stale_cutoff_cycles` consecutive cycles, hard
+  torque-off. Below that, the whole arm holds position that cycle instead of
+  issuing new goals.
+
+If both checks pass, `gravity_torques()` runs on the full 7-angle pose, each
+motor's offset/goal is computed as in the math section above, and a batch of
+`Goal` commands is sent. Either cutoff calls the `on_self_stop` callback
+wired from `lib.rs`, which reuses the exact same teardown path as an
+operator-issued stop, so the UI's displayed mode never drifts from what's
+actually running.
+
+A rate-limited (once/second, not every 20ms) `INFO`-level log line records
+exactly what each branch decided that cycle — staleness, missing motor IDs,
+overcurrent readings, or for the normal path each motor's
+`(gain, torque_nm, present, offset_ticks, goal)`. This was the actual
+diagnostic tool used to confirm the loop was running correctly during
+hardware bring-up, before it was known to just be under-tuned.
+
+### Command / mode / settings plumbing
+
+Gravity comp is modeled as an **orthogonal per-bus flag**, not a `BusMode`
+variant — a bus can be a mirroring leader *and* gravity-comp'd
+simultaneously. Everything routes through its own
+`StationCommandType::STC_GRAVITY_COMP_COMMAND` and
+`motors_mirroring::GravityCompCommand` message
+(`protobufs/drivers/motors-mirroring/mirroring.proto`), with five command
+types:
+
+| `GravityCompCommandType` | Payload | Effect |
+|---|---|---|
+| `GCT_START_GRAVITY_COMP` | bus | Starts the loop, seeded from staged/saved settings (see below) |
+| `GCT_STOP_GRAVITY_COMP` | bus | Stops the loop, torque off |
+| `GCT_SET_GAIN` | bus, `motor_id` (1–7), `gain_rad_per_nm` | Per-joint live gain update |
+| `GCT_SET_TORQUE_LIMIT` | bus, `torque_limit` | Global live torque-limit update (real register write) |
+| `GCT_SAVE_SETTINGS` | bus | Persists current staged settings to normfs |
+
+There are **two** separate normfs queues, each restored on backend startup
+for **display purposes only** — restoring never re-arms the control loop
+itself, since gravity comp actively drives motors the instant it starts, and
+silently re-enabling it after a restart with no fresh operator confirmation
+would be unsafe:
+
+- `motors_mirroring/gravity_comp_modes` — last known enabled/disabled state
+  per bus (`GravityCompModeEnvelope`).
+- `motors_mirroring/gravity_comp_settings` — last-saved per-joint gains +
+  torque limit per bus (`GravityCompSettingsEnvelope`), written only when
+  the operator explicitly saves (see below).
+
+## What we learned tuning this on real hardware
+
+- **The default gain is deliberately conservative and will feel like
+  nothing is happening at first.** At the default `0.05 rad/Nm`, a
+  horizontal-reach pose (`theta = [0, 1.5, 0, 0, 0, 0, 0]`) produces only
+  ~0.55 Nm at the shoulder — about 1.6° of commanded offset, tens of ticks,
+  well under the 60-tick default ceiling. Combined with the servo's own low
+  proportional gain (`ELROBOT_PID.p = 16`, chosen for backdrivability), this
+  is genuinely too weak to feel by hand. This is expected, not a bug — start
+  around 0.2–0.4 rad/Nm to actually feel it.
+
+- **A single global gain can't satisfy every joint.** Different joints see
+  very different gravity-torque magnitudes and hit the `max_offset_ticks`
+  saturation ceiling at different gains. This is why gain became a
+  `[f64; 7]` (per-joint) rather than one scalar, editable from a new column
+  in the motor table (see UI section).
+
+- **Saturated joints can drag their neighbors.** On hardware, running
+  joints 2/3/4 pinned at the ±60-tick ceiling under one high global gain
+  (0.6) caused joint 5 to visibly drift/rotate on its own, even though
+  joint 5's *own* computed offset was shrinking over the same interval.
+  Root cause: `goal = present_position + offset` is recomputed every cycle
+  from the servo's *just-measured* actual position, not a fixed reference —
+  and a joint's torque is computed via full forward kinematics of
+  everything upstream of it. If upstream joints are saturated (not holding,
+  slowly losing to gravity), the pose used to compute a downstream joint's
+  torque keeps shifting underneath it, so that joint keeps chasing a moving
+  target instead of settling at one fixed equilibrium, even while its own
+  offset value looks like it's converging. Net effect: it behaves more like
+  a slow rate command than a spring, for as long as the upstream saturation
+  persists.
+
+  Practical fix, confirmed to work: don't run all 7 joints at one high
+  gain. Lower the gain specifically on joints that are saturating (in this
+  case 2/3/4) so they stop pinning at the ceiling, and tune the rest
+  independently. This removes the "moving ground" the dragged joint was
+  chasing.
+
+- **The torque limit ceiling is a deliberate, non-adjustable safety
+  boundary, not a tuning parameter.** `TorqueLimit` here is capped in code
+  at 150 (`GRAVITY_COMP_TORQUE_LIMIT_CEILING`), on the servo's own 0–1000
+  effort scale (~15% of max), regardless of what's requested via the UI or
+  a config file. For comparison: normal mirrored/follower operation uses
+  500 (50%), and calibration sweeps use 300 (30%). Gravity comp is meant to
+  lightly assist a leader arm someone's hand is on, not fight them — the
+  ceiling is set well below what would make the arm hard to backdrive, and
+  raising it would be a deliberate safety tradeoff, not a routine tuning
+  change.
+
+## UI
+
+All of this lives in `software/station/clients/station-viewer/src/st3215/`.
+
+- **`BusCard.tsx`** — the "Gravity Comp" toggle button, next to the 3D/
+  camera view switch. Color-coded so its state is unambiguous: amber/filled
+  when enabled ("Gravity Comp: ON", with a pulsing dot), muted/outlined
+  when disabled. Disabled entirely if the bus is currently a mirroring
+  *follower* (gravity comp only makes sense on a backdrivable leader).
+  Next to it: a global **Torque Limit** number input (0–150, live —
+  changing it sends `GCT_SET_TORQUE_LIMIT` immediately, applied whether or
+  not gravity comp is currently running) and a **SAVE GRAVITY** button
+  (sends `GCT_SAVE_SETTINGS`).
+- **`MotorDataTable.tsx`** — a new **GRAV** column, inserted between the
+  existing MAX and STATUS columns, with one gain input (0.00–1.00) per arm
+  motor row (1–7). Motor 8 (gripper) shows `-` and is never editable, since
+  gravity comp never touches it. Editing a cell sends a per-motor
+  `GCT_SET_GAIN`. This table is shared across the 3D view
+  (`BusWebGLRenderer.tsx`) and the camera-first view (`RobotCameraView.tsx`)
+  — both were threaded with the same `gravityCompJointGains`/
+  `onGravityCompJointGainChange` props so the column appears consistently
+  wherever the motor table is shown for a gravity-comp-capable bus.
+- Changing the mirroring/"Web-controlled" source for a bus with gravity
+  comp enabled sends `GCT_STOP_GRAVITY_COMP` first
+  (`handleControlSourceChange`) — gravity comp and mirroring both write
+  `GoalPosition` continuously, so leaving both active on the same bus would
+  fight every ~20ms.
+
+## How settings are read and written
+
+Three layers, in order of persistence:
+
+1. **Live control-loop state** (in-memory, only while a task is running) —
+   `Arc<RwLock<[f64; 7]>>` for gains and `Arc<RwLock<u16>>` for torque
+   limit, owned by the running `GravityCompTask`. Read once per 20ms cycle.
+   Gone the instant the task stops.
+
+2. **Staged settings** (in-memory, per-bus, survives stop/start but not a
+   process restart) — a `HashMap<BusKey, GravitySettings>` in `lib.rs`,
+   populated lazily by `ensure_gravity_settings()` (first touch for a bus
+   seeds it from `Inference::gravity_comp_defaults()`, i.e. the config-file
+   default gain applied uniformly to all 7 joints). Every `GCT_SET_GAIN` /
+   `GCT_SET_TORQUE_LIMIT` command updates this map *unconditionally* — even
+   if gravity comp isn't currently running on that bus — and additionally
+   applies live to the running task if there is one
+   (`Inference::set_gravity_comp_gain`/`set_gravity_comp_torque_limit`,
+   returning whether it actually applied live). `GCT_START_GRAVITY_COMP`
+   always seeds the new task from this map rather than always resetting to
+   config defaults, so table edits made before pressing "Gravity Comp"
+   already take effect the moment it starts.
+
+3. **Saved settings** (on disk, via normfs, survives a restart) — only
+   written when the operator explicitly clicks **SAVE GRAVITY**
+   (`GCT_SAVE_SETTINGS` → `handle_save_gravity_comp_settings`), which reads
+   the current staged entry for that bus and enqueues a
+   `GravityCompSettingsEnvelope` onto the
+   `motors_mirroring/gravity_comp_settings` queue. No-op (logged) if
+   nothing has ever been staged for that bus. On the next backend startup,
+   this queue (and the separate `gravity_comp_modes` queue for the
+   enabled/disabled display state) is replayed to repopulate the in-memory
+   staged-settings map — restoring is display/pre-fill only; it never calls
+   `start_gravity_comp()` on its own. An explicit `GCT_START_GRAVITY_COMP`
+   command is always required to actually drive motors again after a
+   restart.
+
+Every state-changing command also triggers `merge_modes()`, which
+rebuilds and broadcasts `InferenceState.gravity_comp` (a
+`GravityCompBusState` per bus, carrying `joint_gains_rad_per_nm` and
+`torque_limit`) so every connected UI reflects the current staged/live
+values, not just the client that made the change.
+
+Not everything is exposed to the UI today. Per-joint `gain_rad_per_nm` and
+the global `torque_limit` are the only two live/UI-tunable knobs. The
+remaining `GravityCompConfig` fields — `max_offset_ticks` (60), the
+overcurrent `current_cutoff` (60), and `stale_cutoff_cycles` (5) — are
+config-file-only (`gravity-comp:` under `drivers.st3215` in the station YAML,
+see `software/station/shared/station-iface/src/config.rs`), set once at
+startup and not currently changeable while running.

--- a/protobufs/drivers/motors-mirroring/mirroring.proto
+++ b/protobufs/drivers/motors-mirroring/mirroring.proto
@@ -53,6 +53,8 @@ message RxEnvelope {
 
     InferenceState state   = 10;
     Command        command = 11;
+
+    GravityCompCommand gravity_command = 12;
 }
 
 message InferenceState {
@@ -69,4 +71,40 @@ message InferenceState {
 
     repeated Bus       modes     = 10;
     repeated Mirroring mirroring = 11;
+
+    repeated GravityCompBusState gravity_comp = 12;
+}
+
+// Gravity compensation is an orthogonal per-bus flag, independent of BusMode:
+// a bus can be BR_LEADER (mirroring source) and gravity-comp-enabled at the
+// same time, so this is modeled as its own enum/messages rather than a new
+// BusMode variant.
+enum GravityCompState {
+    GC_UNKNOWN  = 0;
+    GC_DISABLED = 1;
+    GC_ENABLED  = 2;
+}
+
+message GravityCompModeEnvelope {
+    uint64 monotonic_stamp_ns = 1;
+    uint64 local_stamp_ns     = 2;
+    uint64 app_start_id       = 3;
+
+    MirroringBus     bus   = 4;
+    GravityCompState state = 5;
+}
+
+enum GravityCompCommandType {
+    GCT_START_GRAVITY_COMP = 0;
+    GCT_STOP_GRAVITY_COMP  = 1;
+}
+
+message GravityCompCommand {
+    GravityCompCommandType type = 1;
+    MirroringBus            bus  = 2;
+}
+
+message GravityCompBusState {
+    MirroringBus     id    = 1;
+    GravityCompState state = 2;
 }

--- a/protobufs/drivers/motors-mirroring/mirroring.proto
+++ b/protobufs/drivers/motors-mirroring/mirroring.proto
@@ -97,26 +97,61 @@ message GravityCompModeEnvelope {
 enum GravityCompCommandType {
     GCT_START_GRAVITY_COMP = 0;
     GCT_STOP_GRAVITY_COMP  = 1;
-    // Live-updates the gain of an already-running gravity-comp task, without
-    // restarting it. No-op (logged) if gravity comp isn't running on `bus`.
+    // Live-updates the gain of one arm joint on an already-running
+    // gravity-comp task, without restarting it. Requires motor_id and
+    // gain_rad_per_nm. No-op (logged) if gravity comp isn't running on `bus`.
     GCT_SET_GAIN           = 2;
+    // Live-updates the torque limit (applies to all 7 arm motors), without
+    // restarting. Requires torque_limit. Unlike gain (a pure software
+    // multiplier), this re-sends the TorqueLimit register write immediately.
+    GCT_SET_TORQUE_LIMIT   = 3;
+    // Persists the bus's current per-joint gains and torque limit (whether
+    // running or not) so they're pre-filled as defaults next time gravity
+    // comp is started on this bus, surviving a station restart. This is
+    // display/pre-fill data only - saving never re-arms gravity comp itself.
+    GCT_SAVE_SETTINGS      = 4;
 }
 
 message GravityCompCommand {
     GravityCompCommandType type = 1;
     MirroringBus            bus  = 2;
 
-    // Nm-to-radian gain. For GCT_START_GRAVITY_COMP this optionally overrides
-    // the configured default starting gain; for GCT_SET_GAIN this is the new
-    // live value. Ignored for GCT_STOP_GRAVITY_COMP. Hard-clamped server-side
+    // GCT_SET_GAIN: the new gain for `motor_id`. Hard-clamped server-side
     // regardless of what's sent (see GRAVITY_COMP_GAIN_CEILING).
     optional double gain_rad_per_nm = 3;
+
+    // GCT_SET_GAIN: which arm motor (1-7) `gain_rad_per_nm` applies to.
+    optional uint32 motor_id = 4;
+
+    // GCT_SET_TORQUE_LIMIT: the new torque limit for all 7 arm motors.
+    // Hard-clamped server-side (see GRAVITY_COMP_TORQUE_LIMIT_CEILING).
+    optional uint32 torque_limit = 5;
 }
 
 message GravityCompBusState {
     MirroringBus     id    = 1;
     GravityCompState state = 2;
 
-    // Currently active gain, if gravity comp is running on this bus.
-    optional double gain_rad_per_nm = 3;
+    // Per-joint gains for the 7 arm motors, index 0..6 = rev_motor_01..07.
+    // Reflects live values while running, or the last-saved values
+    // (GCT_SAVE_SETTINGS) otherwise, so the UI has something sensible to
+    // show/edit even before gravity comp is started.
+    repeated double joint_gains_rad_per_nm = 4;
+
+    // Torque limit for all 7 arm motors - live value while running, or the
+    // last-saved value otherwise.
+    optional uint32 torque_limit = 5;
+}
+
+// Persisted per-bus gravity-comp tuning (motors_mirroring/gravity_comp_settings
+// queue). Restored on startup for display/pre-fill only - never re-arms
+// gravity comp itself, matching GravityCompModeEnvelope's restore semantics.
+message GravityCompSettingsEnvelope {
+    uint64 monotonic_stamp_ns = 1;
+    uint64 local_stamp_ns     = 2;
+    uint64 app_start_id       = 3;
+
+    MirroringBus    bus                     = 4;
+    repeated double joint_gains_rad_per_nm  = 5;
+    uint32          torque_limit             = 6;
 }

--- a/protobufs/drivers/motors-mirroring/mirroring.proto
+++ b/protobufs/drivers/motors-mirroring/mirroring.proto
@@ -97,14 +97,26 @@ message GravityCompModeEnvelope {
 enum GravityCompCommandType {
     GCT_START_GRAVITY_COMP = 0;
     GCT_STOP_GRAVITY_COMP  = 1;
+    // Live-updates the gain of an already-running gravity-comp task, without
+    // restarting it. No-op (logged) if gravity comp isn't running on `bus`.
+    GCT_SET_GAIN           = 2;
 }
 
 message GravityCompCommand {
     GravityCompCommandType type = 1;
     MirroringBus            bus  = 2;
+
+    // Nm-to-radian gain. For GCT_START_GRAVITY_COMP this optionally overrides
+    // the configured default starting gain; for GCT_SET_GAIN this is the new
+    // live value. Ignored for GCT_STOP_GRAVITY_COMP. Hard-clamped server-side
+    // regardless of what's sent (see GRAVITY_COMP_GAIN_CEILING).
+    optional double gain_rad_per_nm = 3;
 }
 
 message GravityCompBusState {
     MirroringBus     id    = 1;
     GravityCompState state = 2;
+
+    // Currently active gain, if gravity comp is running on this bus.
+    optional double gain_rad_per_nm = 3;
 }

--- a/protobufs/station/drivers.proto
+++ b/protobufs/station/drivers.proto
@@ -19,6 +19,7 @@ enum QueueDataType {
 
     QDT_MOTOR_MIRRORING_MODES = 30;
     QDT_MOTOR_MIRRORING_RX    = 32;
+    QDT_MOTOR_MIRRORING_GRAVITY_COMP_MODES = 33; // motors_mirroring.GravityCompModeEnvelope
 
     QDT_YAHBOOM_DOGZILLA_LITE_SERIAL_TX = 40; // yahboom_dogzilla_lite.TxEnvelope
     QDT_YAHBOOM_DOGZILLA_LITE_SERIAL_RX = 41; // yahboom_dogzilla_lite.RxEnvelope
@@ -30,4 +31,5 @@ enum StationCommandType {
     STC_MOTOR_MIRRORING_COMMAND = 1; // motors_mirroring.Command
     STC_INFERENCE_TAG_COMMAND   = 2; // inference_tags.Command
     STC_YAHBOOM_DOGZILLA_LITE_COMMAND        = 3; // yahboom_dogzilla_lite.Command
+    STC_GRAVITY_COMP_COMMAND    = 4; // motors_mirroring.GravityCompCommand
 }

--- a/protobufs/station/drivers.proto
+++ b/protobufs/station/drivers.proto
@@ -20,6 +20,7 @@ enum QueueDataType {
     QDT_MOTOR_MIRRORING_MODES = 30;
     QDT_MOTOR_MIRRORING_RX    = 32;
     QDT_MOTOR_MIRRORING_GRAVITY_COMP_MODES = 33; // motors_mirroring.GravityCompModeEnvelope
+    QDT_MOTOR_MIRRORING_GRAVITY_COMP_SETTINGS = 34; // motors_mirroring.GravityCompSettingsEnvelope
 
     QDT_YAHBOOM_DOGZILLA_LITE_SERIAL_TX = 40; // yahboom_dogzilla_lite.TxEnvelope
     QDT_YAHBOOM_DOGZILLA_LITE_SERIAL_RX = 41; // yahboom_dogzilla_lite.RxEnvelope

--- a/software/drivers/motors-mirroring/src/config.rs
+++ b/software/drivers/motors-mirroring/src/config.rs
@@ -7,8 +7,14 @@ pub const GRAVITY_COMP_REFRESH_INTERVAL: Duration = Duration::from_millis(20);
 
 /// Hard ceilings enforced in code regardless of what a config file supplies -
 /// a misconfigured value can never push the arm past these.
-const GRAVITY_COMP_TORQUE_LIMIT_CEILING: u16 = 150;
+pub const GRAVITY_COMP_TORQUE_LIMIT_CEILING: u16 = 150;
 const GRAVITY_COMP_MAX_OFFSET_TICKS_CEILING: u16 = 200;
+
+/// Clamps a torque limit (config-supplied or live from the UI) to the hard
+/// ceiling, independent of source.
+pub fn clamp_gravity_comp_torque_limit(value: u16) -> u16 {
+    value.min(GRAVITY_COMP_TORQUE_LIMIT_CEILING)
+}
 
 /// Hard ceiling on `gain_rad_per_nm`, including when set live from the UI
 /// (see `gravity_comp::GravityComp::set_gain`) - independent of any
@@ -60,7 +66,7 @@ impl GravityCompConfig {
     /// Clamp user-supplied values to hard safety ceilings - never trust
     /// configured values alone.
     pub fn clamped(mut self) -> Self {
-        self.torque_limit = self.torque_limit.min(GRAVITY_COMP_TORQUE_LIMIT_CEILING);
+        self.torque_limit = clamp_gravity_comp_torque_limit(self.torque_limit);
         self.max_offset_ticks = self.max_offset_ticks.min(GRAVITY_COMP_MAX_OFFSET_TICKS_CEILING);
         self.gain_rad_per_nm = clamp_gravity_comp_gain(self.gain_rad_per_nm);
         self

--- a/software/drivers/motors-mirroring/src/config.rs
+++ b/software/drivers/motors-mirroring/src/config.rs
@@ -10,6 +10,18 @@ pub const GRAVITY_COMP_REFRESH_INTERVAL: Duration = Duration::from_millis(20);
 const GRAVITY_COMP_TORQUE_LIMIT_CEILING: u16 = 150;
 const GRAVITY_COMP_MAX_OFFSET_TICKS_CEILING: u16 = 200;
 
+/// Hard ceiling on `gain_rad_per_nm`, including when set live from the UI
+/// (see `gravity_comp::GravityComp::set_gain`) - independent of any
+/// config-file value.
+pub const GRAVITY_COMP_GAIN_CEILING: f64 = 1.0;
+
+pub fn clamp_gravity_comp_gain(gain: f64) -> f64 {
+    if !gain.is_finite() {
+        return 0.0;
+    }
+    gain.clamp(0.0, GRAVITY_COMP_GAIN_CEILING)
+}
+
 #[derive(Clone)]
 pub struct MotorConfig {
     pub safety_margin: u16,
@@ -50,6 +62,7 @@ impl GravityCompConfig {
     pub fn clamped(mut self) -> Self {
         self.torque_limit = self.torque_limit.min(GRAVITY_COMP_TORQUE_LIMIT_CEILING);
         self.max_offset_ticks = self.max_offset_ticks.min(GRAVITY_COMP_MAX_OFFSET_TICKS_CEILING);
+        self.gain_rad_per_nm = clamp_gravity_comp_gain(self.gain_rad_per_nm);
         self
     }
 }

--- a/software/drivers/motors-mirroring/src/config.rs
+++ b/software/drivers/motors-mirroring/src/config.rs
@@ -2,6 +2,14 @@ use std::{collections::HashMap, time::Duration};
 
 pub const MIRRORING_REFRESH_INTERVAL: Duration = Duration::from_millis(20);
 
+/// Gravity compensation runs at the same cadence as mirroring.
+pub const GRAVITY_COMP_REFRESH_INTERVAL: Duration = Duration::from_millis(20);
+
+/// Hard ceilings enforced in code regardless of what a config file supplies -
+/// a misconfigured value can never push the arm past these.
+const GRAVITY_COMP_TORQUE_LIMIT_CEILING: u16 = 150;
+const GRAVITY_COMP_MAX_OFFSET_TICKS_CEILING: u16 = 200;
+
 #[derive(Clone)]
 pub struct MotorConfig {
     pub safety_margin: u16,
@@ -18,6 +26,45 @@ pub struct MotorConfig {
     /// Per-motor current threshold overrides. Key is motor_id (0-255).
     /// If a motor_id is in this map, its value overrides the default current_threshold.
     pub per_motor_current_threshold: HashMap<u8, u16>,
+    pub gravity_comp: GravityCompConfig,
+}
+
+/// Tunables for the leader-arm gravity compensation control loop.
+///
+/// `gain_rad_per_nm` cannot be derived analytically from the ST3215's internal
+/// PID coefficients (they're in undocumented firmware units) - it must be
+/// tuned empirically on real hardware, starting near zero and increasing
+/// until the arm feels weightless without oscillating.
+#[derive(Clone, Copy)]
+pub struct GravityCompConfig {
+    pub gain_rad_per_nm: f64,
+    pub max_offset_ticks: u16,
+    pub torque_limit: u16,
+    pub current_cutoff: u16,
+    pub stale_cutoff_cycles: u32,
+}
+
+impl GravityCompConfig {
+    /// Clamp user-supplied values to hard safety ceilings - never trust
+    /// configured values alone.
+    pub fn clamped(mut self) -> Self {
+        self.torque_limit = self.torque_limit.min(GRAVITY_COMP_TORQUE_LIMIT_CEILING);
+        self.max_offset_ticks = self.max_offset_ticks.min(GRAVITY_COMP_MAX_OFFSET_TICKS_CEILING);
+        self
+    }
+}
+
+impl Default for GravityCompConfig {
+    fn default() -> Self {
+        Self {
+            gain_rad_per_nm: 0.05,
+            max_offset_ticks: 60,
+            torque_limit: 100,
+            current_cutoff: 60,
+            stale_cutoff_cycles: 5,
+        }
+        .clamped()
+    }
 }
 
 impl MotorConfig {
@@ -53,16 +100,30 @@ impl Default for MotorConfig {
             max_steps: 4096,
             current_threshold: 100, // enabled by default with threshold of 100
             per_motor_current_threshold: HashMap::new(),
+            gravity_comp: GravityCompConfig::default(),
         }
     }
 }
 
 impl From<&station_iface::config::St3215Config> for MotorConfig {
     fn from(config: &station_iface::config::St3215Config) -> Self {
+        let gravity_comp = config
+            .gravity_comp
+            .as_ref()
+            .map(|gc| GravityCompConfig {
+                gain_rad_per_nm: gc.gain_rad_per_nm,
+                max_offset_ticks: gc.max_offset_ticks,
+                torque_limit: gc.torque_limit,
+                current_cutoff: gc.current_cutoff,
+                stale_cutoff_cycles: gc.stale_cutoff_cycles,
+            }.clamped())
+            .unwrap_or_default();
+
         Self {
             current_threshold: config.current_threshold,
             deadband: config.deadband,
             per_motor_current_threshold: config.motor_current_thresholds.clone().unwrap_or_default(),
+            gravity_comp,
             ..Default::default()
         }
     }

--- a/software/drivers/motors-mirroring/src/gravity_comp/CLAUDE.md
+++ b/software/drivers/motors-mirroring/src/gravity_comp/CLAUDE.md
@@ -1,0 +1,131 @@
+# Gravity Compensation
+
+Opt-in mode that makes the ElRobot leader arm hold its pose against gravity
+while remaining easy to move by hand, instead of the default fully
+torque-disabled ("floppy") leader behavior. Toggled from the "Gravity Comp"
+button in station-viewer's `BusCard.tsx`, scoped to whichever bus that's
+clicked on — independent of whether that bus is currently mirroring to a
+follower.
+
+## The constraint that shapes everything here
+
+Feetech ST3215 servos have **no native torque/current-setpoint register** —
+only a position-control loop with a `TorqueLimit` effort clamp
+(`software/drivers/st3215/src/protocol/memory.rs`). There is no way to tell a
+motor "apply 0.4 Nm"; you can only tell it "go to position X" and "don't push
+harder than Y". So gravity compensation is *approximated*: every 20ms, compute
+how hard gravity is currently pulling on each joint, then nudge
+`GoalPosition` a little further in that same direction. The servo's own
+internal position gain then supplies a restoring torque roughly proportional
+to that offset — a virtual spring, not a real torque source. This only
+approximates *static* holding torque; it is not a substitute for real
+closed-loop torque control and will not behave correctly under fast dynamic
+motion.
+
+## Module layout
+
+- **`elrobot_dynamics.rs`** — static data tables (joint origins/axes/limits,
+  per-link mass and center-of-mass) extracted by hand from
+  `hardware/elrobot/simulation/elrobot_follower.urdf`, plus
+  `forward_kinematics()` and `gravity_torques()`. Gravity torque is computed
+  via the virtual-work / Jacobian-transpose method: for each joint, sum the
+  moment every *outboard* link's weight exerts about that joint's axis. No
+  inertia tensors or velocity terms — this is a static model only.
+- **`kinematics.rs`** — minimal hand-rolled `Vec3`/`Mat3` (Rodrigues rotation).
+  No `nalgebra`/`urdf-rs` dependency: the chain is fixed at 7 joints and the
+  math is small enough to hand-roll, matching this codebase's existing style
+  (see `st3215::protocol::units`'s manual bit-twiddling).
+- **`control.rs`** — the control law: raw servo ticks → joint angle (mirrors
+  the frontend's `resolveElrobotJointValue` sign convention exactly), and
+  torque → clamped `GoalPosition` offset using each motor's *live calibrated*
+  range (not a fixed tick-per-radian constant).
+- **`mod.rs`** — orchestration: per-bus background task lifecycle
+  (`GravityComp::start`/`stop`), the 20ms control loop, and the safety
+  cutoffs (below). This is also where `MotorCommand::TorqueLimit` gets sent
+  before `Torque(1)` on start, and torque gets disabled + `TorqueLimit`
+  restored to the ST3215 default on stop.
+
+## Known approximations (deliberate, not bugs)
+
+- **Follower masses, not leader masses.** The URDF models the *follower*
+  arm's servos (12V/30kg). The leader uses physically lighter,
+  different-gear-ratio servos (per the hardware BOM) chosen for
+  backdrivability. Reusing follower link masses is a first-pass
+  approximation — `gain_rad_per_nm` (see Tuning below) is the intended lever
+  for correcting the residual error on real hardware, not this mass table.
+- **Lumped gripper tip.** Motor 8 (gripper) and its gear/jaws are collapsed
+  into one fixed point mass attached at the `ST3215_8_v1_1` frame, rather
+  than modeled per-gripper-angle. The URDF's inertial data for the jaw links
+  contains physically implausible offsets (larger than the arm's own 430mm
+  reach — a known artifact of this URDF's CAD export for prismatic/mimic
+  joints), so those numbers aren't usable directly. Motor 8 itself is never
+  enabled or commanded by gravity comp in either direction.
+- **ElRobot only.** SO101 has no mass/inertia data checked into this repo, so
+  it isn't supported. Gating is in the frontend's
+  `devices/registry.ts::supportsGravityComp()`.
+- **Gravity is assumed along -Z in the URDF's own base frame** — consistent
+  with joint 1's axis being ~(0,0,1) (a base "yaw" joint on an arm bolted to
+  a table, output shaft vertical). If a future arm variant is mounted
+  differently, this assumption needs revisiting.
+
+## Command / mode plumbing
+
+Modeled as an **orthogonal per-bus boolean**, entirely separate from
+`BusMode` (`BR_LEADER`/`BR_FOLLOWER`) — a bus can be a mirroring leader *and*
+gravity-comp'd at the same time, so this is not a `BusMode` variant. See
+`GravityCompState`/`GravityCompCommand`/`GravityCompBusState` in
+`protobufs/drivers/motors-mirroring/mirroring.proto`, routed via its own
+`StationCommandType::STC_GRAVITY_COMP_COMMAND` (a dedicated command type
+rather than overloading `STC_MOTOR_MIRRORING_COMMAND`, to avoid proto3
+decode ambiguity between two different message shapes on the same wire
+type). Handlers live in `../lib.rs`
+(`handle_start_gravity_comp`/`handle_stop_gravity_comp`/
+`deactivate_gravity_comp`).
+
+Mode *state* is persisted to its own normfs queue
+(`motors_mirroring/gravity_comp_modes`) and restored on backend restart for
+**display purposes only** — restoring never calls `start_gravity_comp()`
+again. Unlike mirroring pairs (inert until a live loop reads fresh leader
+data), gravity comp actively drives motors the instant its task starts, so
+silently re-arming it after a restart with no fresh operator confirmation
+would be unsafe. An explicit command is always required to (re-)enable it.
+
+## Safety cutoffs (all in `mod.rs::run_control_loop`)
+
+- **Staleness**: if `st3215/inference` data for the bus goes stale
+  (`MAX_DATA_AGE_NS`, shared with the mirroring loop) for
+  `stale_cutoff_cycles` consecutive iterations, hard torque-off — not "hold
+  last goal".
+- **Overcurrent**: if any arm motor's current exceeds `current_cutoff` for
+  `stale_cutoff_cycles` consecutive cycles, hard torque-off. Below that
+  threshold, the whole arm holds position that cycle rather than sending new
+  goals.
+- **Self-stop notification**: either cutoff calls `on_self_stop`, a callback
+  wired in `lib.rs` that reuses the exact same teardown path as an
+  operator-issued stop command (`deactivate_gravity_comp`), so the mode
+  displayed in the UI never drifts from what's actually running.
+- **Hard ceilings independent of config**: `GravityCompConfig::clamped()` in
+  `../config.rs` clamps `torque_limit`/`max_offset_ticks` to fixed ceilings
+  regardless of what a YAML config supplies.
+
+## Tuning
+
+`gain_rad_per_nm` (in `GravityCompConfig`, default `0.05`) cannot be derived
+from the ST3215's internal PID coefficients — those are undocumented
+firmware units. It must be tuned empirically on real hardware: start low,
+increase until the arm feels weightless without oscillating. Configurable
+via `gravity-comp:` under `drivers.st3215` in the station YAML config (see
+`software/station/shared/station-iface/src/config.rs::GravityCompConfig`).
+
+## Testing
+
+Unit tests cover the dynamics/control math only (no hardware needed):
+`cargo test -p motors-mirroring`. They check things like joint 1's
+near-vertical axis producing ~0 gravity torque, and shoulder torque growing
+with horizontal reach — sanity checks on the sign/axis conventions, not a
+substitute for on-arm validation.
+
+**Not yet tested on real hardware**: a bus simultaneously gravity-comp'd and
+mirrored to a follower. This is a genuinely new code path — before this
+module existed, `Inference` never wrote `GoalPosition` to a *source* bus's
+own motors, only to *targets*.

--- a/software/drivers/motors-mirroring/src/gravity_comp/CLAUDE.md
+++ b/software/drivers/motors-mirroring/src/gravity_comp/CLAUDE.md
@@ -110,12 +110,42 @@ would be unsafe. An explicit command is always required to (re-)enable it.
 
 ## Tuning
 
-`gain_rad_per_nm` (in `GravityCompConfig`, default `0.05`) cannot be derived
-from the ST3215's internal PID coefficients — those are undocumented
-firmware units. It must be tuned empirically on real hardware: start low,
-increase until the arm feels weightless without oscillating. Configurable
-via `gravity-comp:` under `drivers.st3215` in the station YAML config (see
-`software/station/shared/station-iface/src/config.rs::GravityCompConfig`).
+`gain_rad_per_nm` (in `GravityCompConfig`, default `0.05`, hard ceiling
+`GRAVITY_COMP_GAIN_CEILING = 1.0` in `../config.rs`) cannot be derived from
+the ST3215's internal PID coefficients — those are undocumented firmware
+units. It must be tuned empirically on real hardware: start low, increase
+until the arm feels weightless without oscillating.
+
+**Live, from the UI, without a restart** — this is the expected way to tune
+it day-to-day. The "Gravity Comp" button in `BusCard.tsx` has a gain input
+next to it. While gravity comp is running, changing that value sends a
+`GCT_SET_GAIN` command that updates the running control loop's gain
+in-place (`GravityComp::set_gain` → `Arc<RwLock<f64>>` read once per 20ms
+cycle in `run_control_loop`, not re-read from the static `MotorConfig`).
+Starting gravity comp also accepts an optional initial gain override on the
+`GCT_START_GRAVITY_COMP` command, so the UI's current input value is used
+immediately rather than always falling back to the config default. The
+active gain is broadcast back in `GravityCompBusState.gain_rad_per_nm` so
+the UI reflects reality (e.g. after a page reload) rather than only its own
+locally-remembered value.
+
+Since the default gain is quite conservative, a fresh install will likely
+feel like *nothing is happening* at first — this is expected, not a bug; see
+the worked example below.
+
+**Config-file default** (used only as the starting point before any live
+override): `gravity-comp:` under `drivers.st3215` in the station YAML config
+(see `software/station/shared/station-iface/src/config.rs::GravityCompConfig`).
+
+**Sanity-checking the numbers**: for a horizontal-reach pose
+(`theta = [0, 1.5, 0, 0, 0, 0, 0]`), `gravity_torques()` gives roughly
+0.55 Nm at the shoulder (joint 2), the largest of any joint. At the default
+gain (0.05 rad/Nm) that's only ~0.028 rad (~1.6°) of commanded offset —
+tens of ticks, well under `max_offset_ticks` (60) — combined with the
+servo's own low proportional gain (`ELROBOT_PID.p = 16`, chosen for
+backdrivability) this can be too weak to feel by hand. Try roughly
+0.2–0.4 rad/Nm as a more noticeable starting point, watch for oscillation,
+and back off if the arm hunts/vibrates rather than settling.
 
 ## Testing
 

--- a/software/drivers/motors-mirroring/src/gravity_comp/CLAUDE.md
+++ b/software/drivers/motors-mirroring/src/gravity_comp/CLAUDE.md
@@ -142,26 +142,59 @@ the ST3215's internal PID coefficients — those are undocumented firmware
 units. It must be tuned empirically on real hardware: start low, increase
 until the arm feels weightless without oscillating.
 
+**Per-joint, not global.** A single gain cannot satisfy every joint at once —
+different joints carry very different gravity-torque magnitudes and see the
+saturating `max_offset_ticks` clamp at different points. `gain_rad_per_nm` is
+therefore a `[f64; 7]` (`JointGains`, one value per arm motor 1-7), not a
+scalar. A saturated joint doesn't just fail to hold its own pose — through
+the rigid kinematic chain it can drag an unsaturated downstream joint along
+with it (observed on hardware: joints 2/3/4 pinned at the ±60-tick ceiling
+under a high global gain caused joint 5 to drift/rotate on its own even
+though its individual offset was shrinking). Lowering the gain on the
+saturating upstream joints, rather than raising the downstream one further,
+is the fix.
+
 **Live, from the UI, without a restart** — this is the expected way to tune
-it day-to-day. The "Gravity Comp" button in `BusCard.tsx` has a gain input
-next to it. While gravity comp is running, changing that value sends a
-`GCT_SET_GAIN` command that updates the running control loop's gain
-in-place (`GravityComp::set_gain` → `Arc<RwLock<f64>>` read once per 20ms
-cycle in `run_control_loop`, not re-read from the static `MotorConfig`).
-Starting gravity comp also accepts an optional initial gain override on the
-`GCT_START_GRAVITY_COMP` command, so the UI's current input value is used
-immediately rather than always falling back to the config default. The
-active gain is broadcast back in `GravityCompBusState.gain_rad_per_nm` so
-the UI reflects reality (e.g. after a page reload) rather than only its own
+it day-to-day. `MotorDataTable.tsx` has a "GRAV" column (between MAX and
+STATUS) with one gain input per arm motor (1-7; the gripper, motor 8, shows
+"-" and is never editable). Changing a value sends a per-motor `GCT_SET_GAIN`
+command (`motor_id` + `gain_rad_per_nm`) that always updates the staged
+per-bus `GravitySettings` server-side, and additionally updates the running
+control loop in-place if gravity comp is currently enabled
+(`GravityComp::set_gain` → `Arc<RwLock<JointGains>>`, indexed by
+`motor_id_to_index`, read once per 20ms cycle in `run_control_loop` — never
+re-read from the static `MotorConfig`). `BusCard.tsx` also has a global
+"Torque Limit" input (`GCT_SET_TORQUE_LIMIT`) next to the "Gravity Comp"
+toggle — unlike gain, this is real hardware register state, so setting it
+immediately re-sends a `TorqueLimit` write regardless of whether the loop is
+running. Starting gravity comp (`GCT_START_GRAVITY_COMP`) never carries a
+gain/torque-limit payload itself; the backend always seeds the new task from
+whatever is currently staged for that bus (`ensure_gravity_settings` in
+`../lib.rs`, falling back to `Inference::gravity_comp_defaults()` if nothing
+has ever been staged). The active values are broadcast back in
+`GravityCompBusState.joint_gains_rad_per_nm`/`torque_limit` so the UI
+reflects reality (e.g. after a page reload) rather than only its own
 locally-remembered value.
+
+**Persisting across restarts**: staged edits (per-joint gains and torque
+limit) live only in the in-memory `gravity_settings` map until the operator
+clicks "SAVE GRAVITY" (`BusCard.tsx` → `GCT_SAVE_SETTINGS` →
+`handle_save_gravity_comp_settings` in `../lib.rs`), which writes a
+`GravityCompSettingsEnvelope` to its own normfs queue
+(`motors_mirroring/gravity_comp_settings`). That queue is restored on
+startup the same way the gravity-comp *mode* queue is — display/pre-fill
+only, so a restart shows the last-saved values in the table without ever
+re-arming the control loop itself.
 
 Since the default gain is quite conservative, a fresh install will likely
 feel like *nothing is happening* at first — this is expected, not a bug; see
 the worked example below.
 
-**Config-file default** (used only as the starting point before any live
-override): `gravity-comp:` under `drivers.st3215` in the station YAML config
-(see `software/station/shared/station-iface/src/config.rs::GravityCompConfig`).
+**Config-file default** (used only as the starting point before anything has
+ever been staged/saved for a bus): `gravity-comp:` under `drivers.st3215` in
+the station YAML config (see
+`software/station/shared/station-iface/src/config.rs::GravityCompConfig`) —
+applied uniformly to all 7 joints via `Inference::gravity_comp_defaults()`.
 
 **Sanity-checking the numbers**: for a horizontal-reach pose
 (`theta = [0, 1.5, 0, 0, 0, 0, 0]`), `gravity_torques()` gives roughly

--- a/software/drivers/motors-mirroring/src/gravity_comp/CLAUDE.md
+++ b/software/drivers/motors-mirroring/src/gravity_comp/CLAUDE.md
@@ -107,6 +107,32 @@ would be unsafe. An explicit command is always required to (re-)enable it.
 - **Hard ceilings independent of config**: `GravityCompConfig::clamped()` in
   `../config.rs` clamps `torque_limit`/`max_offset_ticks` to fixed ceilings
   regardless of what a YAML config supplies.
+- **Explicit shutdown**: `Inference::stop_all_gravity_comp()` (called from
+  `station`'s `Station::shutdown()` in `main.rs`, via the `Arc<Inference>`
+  now returned by `motors_mirroring::start()`) stops every running task and
+  disables torque before the process exits, rather than relying on implicit
+  task-drop when the tokio runtime tears down.
+- **Mutual exclusion with other GoalPosition writers**: gravity comp and
+  mirroring/"Web-controlled" both continuously write `GoalPosition` to the
+  same bus's motors, so leaving both active fights every ~20ms. The frontend
+  (`BusCard.tsx::handleControlSourceChange`) sends `GCT_STOP_GRAVITY_COMP`
+  first whenever the control-source dropdown changes for a bus with gravity
+  comp enabled.
+
+## A reentrancy pitfall already avoided here
+
+`GravityComp::start()`/`stop()` are invoked synchronously from
+`lib.rs::process_command_pack`, which is itself the "commands" normfs
+queue's own subscription callback. `send_setup_commands`/
+`send_teardown_commands` call `Inference::send_st3215_commands`, which
+enqueues onto that *same* "commands" queue. Calling them inline would
+re-enter that queue's enqueue/subscribe machinery from within its own
+callback stack. Both are deferred onto their own `tokio::spawn`'d task to
+break that reentrancy — matching the pattern `Inference::start`/`stop`
+already use for mirroring's equivalent sends. If you add a new gravity-comp
+code path that calls `send_st3215_commands` (or anything that calls
+`normfs.enqueue` on the commands queue) from a handler in `lib.rs`, defer it
+the same way rather than calling it inline.
 
 ## Tuning
 
@@ -159,3 +185,14 @@ substitute for on-arm validation.
 mirrored to a follower. This is a genuinely new code path — before this
 module existed, `Inference` never wrote `GoalPosition` to a *source* bus's
 own motors, only to *targets*.
+
+**On-hardware diagnostics**: `run_control_loop` logs a rate-limited (once/
+second, not every 20ms cycle) summary at `INFO` level covering exactly what
+each branch is doing that cycle - staleness, which motor IDs are missing (if
+any), overcurrent readings per motor, and for the normal path, each motor's
+computed gravity torque/offset/goal and whether commands were actually sent.
+Check the `station` process's own log output (not the browser console) when
+gravity comp seems to have no effect - this tells you definitively whether
+the loop is stuck waiting on motor data, tripping the overcurrent cutoff, or
+genuinely sending goals that are just too small to feel (a gain problem, not
+a code problem).

--- a/software/drivers/motors-mirroring/src/gravity_comp/control.rs
+++ b/software/drivers/motors-mirroring/src/gravity_comp/control.rs
@@ -1,0 +1,87 @@
+//! Control law converting a computed gravity torque (Nm) into a servo
+//! `GoalPosition` offset, using the ST3215's position loop as an implicit
+//! spring (the servo has no native torque/current setpoint register).
+
+use crate::config::MotorConfig;
+use crate::inference::normalize;
+
+/// Ticks per radian for a given motor's *live calibrated* range, derived
+/// from its known URDF joint angle limits rather than a fixed global
+/// constant - the calibrated range on a real unit rarely matches the servo's
+/// full 4096-tick sweep exactly.
+pub fn ticks_per_radian(range_min: u16, range_max: u16, joint_lower: f64, joint_upper: f64, config: &MotorConfig) -> f64 {
+    let angular_range = (joint_upper - joint_lower).abs();
+    if angular_range < 1e-9 {
+        return 0.0;
+    }
+    let range_size = normalize::get_steps_range(range_min, range_max, config) as f64;
+    range_size / angular_range
+}
+
+/// Raw present-position ticks -> joint angle (radians), mirroring the exact
+/// convention the frontend uses in `devices/elrobot/config.ts`'s
+/// `resolveElrobotJointValue`: normalize into the calibrated range, map
+/// through the URDF joint limits, then flip (`upper - position`).
+pub fn raw_to_joint_angle(
+    present_position: u16,
+    range_min: u16,
+    range_max: u16,
+    joint_lower: f64,
+    joint_upper: f64,
+    config: &MotorConfig,
+) -> f64 {
+    let normalized = normalize::normalize_position(present_position, range_min, range_max, config) / 100.0;
+    let joint_position = joint_lower + normalized * (joint_upper - joint_lower);
+    joint_upper - joint_position
+}
+
+/// Converts a computed gravity torque into a clamped `GoalPosition` tick
+/// offset to add to `present_position`.
+///
+/// The offset is a small bias in the direction gravity is pulling the joint,
+/// proportional to how hard it's pulling: the servo's internal position loop
+/// then supplies a restoring torque proportional to that bias, approximating
+/// the needed holding torque. Sign is flipped to match the same
+/// `upper - joint_position` inversion used by `raw_to_joint_angle`.
+pub fn gravity_torque_to_goal_offset_ticks(tau_nm: f64, gain_rad_per_nm: f64, max_offset_ticks: u16, ticks_per_radian: f64) -> i32 {
+    let delta_theta_rad = gain_rad_per_nm * tau_nm;
+    let delta_ticks = -(delta_theta_rad * ticks_per_radian);
+    let max = max_offset_ticks as f64;
+    delta_ticks.clamp(-max, max).round() as i32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> MotorConfig {
+        MotorConfig::default()
+    }
+
+    #[test]
+    fn zero_torque_produces_zero_offset() {
+        let tpr = ticks_per_radian(0, 4000, -1.5, 1.5, &test_config());
+        assert_eq!(gravity_torque_to_goal_offset_ticks(0.0, 0.05, 60, tpr), 0);
+    }
+
+    #[test]
+    fn offset_is_clamped_to_max() {
+        let tpr = ticks_per_radian(0, 4000, -1.5, 1.5, &test_config());
+        let offset = gravity_torque_to_goal_offset_ticks(1000.0, 0.05, 60, tpr);
+        assert_eq!(offset.unsigned_abs(), 60);
+    }
+
+    #[test]
+    fn raw_to_joint_angle_matches_endpoints() {
+        let config = test_config();
+        // present_position == range_min -> normalized 0 -> joint_position ==
+        // joint_lower -> angle == upper - lower.
+        let angle_at_min = raw_to_joint_angle(1000, 1000, 3000, -1.0, 1.0, &config);
+        assert!((angle_at_min - 2.0).abs() < 1e-9);
+
+        // present_position == range_max -> normalized 100 -> joint_position ==
+        // joint_upper -> angle == 0.
+        let angle_at_max = raw_to_joint_angle(3000, 1000, 3000, -1.0, 1.0, &config);
+        assert!(angle_at_max.abs() < 1e-9);
+    }
+}

--- a/software/drivers/motors-mirroring/src/gravity_comp/elrobot_dynamics.rs
+++ b/software/drivers/motors-mirroring/src/gravity_comp/elrobot_dynamics.rs
@@ -1,0 +1,255 @@
+//! Static gravity-dynamics model for the ElRobot 7-DOF arm, extracted from
+//! `hardware/elrobot/simulation/elrobot_follower.urdf`.
+//!
+//! Only mass and center-of-mass (CoM) data is needed for a *static* gravity
+//! torque (no inertia tensors, no velocity/acceleration terms) - this models
+//! how hard gravity pulls on each joint while the arm is held still or moved
+//! slowly, which is what "gravity compensation" needs.
+//!
+//! KNOWN APPROXIMATIONS (documented, not bugs):
+//! - The URDF models the follower arm's servos (12V/30kg). The leader uses
+//!   physically lighter, different-gear-ratio servos (per the hardware BOM),
+//!   so link masses are a first-pass approximation. The empirically-tuned
+//!   `gain_rad_per_nm` (see `config::GravityCompConfig`) is the intended lever
+//!   for correcting residual error on real hardware, not this mass table.
+//! - The gripper subassembly (ST3215_8_v1_1 housing + gear + both jaws) is
+//!   lumped into a single fixed point mass attached rigidly at the
+//!   Gripper_Base output frame (motor 8's own position), rather than modeled
+//!   per-gripper-angle. The URDF's inertial `<origin>` data for the jaw links
+//!   contains clearly implausible values (offsets larger than the arm's own
+//!   430mm reach - a known artifact of this URDF's CAD export for
+//!   prismatic/mimic joints), so those numbers are not usable directly; a
+//!   fixed lumped mass at the gripper attachment point is the defensible
+//!   approximation given the gripper is compact relative to the rest of the
+//!   arm. Motor 8 itself is never enabled/commanded by gravity compensation
+//!   in either direction.
+//! - Gravity is assumed to act along -Z in this URDF's own base_link frame,
+//!   consistent with joint 1's axis being ~(0,0,1) (a base "yaw" joint on an
+//!   arm bolted to a table with its output shaft vertical).
+
+use super::kinematics::{Mat3, Vec3};
+
+pub const GRAVITY_MPS2: f64 = 9.81;
+
+/// Number of actuated (compensated) joints: rev_motor_01..rev_motor_07.
+pub const JOINT_COUNT: usize = 7;
+
+/// Number of gravity-relevant mass points (link brackets/housings + the
+/// lumped gripper tip). Excludes `base_link` and `ST3215_1_v1_1`, which are
+/// inboard of joint 1 and so never contribute torque to any actuated joint.
+const LINK_COUNT: usize = 14;
+
+/// Translation (parent frame -> child frame) for each `fixed` joint in the
+/// chain, in URDF order: Rigid1, Rigid3, Rigid7, Rigid9, Rigid11, Rigid13,
+/// Rigid15, Rigid17. All have `rpy="0 0 0"` so no rotation is needed.
+const FIXED_OFFSETS: [Vec3; 8] = [
+    Vec3::new(0.0, 0.007585, 0.0315),         // Rigid 1: base_link -> ST3215_1_v1_1
+    Vec3::new(0.000625, -0.000058, 0.0067),   // Rigid 3: Joint_01_1 -> ST3215_2_v1_1
+    Vec3::new(0.019863, -0.000487, 0.055827), // Rigid 7: Joint_02_1 -> ST3215_3_v1_1
+    Vec3::new(0.021263, 0.001933, 0.036403),  // Rigid 9: Joint_03_v1_1 -> ST3215_4_v1_1
+    Vec3::new(0.020391, 0.065663, -0.010035), // Rigid 11: Joint_04_v1_1 -> ST3215_5_v1_1
+    Vec3::new(0.000065, 0.0075, -0.000001),   // Rigid 13: Joint_05_v1_1 -> ST3215_6_v1_1
+    Vec3::new(0.020478, 0.038023, -0.010611), // Rigid 15: Joint_06_v1_1 -> ST3215_7_v1_1
+    Vec3::new(0.000776, 0.045242, -0.000409), // Rigid 17: Gripper_Base_v1_1 -> ST3215_8_v1_1 (lumped tip attach point)
+];
+
+/// Joint pivot origin (relative to the preceding housing frame), in URDF
+/// order rev_motor_01..rev_motor_07.
+const JOINT_ORIGIN_LOCAL: [Vec3; JOINT_COUNT] = [
+    Vec3::new(0.0, 0.034904, 0.017505),
+    Vec3::new(-0.020293, -0.000308, 0.035233),
+    Vec3::new(-0.019985, -0.000309, 0.035408),
+    Vec3::new(-0.02029, 0.035229, 0.000662),
+    Vec3::new(0.000323, 0.0172, 0.010051),
+    Vec3::new(-0.019988, 0.035407, 0.000351),
+    Vec3::new(0.000473, 0.017284, 0.009899),
+];
+
+/// Joint rotation axis, expressed in the joint's own (parent-aligned, since
+/// all joint `rpy` are zero) frame, as given directly in the URDF `<axis>`.
+const JOINT_AXIS_LOCAL: [Vec3; JOINT_COUNT] = [
+    Vec3::new(0.0, -0.008727, 0.999962),
+    Vec3::new(-0.999962, -0.000076, 0.008726),
+    Vec3::new(-0.999848, -0.000152, 0.017452),
+    Vec3::new(-0.99981, 0.008574, 0.017527),
+    Vec3::new(-0.008573, -0.999963, 0.000151),
+    Vec3::new(-0.999697, 0.0173, 0.017525),
+    Vec3::new(-0.017144, -0.999812, 0.009029),
+];
+
+/// (lower, upper) joint angle limits in radians, matching the URDF `<limit>`
+/// and the same convention `resolveElrobotJointValue` uses on the frontend
+/// (`devices/elrobot/config.ts`).
+pub const JOINT_LIMITS_RAD: [(f64, f64); JOINT_COUNT] = [
+    (-1.5509, 1.5509),
+    (-1.6122, 1.6122),
+    (-1.7610, 1.7610),
+    (-1.7533, 1.7533),
+    (-2.62, 3.252),
+    (-1.3775, 1.7641),
+    (-3.2014, 2.7336),
+];
+
+/// CoM offset within each link's own frame (URDF `<inertial><origin>`, all
+/// `rpy="0 0 0"`), in chain order:
+/// L1=Joint_01_1, L2=ST3215_2_v1_1, L3=Joint_02_1, L4=ST3215_3_v1_1,
+/// L5=Joint_03_v1_1, L6=ST3215_4_v1_1, L7=Joint_04_v1_1, L8=ST3215_5_v1_1,
+/// L9=Joint_05_v1_1, L10=ST3215_6_v1_1, L11=Joint_06_v1_1, L12=ST3215_7_v1_1,
+/// L13=Gripper_Base_v1_1, L14=lumped gripper tip (placed exactly at the
+/// ST3215_8_v1_1 frame origin, so no further local offset).
+const LINK_COM_LOCAL: [Vec3; LINK_COUNT] = [
+    Vec3::new(0.00019293358229791917, 0.01053544085767251, -0.002903406181002266),
+    Vec3::new(-0.0014235768458915805, -0.00019407288276004214, 0.02268943356342234),
+    Vec3::new(0.020187292657891796, -0.0003607149418271213, 0.04048886553547183),
+    Vec3::new(-0.0012258665484379326, -0.00019383890721715036, 0.02270059947453923),
+    Vec3::new(0.021383489206350224, 0.0025973738142313213, 0.028573272567347596),
+    Vec3::new(-0.0014236012890871546, 0.022688801414757966, 0.00021876985314867037),
+    Vec3::new(0.02041469568271767, 0.04634775018812741, 0.0004733773672222219),
+    Vec3::new(0.00038301708111886123, -0.001621005306100043, 0.022431224025462493),
+    Vec3::new(-0.0014511731912585726, 0.014886171505002432, 0.00023918947669937518),
+    Vec3::new(-0.0012292541520895308, 0.02270120751988408, 0.000017775252667578956),
+    Vec3::new(0.02043403340818753, 0.03197650673728944, 0.0003564813588719795),
+    Vec3::new(0.00037315403427122225, -0.0014257132266914385, 0.022445026183495337),
+    Vec3::new(0.0005605249651253262, 0.03191999437655846, -0.0005946931738743111),
+    Vec3::ZERO,
+];
+
+/// Mass (kg) for each link in `LINK_COM_LOCAL` order. L14 is the lumped
+/// gripper tip: ST3215_8_v1_1 housing + Gripper_Gear + both jaws
+/// (0.03190666159632515 + 0.0024790841259162795 + 0.012492175356778453 * 2).
+const LINK_MASS_KG: [f64; LINK_COUNT] = [
+    0.036024842090469696,
+    0.03190666159632515,
+    0.04313419527395414,
+    0.03190666159632515,
+    0.03705485612134295,
+    0.03190666159632515,
+    0.04910540016805011,
+    0.03190666159632515,
+    0.015030395597527186,
+    0.03190666159632515,
+    0.03727709058376948,
+    0.03190666159632515,
+    0.046895455343164964,
+    0.05937009643579831,
+];
+
+/// 0-based index of the last (most distal) actuated joint each link's
+/// position depends on. E.g. L2 (ST3215_2_v1_1) is the stator housing for
+/// joint 2 but is itself only moved by joint 1's rotation, so it depends on
+/// joint 1 only (index 0) and must be excluded from joint 2's torque sum.
+const LINK_LAST_JOINT_INDEX: [usize; LINK_COUNT] = [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6];
+
+pub struct ChainPose {
+    pub joint_pos: [Vec3; JOINT_COUNT],
+    pub joint_axis: [Vec3; JOINT_COUNT],
+    pub link_com: [Vec3; LINK_COUNT],
+}
+
+/// Walks the serial chain at the given joint angles (radians) and returns
+/// each joint's pivot position/axis and each link's CoM, all in the
+/// `base_link` frame.
+pub fn forward_kinematics(theta: &[f64; JOINT_COUNT]) -> ChainPose {
+    let mut pos = Vec3::ZERO;
+    let mut rot = Mat3::IDENTITY;
+
+    let mut joint_pos = [Vec3::ZERO; JOINT_COUNT];
+    let mut joint_axis = [Vec3::ZERO; JOINT_COUNT];
+    let mut link_com = [Vec3::ZERO; LINK_COUNT];
+    let mut link_idx = 0usize;
+
+    // Rigid 1: base_link -> ST3215_1_v1_1 (fixed, no rotation).
+    pos = pos.add(rot.mul_vec3(FIXED_OFFSETS[0]));
+
+    for i in 0..JOINT_COUNT {
+        // Joint i pivot, still in the pre-rotation (housing) frame.
+        let jp = pos.add(rot.mul_vec3(JOINT_ORIGIN_LOCAL[i]));
+        let ja = rot.mul_vec3(JOINT_AXIS_LOCAL[i]).normalize();
+        joint_pos[i] = jp;
+        joint_axis[i] = ja;
+
+        // Advance to the child (bracket) frame: same origin as the joint
+        // pivot, rotated by the joint's own angle about its local axis.
+        pos = jp;
+        rot = rot.mul_mat3(&Mat3::from_axis_angle(JOINT_AXIS_LOCAL[i], theta[i]));
+
+        // Link: the "Joint_0N" bracket attached directly at this frame.
+        link_com[link_idx] = pos.add(rot.mul_vec3(LINK_COM_LOCAL[link_idx]));
+        link_idx += 1;
+
+        // Fixed joint to the next housing (or, after joint 7, to the
+        // lumped gripper tip attachment point).
+        pos = pos.add(rot.mul_vec3(FIXED_OFFSETS[i + 1]));
+
+        if i < JOINT_COUNT - 1 {
+            // Link: the next "ST3215_(N+1)" housing, attached here.
+            link_com[link_idx] = pos.add(rot.mul_vec3(LINK_COM_LOCAL[link_idx]));
+            link_idx += 1;
+        } else {
+            // Lumped gripper tip mass, placed exactly at this frame's origin.
+            link_com[link_idx] = pos;
+            link_idx += 1;
+        }
+    }
+
+    ChainPose { joint_pos, joint_axis, link_com }
+}
+
+/// Static gravity torque (Nm) at each of the 7 actuated joints, via the
+/// virtual-work / Jacobian-transpose method: for each link, its weight
+/// contributes a moment about every joint it is outboard of; the component
+/// of that moment along the joint's own axis is the torque gravity exerts
+/// through that joint.
+pub fn gravity_torques(theta: &[f64; JOINT_COUNT]) -> [f64; JOINT_COUNT] {
+    let pose = forward_kinematics(theta);
+    let mut tau = [0.0f64; JOINT_COUNT];
+
+    for link in 0..LINK_COUNT {
+        let weight = Vec3::new(0.0, 0.0, -LINK_MASS_KG[link] * GRAVITY_MPS2);
+        let last_joint = LINK_LAST_JOINT_INDEX[link];
+
+        for joint in 0..=last_joint {
+            let arm = pose.link_com[link].sub(pose.joint_pos[joint]);
+            let moment = arm.cross(weight);
+            tau[joint] += moment.dot(pose.joint_axis[joint]);
+        }
+    }
+
+    tau
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_pose_produces_finite_torques() {
+        let torques = gravity_torques(&[0.0; JOINT_COUNT]);
+        for t in torques {
+            assert!(t.is_finite());
+        }
+    }
+
+    #[test]
+    fn joint_1_torque_is_negligible_since_its_axis_is_vertical() {
+        // Joint 1 rotates about a near-vertical axis, so gravity (acting
+        // along -Z) should produce almost no torque about it regardless of
+        // pose - a useful sanity check on the sign/axis conventions above.
+        let torques = gravity_torques(&[0.3, 0.4, -0.2, 0.5, -0.3, 0.2, 0.1]);
+        assert!(torques[0].abs() < 0.05, "joint 1 torque was {}", torques[0]);
+    }
+
+    #[test]
+    fn shoulder_torque_grows_with_horizontal_reach() {
+        // Joint 2 (shoulder) should see more gravity torque when the arm is
+        // extended horizontally than when folded straight up.
+        let folded = gravity_torques(&[0.0; JOINT_COUNT]);
+        let extended = gravity_torques(&[0.0, 1.5, 0.0, 0.0, 0.0, 0.0, 0.0]);
+        assert!(
+            extended[1].abs() > folded[1].abs(),
+            "extended={} folded={}",
+            extended[1],
+            folded[1]
+        );
+    }
+}

--- a/software/drivers/motors-mirroring/src/gravity_comp/kinematics.rs
+++ b/software/drivers/motors-mirroring/src/gravity_comp/kinematics.rs
@@ -1,0 +1,152 @@
+//! Minimal hand-rolled vector/rotation math for the 7-joint ElRobot arm chain.
+//!
+//! No `nalgebra`/`urdf-rs` dependency is added here: the chain is small and
+//! fixed, and the codebase already hand-rolls similarly small numeric
+//! helpers elsewhere (see `st3215::protocol::units`).
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct Vec3 {
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+}
+
+impl Vec3 {
+    pub const ZERO: Vec3 = Vec3 { x: 0.0, y: 0.0, z: 0.0 };
+
+    pub const fn new(x: f64, y: f64, z: f64) -> Self {
+        Self { x, y, z }
+    }
+
+    pub fn add(self, other: Vec3) -> Vec3 {
+        Vec3::new(self.x + other.x, self.y + other.y, self.z + other.z)
+    }
+
+    pub fn sub(self, other: Vec3) -> Vec3 {
+        Vec3::new(self.x - other.x, self.y - other.y, self.z - other.z)
+    }
+
+    pub fn scale(self, s: f64) -> Vec3 {
+        Vec3::new(self.x * s, self.y * s, self.z * s)
+    }
+
+    pub fn dot(self, other: Vec3) -> f64 {
+        self.x * other.x + self.y * other.y + self.z * other.z
+    }
+
+    pub fn cross(self, other: Vec3) -> Vec3 {
+        Vec3::new(
+            self.y * other.z - self.z * other.y,
+            self.z * other.x - self.x * other.z,
+            self.x * other.y - self.y * other.x,
+        )
+    }
+
+    pub fn norm(self) -> f64 {
+        self.dot(self).sqrt()
+    }
+
+    pub fn normalize(self) -> Vec3 {
+        let n = self.norm();
+        if n < 1e-12 {
+            return Vec3::ZERO;
+        }
+        self.scale(1.0 / n)
+    }
+}
+
+/// Row-major 3x3 rotation matrix.
+#[derive(Clone, Copy, Debug)]
+pub struct Mat3 {
+    pub rows: [Vec3; 3],
+}
+
+impl Mat3 {
+    pub const IDENTITY: Mat3 = Mat3 {
+        rows: [
+            Vec3::new(1.0, 0.0, 0.0),
+            Vec3::new(0.0, 1.0, 0.0),
+            Vec3::new(0.0, 0.0, 1.0),
+        ],
+    };
+
+    pub fn mul_vec3(&self, v: Vec3) -> Vec3 {
+        Vec3::new(self.rows[0].dot(v), self.rows[1].dot(v), self.rows[2].dot(v))
+    }
+
+    /// `self * other` (applies `other` first, then `self`).
+    pub fn mul_mat3(&self, other: &Mat3) -> Mat3 {
+        let cols = [
+            Vec3::new(other.rows[0].x, other.rows[1].x, other.rows[2].x),
+            Vec3::new(other.rows[0].y, other.rows[1].y, other.rows[2].y),
+            Vec3::new(other.rows[0].z, other.rows[1].z, other.rows[2].z),
+        ];
+        Mat3 {
+            rows: [
+                Vec3::new(self.rows[0].dot(cols[0]), self.rows[0].dot(cols[1]), self.rows[0].dot(cols[2])),
+                Vec3::new(self.rows[1].dot(cols[0]), self.rows[1].dot(cols[1]), self.rows[1].dot(cols[2])),
+                Vec3::new(self.rows[2].dot(cols[0]), self.rows[2].dot(cols[1]), self.rows[2].dot(cols[2])),
+            ],
+        }
+    }
+
+    /// Rotation matrix for a rotation of `angle_rad` about `axis` (Rodrigues' formula).
+    /// `axis` need not be pre-normalized.
+    pub fn from_axis_angle(axis: Vec3, angle_rad: f64) -> Mat3 {
+        let axis = axis.normalize();
+        let (sin, cos) = angle_rad.sin_cos();
+        let one_minus_cos = 1.0 - cos;
+
+        let (x, y, z) = (axis.x, axis.y, axis.z);
+
+        Mat3 {
+            rows: [
+                Vec3::new(
+                    cos + x * x * one_minus_cos,
+                    x * y * one_minus_cos - z * sin,
+                    x * z * one_minus_cos + y * sin,
+                ),
+                Vec3::new(
+                    y * x * one_minus_cos + z * sin,
+                    cos + y * y * one_minus_cos,
+                    y * z * one_minus_cos - x * sin,
+                ),
+                Vec3::new(
+                    z * x * one_minus_cos - y * sin,
+                    z * y * one_minus_cos + x * sin,
+                    cos + z * z * one_minus_cos,
+                ),
+            ],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identity_rotation_is_noop() {
+        let v = Vec3::new(1.0, 2.0, 3.0);
+        assert_eq!(Mat3::IDENTITY.mul_vec3(v), v);
+    }
+
+    #[test]
+    fn rotate_90_degrees_about_z() {
+        let r = Mat3::from_axis_angle(Vec3::new(0.0, 0.0, 1.0), std::f64::consts::FRAC_PI_2);
+        let v = r.mul_vec3(Vec3::new(1.0, 0.0, 0.0));
+        assert!((v.x).abs() < 1e-9);
+        assert!((v.y - 1.0).abs() < 1e-9);
+        assert!((v.z).abs() < 1e-9);
+    }
+
+    #[test]
+    fn cross_product_orthogonal() {
+        let x = Vec3::new(1.0, 0.0, 0.0);
+        let y = Vec3::new(0.0, 1.0, 0.0);
+        let z = x.cross(y);
+        assert!((z.x).abs() < 1e-9);
+        assert!((z.y).abs() < 1e-9);
+        assert!((z.z - 1.0).abs() < 1e-9);
+    }
+}

--- a/software/drivers/motors-mirroring/src/gravity_comp/mod.rs
+++ b/software/drivers/motors-mirroring/src/gravity_comp/mod.rs
@@ -74,8 +74,23 @@ impl GravityComp {
         }
 
         // One-shot setup, ahead of the hot loop: cap TorqueLimit, then enable
-        // torque, for the 7 arm motors only.
-        Self::send_setup_commands(&normfs, &bus.bus_id, config.gravity_comp.torque_limit);
+        // torque, for the 7 arm motors only. Deferred onto its own spawned
+        // task rather than called inline - this fn is invoked synchronously
+        // from within the "commands" queue's own subscription callback (see
+        // lib.rs::process_command_pack), and send_setup_commands ultimately
+        // calls normfs.enqueue() on that *same* queue. Calling it inline
+        // would re-enter that queue's enqueue/subscribe machinery from
+        // within its own callback stack. Mirroring's Inference::start/stop
+        // avoid this exact reentrancy by deferring their equivalent sends
+        // the same way - this matches that established, proven-safe pattern.
+        {
+            let setup_normfs = Arc::clone(&normfs);
+            let setup_bus_id = bus.bus_id.clone();
+            let torque_limit = config.gravity_comp.torque_limit;
+            tokio::spawn(async move {
+                Self::send_setup_commands(&setup_normfs, &setup_bus_id, torque_limit);
+            });
+        }
 
         let gain = Arc::new(RwLock::new(clamp_gravity_comp_gain(
             initial_gain.unwrap_or(config.gravity_comp.gain_rad_per_nm),
@@ -101,7 +116,23 @@ impl GravityComp {
             task.stop_flag.store(true, Ordering::SeqCst);
             task.handle.abort();
         }
-        Self::send_teardown_commands(normfs, &bus.bus_id);
+        // Deferred for the same reentrancy reason as in start() above.
+        let teardown_normfs = Arc::clone(normfs);
+        let teardown_bus_id = bus.bus_id.clone();
+        tokio::spawn(async move {
+            Self::send_teardown_commands(&teardown_normfs, &teardown_bus_id);
+        });
+    }
+
+    /// Stops every currently-running gravity-comp task, disabling torque on
+    /// each. Called during graceful process shutdown so an active gravity
+    /// comp session doesn't leave a bus's torque state undefined when the
+    /// station process exits.
+    pub fn stop_all(&self, normfs: &Arc<NormFS>) {
+        let buses: Vec<BusKey> = self.tasks.read().keys().cloned().collect();
+        for bus in buses {
+            self.stop(&bus, normfs);
+        }
     }
 
     /// Live-updates the gain for a running gravity-comp task, without
@@ -174,6 +205,11 @@ impl GravityComp {
         let mut station_state = StationState::default();
         let mut stale_cycles: u32 = 0;
         let mut overcurrent_cycles: u32 = 0;
+        // Rate-limited diagnostic summary - one line/second instead of every
+        // 20ms cycle, so the loop's actual behavior (fresh/stale, missing
+        // motors, overcurrent, computed torques/offsets, commands sent) is
+        // visible in logs without flooding them.
+        let mut last_debug_log = tokio::time::Instant::now() - std::time::Duration::from_secs(1);
 
         loop {
             if stop_flag.load(Ordering::SeqCst) {
@@ -181,6 +217,11 @@ impl GravityComp {
             }
 
             let loop_start = tokio::time::Instant::now();
+            let should_log = loop_start.duration_since(last_debug_log) >= std::time::Duration::from_secs(1);
+            if should_log {
+                last_debug_log = loop_start;
+            }
+
             station_state.update_from_st3215_queue(&normfs).await;
 
             let now_ns = systime::get_monotonic_stamp_ns();
@@ -192,6 +233,15 @@ impl GravityComp {
 
             if !fresh {
                 stale_cycles += 1;
+                if should_log {
+                    log::info!(
+                        "Gravity comp on bus {}: stale data (age_ns={:?}, stale_cycles={}/{})",
+                        bus.bus_id,
+                        bus_state.map(|b| now_ns.saturating_sub(b.monotonic_stamp_ns)),
+                        stale_cycles,
+                        config.gravity_comp.stale_cutoff_cycles
+                    );
+                }
                 if stale_cycles >= config.gravity_comp.stale_cutoff_cycles {
                     log::warn!(
                         "Gravity comp on bus {} stopping: stale data for {} consecutive cycles",
@@ -210,6 +260,9 @@ impl GravityComp {
             let bus_state = match bus_state {
                 Some(bus_state) => bus_state,
                 None => {
+                    if should_log {
+                        log::info!("Gravity comp on bus {}: bus_state unexpectedly None despite fresh=true", bus.bus_id);
+                    }
                     Self::sleep_remaining(loop_start).await;
                     continue;
                 }
@@ -218,6 +271,7 @@ impl GravityComp {
             let mut theta = [0.0f64; JOINT_COUNT];
             let mut over_current = false;
             let mut have_all_motors = true;
+            let mut missing_motor_ids = Vec::new();
 
             for (i, &motor_id) in ARM_MOTOR_IDS.iter().enumerate() {
                 match bus_state.motors.get(&motor_id) {
@@ -228,17 +282,42 @@ impl GravityComp {
                             over_current = true;
                         }
                     }
-                    None => have_all_motors = false,
+                    None => {
+                        have_all_motors = false;
+                        missing_motor_ids.push(motor_id);
+                    }
                 }
             }
 
             if !have_all_motors {
+                if should_log {
+                    log::info!(
+                        "Gravity comp on bus {}: waiting on motor data, missing motor ids {:?} (present motor ids: {:?})",
+                        bus.bus_id,
+                        missing_motor_ids,
+                        bus_state.motors.keys().collect::<Vec<_>>()
+                    );
+                }
                 Self::sleep_remaining(loop_start).await;
                 continue;
             }
 
             if over_current {
                 overcurrent_cycles += 1;
+                if should_log {
+                    let currents: Vec<(u8, u16)> = ARM_MOTOR_IDS
+                        .iter()
+                        .filter_map(|id| bus_state.motors.get(id).map(|m| (*id, m.current)))
+                        .collect();
+                    log::info!(
+                        "Gravity comp on bus {}: overcurrent (cutoff={}, overcurrent_cycles={}/{}), currents={:?}",
+                        bus.bus_id,
+                        config.gravity_comp.current_cutoff,
+                        overcurrent_cycles,
+                        config.gravity_comp.stale_cutoff_cycles,
+                        currents
+                    );
+                }
                 if overcurrent_cycles >= config.gravity_comp.stale_cutoff_cycles {
                     log::warn!(
                         "Gravity comp on bus {} stopping: overcurrent for {} consecutive cycles",
@@ -258,6 +337,7 @@ impl GravityComp {
             let torques = elrobot_dynamics::gravity_torques(&theta);
             let current_gain = *gain.read();
             let mut commands = Vec::new();
+            let mut debug_rows: Vec<(u8, f64, u16, i32, u16)> = Vec::new();
 
             for (i, &motor_id) in ARM_MOTOR_IDS.iter().enumerate() {
                 let motor = bus_state.motors.get(&motor_id).expect("checked above");
@@ -265,6 +345,15 @@ impl GravityComp {
 
                 let range_size = normalize::get_steps_range(motor.range_min, motor.range_max, &config);
                 if range_size < config.safety_margin * 2 {
+                    if should_log {
+                        log::info!(
+                            "Gravity comp on bus {}: motor {} skipped, range too narrow (range_size={}, need >= {})",
+                            bus.bus_id,
+                            motor_id,
+                            range_size,
+                            config.safety_margin * 2
+                        );
+                    }
                     continue; // not calibrated enough to safely offset this motor
                 }
 
@@ -278,11 +367,25 @@ impl GravityComp {
 
                 let goal = Self::clamp_goal(motor.present_position, offset, motor.range_min, motor.range_max, config.safety_margin, config.max_steps);
 
+                if should_log {
+                    debug_rows.push((motor_id, torques[i], motor.present_position, offset, goal));
+                }
+
                 commands.push(Command {
                     target_bus_id: bus.bus_id.clone(),
                     motor_id: motor_id as u32,
                     command: MotorCommand::Goal(goal),
                 });
+            }
+
+            if should_log {
+                log::info!(
+                    "Gravity comp on bus {}: gain={:.3}, commands_sent={}, (motor, torque_nm, present, offset_ticks, goal)={:?}",
+                    bus.bus_id,
+                    current_gain,
+                    commands.len(),
+                    debug_rows
+                );
             }
 
             if !commands.is_empty() {

--- a/software/drivers/motors-mirroring/src/gravity_comp/mod.rs
+++ b/software/drivers/motors-mirroring/src/gravity_comp/mod.rs
@@ -19,7 +19,7 @@ use bytes::Bytes;
 use normfs::NormFS;
 use parking_lot::RwLock;
 
-use crate::config::{clamp_gravity_comp_gain, MotorConfig, GRAVITY_COMP_REFRESH_INTERVAL};
+use crate::config::{clamp_gravity_comp_gain, clamp_gravity_comp_torque_limit, MotorConfig, GRAVITY_COMP_REFRESH_INTERVAL};
 use crate::inference::model::StationState;
 use crate::inference::normalize;
 use crate::inference::{Inference, MAX_DATA_AGE_NS};
@@ -31,13 +31,34 @@ use elrobot_dynamics::{JOINT_COUNT, JOINT_LIMITS_RAD};
 /// compensation in either direction.
 pub const ARM_MOTOR_IDS: [u8; JOINT_COUNT] = [1, 2, 3, 4, 5, 6, 7];
 
+/// Per-joint gains, indexed the same as `ARM_MOTOR_IDS` (index 0 = motor 1,
+/// ... index 6 = motor 7).
+pub type JointGains = [f64; JOINT_COUNT];
+
+/// A bus's current gravity-comp tuning: live while running, "staged"
+/// (remembered but not yet persisted) while stopped, and what gets written
+/// to the `motors_mirroring/gravity_comp_settings` queue on GCT_SAVE_SETTINGS.
+#[derive(Clone, Copy, Debug)]
+pub struct GravitySettings {
+    pub joint_gains: JointGains,
+    pub torque_limit: u16,
+}
+
+fn motor_id_to_index(motor_id: u8) -> Option<usize> {
+    ARM_MOTOR_IDS.iter().position(|&id| id == motor_id)
+}
+
 struct GravityCompTask {
     stop_flag: Arc<AtomicBool>,
-    /// Live-adjustable gain, read by the control loop every cycle so it can
-    /// be tuned from the UI without restarting gravity comp or the station
-    /// process. Everything else in `GravityCompConfig` is fixed for the
-    /// lifetime of the task (only the gain was asked to be UI-tunable).
-    gain: Arc<RwLock<f64>>,
+    /// Live-adjustable per-joint gains, read by the control loop every cycle
+    /// so they can be tuned from the UI without restarting gravity comp or
+    /// the station process.
+    gains: Arc<RwLock<JointGains>>,
+    /// Live-adjustable torque limit (applies uniformly to all 7 arm motors).
+    /// Unlike gain (a pure software multiplier), this is a servo register -
+    /// changing it re-sends a TorqueLimit write immediately (see
+    /// `GravityComp::set_torque_limit`), it isn't just read by the loop.
+    torque_limit: Arc<RwLock<u16>>,
     handle: tokio::task::JoinHandle<()>,
 }
 
@@ -61,17 +82,31 @@ impl GravityComp {
     /// terminates itself for safety reasons (stale data or sustained
     /// overcurrent) - the caller uses this to keep displayed mode state
     /// truthful rather than silently drifting from what's actually running.
-    /// `initial_gain`, if provided (e.g. from a UI-supplied start command),
-    /// overrides `config.gravity_comp.gain_rad_per_nm` as the starting point
-    /// - either way it's still hard-clamped and still adjustable afterwards
-    /// via `set_gain`.
-    pub fn start<F>(&self, bus: BusKey, config: MotorConfig, initial_gain: Option<f64>, normfs: Arc<NormFS>, on_self_stop: F)
-    where
+    /// `initial_gains`/`initial_torque_limit`, if provided (e.g. from
+    /// previously-saved settings), override `config.gravity_comp`'s defaults
+    /// as the starting point - either way they're still hard-clamped and
+    /// still adjustable afterwards via `set_gain`/`set_torque_limit`.
+    pub fn start<F>(
+        &self,
+        bus: BusKey,
+        config: MotorConfig,
+        initial_gains: Option<JointGains>,
+        initial_torque_limit: Option<u16>,
+        normfs: Arc<NormFS>,
+        on_self_stop: F,
+    ) where
         F: Fn(BusKey) + Send + Sync + 'static,
     {
         if self.tasks.read().contains_key(&bus) {
             return;
         }
+
+        let gains_value: JointGains = initial_gains
+            .unwrap_or([config.gravity_comp.gain_rad_per_nm; JOINT_COUNT])
+            .map(clamp_gravity_comp_gain);
+        let torque_limit_value = clamp_gravity_comp_torque_limit(
+            initial_torque_limit.unwrap_or(config.gravity_comp.torque_limit),
+        );
 
         // One-shot setup, ahead of the hot loop: cap TorqueLimit, then enable
         // torque, for the 7 arm motors only. Deferred onto its own spawned
@@ -86,27 +121,25 @@ impl GravityComp {
         {
             let setup_normfs = Arc::clone(&normfs);
             let setup_bus_id = bus.bus_id.clone();
-            let torque_limit = config.gravity_comp.torque_limit;
             tokio::spawn(async move {
-                Self::send_setup_commands(&setup_normfs, &setup_bus_id, torque_limit);
+                Self::send_setup_commands(&setup_normfs, &setup_bus_id, torque_limit_value);
             });
         }
 
-        let gain = Arc::new(RwLock::new(clamp_gravity_comp_gain(
-            initial_gain.unwrap_or(config.gravity_comp.gain_rad_per_nm),
-        )));
+        let gains = Arc::new(RwLock::new(gains_value));
+        let torque_limit = Arc::new(RwLock::new(torque_limit_value));
 
         let stop_flag = Arc::new(AtomicBool::new(false));
         let loop_stop_flag = Arc::clone(&stop_flag);
-        let loop_gain = Arc::clone(&gain);
+        let loop_gains = Arc::clone(&gains);
         let loop_bus = bus.clone();
         let loop_normfs = Arc::clone(&normfs);
 
         let handle = tokio::spawn(async move {
-            Self::run_control_loop(loop_bus, loop_stop_flag, loop_gain, loop_normfs, config, on_self_stop).await;
+            Self::run_control_loop(loop_bus, loop_stop_flag, loop_gains, loop_normfs, config, on_self_stop).await;
         });
 
-        self.tasks.write().insert(bus, GravityCompTask { stop_flag, gain, handle });
+        self.tasks.write().insert(bus, GravityCompTask { stop_flag, gains, torque_limit, handle });
     }
 
     /// Stops the control loop for `bus` (if running), disables torque, and
@@ -135,23 +168,72 @@ impl GravityComp {
         }
     }
 
-    /// Live-updates the gain for a running gravity-comp task, without
-    /// restarting it. Returns `false` if `bus` has no running task.
-    pub fn set_gain(&self, bus: &BusKey, gain: f64) -> bool {
+    /// Live-updates the gain of one arm joint for a running gravity-comp
+    /// task, without restarting it. `motor_id` is the raw ST3215 motor ID
+    /// (1-7). Returns `false` if `bus` has no running task or `motor_id`
+    /// isn't one of the 7 compensated arm joints.
+    pub fn set_gain(&self, bus: &BusKey, motor_id: u8, gain: f64) -> bool {
+        let index = match motor_id_to_index(motor_id) {
+            Some(index) => index,
+            None => return false,
+        };
         let tasks = self.tasks.read();
         match tasks.get(bus) {
             Some(task) => {
-                *task.gain.write() = clamp_gravity_comp_gain(gain);
+                task.gains.write()[index] = clamp_gravity_comp_gain(gain);
                 true
             }
             None => false,
         }
     }
 
-    /// Returns the currently active gain for `bus`, or `None` if gravity
-    /// comp isn't running on it.
-    pub fn get_gain(&self, bus: &BusKey) -> Option<f64> {
-        self.tasks.read().get(bus).map(|task| *task.gain.read())
+    /// Live-updates the torque limit (applies to all 7 arm motors) for a
+    /// running gravity-comp task, without restarting it. Unlike gain, this
+    /// immediately re-sends a `TorqueLimit` register write, since it's
+    /// hardware state rather than a value the control loop merely reads.
+    /// Returns `false` if `bus` has no running task.
+    pub fn set_torque_limit(&self, bus: &BusKey, torque_limit: u16, normfs: &Arc<NormFS>) -> bool {
+        let clamped = clamp_gravity_comp_torque_limit(torque_limit);
+        let updated = {
+            let tasks = self.tasks.read();
+            match tasks.get(bus) {
+                Some(task) => {
+                    *task.torque_limit.write() = clamped;
+                    true
+                }
+                None => false,
+            }
+        };
+
+        if updated {
+            let normfs = Arc::clone(normfs);
+            let bus_id = bus.bus_id.clone();
+            tokio::spawn(async move {
+                let mut commands = Vec::new();
+                for &motor_id in &ARM_MOTOR_IDS {
+                    commands.push(Command {
+                        target_bus_id: bus_id.clone(),
+                        motor_id: motor_id as u32,
+                        command: MotorCommand::TorqueLimit(clamped),
+                    });
+                }
+                Inference::send_st3215_commands(&normfs, &Bytes::new(), commands);
+            });
+        }
+
+        updated
+    }
+
+    /// Returns the currently active per-joint gains for `bus`, or `None` if
+    /// gravity comp isn't running on it.
+    pub fn get_gains(&self, bus: &BusKey) -> Option<JointGains> {
+        self.tasks.read().get(bus).map(|task| *task.gains.read())
+    }
+
+    /// Returns the currently active torque limit for `bus`, or `None` if
+    /// gravity comp isn't running on it.
+    pub fn get_torque_limit(&self, bus: &BusKey) -> Option<u16> {
+        self.tasks.read().get(bus).map(|task| *task.torque_limit.read())
     }
 
     fn send_setup_commands(normfs: &Arc<NormFS>, bus_id: &str, torque_limit: u16) {
@@ -195,7 +277,7 @@ impl GravityComp {
     async fn run_control_loop<F>(
         bus: BusKey,
         stop_flag: Arc<AtomicBool>,
-        gain: Arc<RwLock<f64>>,
+        gains: Arc<RwLock<JointGains>>,
         normfs: Arc<NormFS>,
         config: MotorConfig,
         on_self_stop: F,
@@ -335,9 +417,9 @@ impl GravityComp {
             overcurrent_cycles = 0;
 
             let torques = elrobot_dynamics::gravity_torques(&theta);
-            let current_gain = *gain.read();
+            let current_gains = *gains.read();
             let mut commands = Vec::new();
-            let mut debug_rows: Vec<(u8, f64, u16, i32, u16)> = Vec::new();
+            let mut debug_rows: Vec<(u8, f64, f64, u16, i32, u16)> = Vec::new();
 
             for (i, &motor_id) in ARM_MOTOR_IDS.iter().enumerate() {
                 let motor = bus_state.motors.get(&motor_id).expect("checked above");
@@ -360,7 +442,7 @@ impl GravityComp {
                 let tpr = control::ticks_per_radian(motor.range_min, motor.range_max, lower, upper, &config);
                 let offset = control::gravity_torque_to_goal_offset_ticks(
                     torques[i],
-                    current_gain,
+                    current_gains[i],
                     config.gravity_comp.max_offset_ticks,
                     tpr,
                 );
@@ -368,7 +450,7 @@ impl GravityComp {
                 let goal = Self::clamp_goal(motor.present_position, offset, motor.range_min, motor.range_max, config.safety_margin, config.max_steps);
 
                 if should_log {
-                    debug_rows.push((motor_id, torques[i], motor.present_position, offset, goal));
+                    debug_rows.push((motor_id, current_gains[i], torques[i], motor.present_position, offset, goal));
                 }
 
                 commands.push(Command {
@@ -380,9 +462,8 @@ impl GravityComp {
 
             if should_log {
                 log::info!(
-                    "Gravity comp on bus {}: gain={:.3}, commands_sent={}, (motor, torque_nm, present, offset_ticks, goal)={:?}",
+                    "Gravity comp on bus {}: commands_sent={}, (motor, gain, torque_nm, present, offset_ticks, goal)={:?}",
                     bus.bus_id,
-                    current_gain,
                     commands.len(),
                     debug_rows
                 );

--- a/software/drivers/motors-mirroring/src/gravity_comp/mod.rs
+++ b/software/drivers/motors-mirroring/src/gravity_comp/mod.rs
@@ -1,0 +1,289 @@
+//! Orchestration for the leader-arm gravity compensation control loop.
+//!
+//! ST3215 servos have no native torque/current-setpoint register, only a
+//! position loop with a `TorqueLimit` effort clamp - so gravity compensation
+//! is approximated by continuously nudging `GoalPosition` around the arm's
+//! current pose by an amount proportional to the computed gravity torque,
+//! using the servo's internal position gain as an implicit spring. See
+//! `elrobot_dynamics` for the torque model and `control` for the offset law.
+
+mod control;
+mod elrobot_dynamics;
+mod kinematics;
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use bytes::Bytes;
+use normfs::NormFS;
+use parking_lot::RwLock;
+
+use crate::config::{MotorConfig, GRAVITY_COMP_REFRESH_INTERVAL};
+use crate::inference::model::StationState;
+use crate::inference::normalize;
+use crate::inference::{Inference, MAX_DATA_AGE_NS};
+use crate::types::{BusKey, Command, MotorCommand};
+use elrobot_dynamics::{JOINT_COUNT, JOINT_LIMITS_RAD};
+
+/// ST3215 motor IDs for the 7 compensated arm joints (rev_motor_01..07).
+/// Motor 8 (the gripper) is never enabled or commanded by gravity
+/// compensation in either direction.
+pub const ARM_MOTOR_IDS: [u8; JOINT_COUNT] = [1, 2, 3, 4, 5, 6, 7];
+
+struct GravityCompTask {
+    stop_flag: Arc<AtomicBool>,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+/// Tracks the running gravity-comp control-loop task per bus. Owned by
+/// `Inference`, which is the only thing that talks to `normfs`/motor state on
+/// behalf of gravity comp - this struct is just task lifecycle management.
+#[derive(Default)]
+pub struct GravityComp {
+    tasks: RwLock<HashMap<BusKey, GravityCompTask>>,
+}
+
+impl GravityComp {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Starts the control loop for `bus`. No-op if already running (idempotent,
+    /// matching `Inference::start`'s style for mirroring).
+    ///
+    /// `on_self_stop` is invoked (off the control loop's own task) if the loop
+    /// terminates itself for safety reasons (stale data or sustained
+    /// overcurrent) - the caller uses this to keep displayed mode state
+    /// truthful rather than silently drifting from what's actually running.
+    pub fn start<F>(&self, bus: BusKey, config: MotorConfig, normfs: Arc<NormFS>, on_self_stop: F)
+    where
+        F: Fn(BusKey) + Send + Sync + 'static,
+    {
+        if self.tasks.read().contains_key(&bus) {
+            return;
+        }
+
+        // One-shot setup, ahead of the hot loop: cap TorqueLimit, then enable
+        // torque, for the 7 arm motors only.
+        Self::send_setup_commands(&normfs, &bus.bus_id, config.gravity_comp.torque_limit);
+
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        let loop_stop_flag = Arc::clone(&stop_flag);
+        let loop_bus = bus.clone();
+        let loop_normfs = Arc::clone(&normfs);
+
+        let handle = tokio::spawn(async move {
+            Self::run_control_loop(loop_bus, loop_stop_flag, loop_normfs, config, on_self_stop).await;
+        });
+
+        self.tasks.write().insert(bus, GravityCompTask { stop_flag, handle });
+    }
+
+    /// Stops the control loop for `bus` (if running), disables torque, and
+    /// restores the default torque limit on the 7 arm motors.
+    pub fn stop(&self, bus: &BusKey, normfs: &Arc<NormFS>) {
+        if let Some(task) = self.tasks.write().remove(bus) {
+            task.stop_flag.store(true, Ordering::SeqCst);
+            task.handle.abort();
+        }
+        Self::send_teardown_commands(normfs, &bus.bus_id);
+    }
+
+    fn send_setup_commands(normfs: &Arc<NormFS>, bus_id: &str, torque_limit: u16) {
+        let mut commands = Vec::new();
+        for &motor_id in &ARM_MOTOR_IDS {
+            commands.push(Command {
+                target_bus_id: bus_id.to_string(),
+                motor_id: motor_id as u32,
+                command: MotorCommand::TorqueLimit(torque_limit),
+            });
+        }
+        for &motor_id in &ARM_MOTOR_IDS {
+            commands.push(Command {
+                target_bus_id: bus_id.to_string(),
+                motor_id: motor_id as u32,
+                command: MotorCommand::Torque(1),
+            });
+        }
+        Inference::send_st3215_commands(normfs, &Bytes::new(), commands);
+    }
+
+    fn send_teardown_commands(normfs: &Arc<NormFS>, bus_id: &str) {
+        let mut commands = Vec::new();
+        for &motor_id in &ARM_MOTOR_IDS {
+            commands.push(Command {
+                target_bus_id: bus_id.to_string(),
+                motor_id: motor_id as u32,
+                command: MotorCommand::Torque(0),
+            });
+        }
+        for &motor_id in &ARM_MOTOR_IDS {
+            commands.push(Command {
+                target_bus_id: bus_id.to_string(),
+                motor_id: motor_id as u32,
+                command: MotorCommand::TorqueLimit(st3215::presets::DEFAULT_TORQUE_LIMIT),
+            });
+        }
+        Inference::send_st3215_commands(normfs, &Bytes::new(), commands);
+    }
+
+    async fn run_control_loop<F>(
+        bus: BusKey,
+        stop_flag: Arc<AtomicBool>,
+        normfs: Arc<NormFS>,
+        config: MotorConfig,
+        on_self_stop: F,
+    ) where
+        F: Fn(BusKey) + Send + Sync + 'static,
+    {
+        let mut station_state = StationState::default();
+        let mut stale_cycles: u32 = 0;
+        let mut overcurrent_cycles: u32 = 0;
+
+        loop {
+            if stop_flag.load(Ordering::SeqCst) {
+                return;
+            }
+
+            let loop_start = tokio::time::Instant::now();
+            station_state.update_from_st3215_queue(&normfs).await;
+
+            let now_ns = systime::get_monotonic_stamp_ns();
+            let bus_state = station_state.buses.get(&bus);
+
+            let fresh = bus_state
+                .map(|b| b.monotonic_stamp_ns > 0 && now_ns.saturating_sub(b.monotonic_stamp_ns) < MAX_DATA_AGE_NS)
+                .unwrap_or(false);
+
+            if !fresh {
+                stale_cycles += 1;
+                if stale_cycles >= config.gravity_comp.stale_cutoff_cycles {
+                    log::warn!(
+                        "Gravity comp on bus {} stopping: stale data for {} consecutive cycles",
+                        bus.bus_id,
+                        stale_cycles
+                    );
+                    Self::send_teardown_commands(&normfs, &bus.bus_id);
+                    on_self_stop(bus.clone());
+                    return;
+                }
+                Self::sleep_remaining(loop_start).await;
+                continue;
+            }
+            stale_cycles = 0;
+
+            let bus_state = match bus_state {
+                Some(bus_state) => bus_state,
+                None => {
+                    Self::sleep_remaining(loop_start).await;
+                    continue;
+                }
+            };
+
+            let mut theta = [0.0f64; JOINT_COUNT];
+            let mut over_current = false;
+            let mut have_all_motors = true;
+
+            for (i, &motor_id) in ARM_MOTOR_IDS.iter().enumerate() {
+                match bus_state.motors.get(&motor_id) {
+                    Some(motor) => {
+                        let (lower, upper) = JOINT_LIMITS_RAD[i];
+                        theta[i] = control::raw_to_joint_angle(motor.present_position, motor.range_min, motor.range_max, lower, upper, &config);
+                        if motor.current >= config.gravity_comp.current_cutoff {
+                            over_current = true;
+                        }
+                    }
+                    None => have_all_motors = false,
+                }
+            }
+
+            if !have_all_motors {
+                Self::sleep_remaining(loop_start).await;
+                continue;
+            }
+
+            if over_current {
+                overcurrent_cycles += 1;
+                if overcurrent_cycles >= config.gravity_comp.stale_cutoff_cycles {
+                    log::warn!(
+                        "Gravity comp on bus {} stopping: overcurrent for {} consecutive cycles",
+                        bus.bus_id,
+                        overcurrent_cycles
+                    );
+                    Self::send_teardown_commands(&normfs, &bus.bus_id);
+                    on_self_stop(bus.clone());
+                    return;
+                }
+                // Hold position this cycle rather than commanding a new goal.
+                Self::sleep_remaining(loop_start).await;
+                continue;
+            }
+            overcurrent_cycles = 0;
+
+            let torques = elrobot_dynamics::gravity_torques(&theta);
+            let mut commands = Vec::new();
+
+            for (i, &motor_id) in ARM_MOTOR_IDS.iter().enumerate() {
+                let motor = bus_state.motors.get(&motor_id).expect("checked above");
+                let (lower, upper) = JOINT_LIMITS_RAD[i];
+
+                let range_size = normalize::get_steps_range(motor.range_min, motor.range_max, &config);
+                if range_size < config.safety_margin * 2 {
+                    continue; // not calibrated enough to safely offset this motor
+                }
+
+                let tpr = control::ticks_per_radian(motor.range_min, motor.range_max, lower, upper, &config);
+                let offset = control::gravity_torque_to_goal_offset_ticks(
+                    torques[i],
+                    config.gravity_comp.gain_rad_per_nm,
+                    config.gravity_comp.max_offset_ticks,
+                    tpr,
+                );
+
+                let goal = Self::clamp_goal(motor.present_position, offset, motor.range_min, motor.range_max, config.safety_margin, config.max_steps);
+
+                commands.push(Command {
+                    target_bus_id: bus.bus_id.clone(),
+                    motor_id: motor_id as u32,
+                    command: MotorCommand::Goal(goal),
+                });
+            }
+
+            if !commands.is_empty() {
+                Inference::send_st3215_commands(&normfs, &Bytes::new(), commands);
+            }
+
+            Self::sleep_remaining(loop_start).await;
+        }
+    }
+
+    /// Applies the offset to `present`, wrapping into the servo's tick space,
+    /// then clamps into the calibrated range minus a safety margin.
+    fn clamp_goal(present: u16, offset: i32, range_min: u16, range_max: u16, margin: u16, max_steps: u16) -> u16 {
+        let max_steps_i = max_steps as i32;
+        let raw = (present as i32 + offset).rem_euclid(max_steps_i);
+
+        if range_max < range_min {
+            // Calibrated range wraps across the 0/max_steps boundary - skip
+            // clamping in this rarer case and hold position rather than risk
+            // an incorrect wraparound comparison.
+            return present;
+        }
+
+        let lo = range_min as i32 + margin as i32;
+        let hi = range_max as i32 - margin as i32;
+        if hi <= lo {
+            return present;
+        }
+
+        raw.clamp(lo, hi) as u16
+    }
+
+    async fn sleep_remaining(loop_start: tokio::time::Instant) {
+        let elapsed = loop_start.elapsed();
+        if elapsed < GRAVITY_COMP_REFRESH_INTERVAL {
+            tokio::time::sleep(GRAVITY_COMP_REFRESH_INTERVAL - elapsed).await;
+        }
+    }
+}

--- a/software/drivers/motors-mirroring/src/gravity_comp/mod.rs
+++ b/software/drivers/motors-mirroring/src/gravity_comp/mod.rs
@@ -19,7 +19,7 @@ use bytes::Bytes;
 use normfs::NormFS;
 use parking_lot::RwLock;
 
-use crate::config::{MotorConfig, GRAVITY_COMP_REFRESH_INTERVAL};
+use crate::config::{clamp_gravity_comp_gain, MotorConfig, GRAVITY_COMP_REFRESH_INTERVAL};
 use crate::inference::model::StationState;
 use crate::inference::normalize;
 use crate::inference::{Inference, MAX_DATA_AGE_NS};
@@ -33,6 +33,11 @@ pub const ARM_MOTOR_IDS: [u8; JOINT_COUNT] = [1, 2, 3, 4, 5, 6, 7];
 
 struct GravityCompTask {
     stop_flag: Arc<AtomicBool>,
+    /// Live-adjustable gain, read by the control loop every cycle so it can
+    /// be tuned from the UI without restarting gravity comp or the station
+    /// process. Everything else in `GravityCompConfig` is fixed for the
+    /// lifetime of the task (only the gain was asked to be UI-tunable).
+    gain: Arc<RwLock<f64>>,
     handle: tokio::task::JoinHandle<()>,
 }
 
@@ -56,7 +61,11 @@ impl GravityComp {
     /// terminates itself for safety reasons (stale data or sustained
     /// overcurrent) - the caller uses this to keep displayed mode state
     /// truthful rather than silently drifting from what's actually running.
-    pub fn start<F>(&self, bus: BusKey, config: MotorConfig, normfs: Arc<NormFS>, on_self_stop: F)
+    /// `initial_gain`, if provided (e.g. from a UI-supplied start command),
+    /// overrides `config.gravity_comp.gain_rad_per_nm` as the starting point
+    /// - either way it's still hard-clamped and still adjustable afterwards
+    /// via `set_gain`.
+    pub fn start<F>(&self, bus: BusKey, config: MotorConfig, initial_gain: Option<f64>, normfs: Arc<NormFS>, on_self_stop: F)
     where
         F: Fn(BusKey) + Send + Sync + 'static,
     {
@@ -68,16 +77,21 @@ impl GravityComp {
         // torque, for the 7 arm motors only.
         Self::send_setup_commands(&normfs, &bus.bus_id, config.gravity_comp.torque_limit);
 
+        let gain = Arc::new(RwLock::new(clamp_gravity_comp_gain(
+            initial_gain.unwrap_or(config.gravity_comp.gain_rad_per_nm),
+        )));
+
         let stop_flag = Arc::new(AtomicBool::new(false));
         let loop_stop_flag = Arc::clone(&stop_flag);
+        let loop_gain = Arc::clone(&gain);
         let loop_bus = bus.clone();
         let loop_normfs = Arc::clone(&normfs);
 
         let handle = tokio::spawn(async move {
-            Self::run_control_loop(loop_bus, loop_stop_flag, loop_normfs, config, on_self_stop).await;
+            Self::run_control_loop(loop_bus, loop_stop_flag, loop_gain, loop_normfs, config, on_self_stop).await;
         });
 
-        self.tasks.write().insert(bus, GravityCompTask { stop_flag, handle });
+        self.tasks.write().insert(bus, GravityCompTask { stop_flag, gain, handle });
     }
 
     /// Stops the control loop for `bus` (if running), disables torque, and
@@ -88,6 +102,25 @@ impl GravityComp {
             task.handle.abort();
         }
         Self::send_teardown_commands(normfs, &bus.bus_id);
+    }
+
+    /// Live-updates the gain for a running gravity-comp task, without
+    /// restarting it. Returns `false` if `bus` has no running task.
+    pub fn set_gain(&self, bus: &BusKey, gain: f64) -> bool {
+        let tasks = self.tasks.read();
+        match tasks.get(bus) {
+            Some(task) => {
+                *task.gain.write() = clamp_gravity_comp_gain(gain);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Returns the currently active gain for `bus`, or `None` if gravity
+    /// comp isn't running on it.
+    pub fn get_gain(&self, bus: &BusKey) -> Option<f64> {
+        self.tasks.read().get(bus).map(|task| *task.gain.read())
     }
 
     fn send_setup_commands(normfs: &Arc<NormFS>, bus_id: &str, torque_limit: u16) {
@@ -131,6 +164,7 @@ impl GravityComp {
     async fn run_control_loop<F>(
         bus: BusKey,
         stop_flag: Arc<AtomicBool>,
+        gain: Arc<RwLock<f64>>,
         normfs: Arc<NormFS>,
         config: MotorConfig,
         on_self_stop: F,
@@ -222,6 +256,7 @@ impl GravityComp {
             overcurrent_cycles = 0;
 
             let torques = elrobot_dynamics::gravity_torques(&theta);
+            let current_gain = *gain.read();
             let mut commands = Vec::new();
 
             for (i, &motor_id) in ARM_MOTOR_IDS.iter().enumerate() {
@@ -236,7 +271,7 @@ impl GravityComp {
                 let tpr = control::ticks_per_radian(motor.range_min, motor.range_max, lower, upper, &config);
                 let offset = control::gravity_torque_to_goal_offset_ticks(
                     torques[i],
-                    config.gravity_comp.gain_rad_per_nm,
+                    current_gain,
                     config.gravity_comp.max_offset_ticks,
                     tpr,
                 );

--- a/software/drivers/motors-mirroring/src/inference/mod.rs
+++ b/software/drivers/motors-mirroring/src/inference/mod.rs
@@ -1,9 +1,9 @@
 #![allow(clippy::collapsible_if)]
 #![allow(clippy::needless_borrow)]
 
-mod model;
+pub(crate) mod model;
 mod mirror;
-mod normalize;
+pub(crate) mod normalize;
 use bytes::Bytes;
 use prost::Message;
 use station_iface::iface_proto::commands::{DriverCommand, StationCommandsPack};
@@ -15,11 +15,13 @@ use crate::{config, proto::mirroring::inference_state::Mirroring, proto::mirrori
 use crate::proto::mirroring;
 
 /// Maximum acceptable data age before considering it stale (100ms in nanoseconds)
-const MAX_DATA_AGE_NS: u64 = 100_000_000;
+pub(crate) const MAX_DATA_AGE_NS: u64 = 100_000_000;
 
 pub struct Inference {
     state: Arc<RwLock<model::State>>,
     normfs: Arc<NormFS>,
+    config: config::MotorConfig,
+    gravity_comp: crate::gravity_comp::GravityComp,
 }
 
 impl Inference {
@@ -30,6 +32,8 @@ impl Inference {
         let res = Self {
             state: Arc::new(RwLock::new(model::State::default())),
             normfs,
+            config: config.clone(),
+            gravity_comp: crate::gravity_comp::GravityComp::new(),
         };
 
         let state = Arc::clone(&res.state);
@@ -39,6 +43,23 @@ impl Inference {
         });
 
         res
+    }
+
+    /// Starts gravity compensation for `bus`. No-op if already running.
+    /// `on_self_stop` is called if the control loop terminates itself for
+    /// safety reasons (stale data or sustained overcurrent), so the caller
+    /// can keep displayed mode state truthful.
+    pub fn start_gravity_comp<F>(&self, bus: BusKey, on_self_stop: F)
+    where
+        F: Fn(BusKey) + Send + Sync + 'static,
+    {
+        self.gravity_comp.start(bus, self.config.clone(), Arc::clone(&self.normfs), on_self_stop);
+    }
+
+    /// Stops gravity compensation for `bus` (if running) and disables torque
+    /// on its arm motors.
+    pub fn stop_gravity_comp(&self, bus: BusKey) {
+        self.gravity_comp.stop(&bus, &self.normfs);
     }
 
     pub fn start(&self, from: BusKey, to: Vec<BusKey>) {
@@ -394,7 +415,7 @@ impl Inference {
         });
     }
 
-    fn send_st3215_commands(
+    pub(crate) fn send_st3215_commands(
         normfs: &Arc<NormFS>,
         state_id: &Bytes,
         commands: Vec<Command>,
@@ -408,6 +429,7 @@ impl Inference {
         };
 
         // Group commands by (bus_id, address) for SyncWrite batching
+        let mut torque_limit_cmds: HashMap<String, Vec<(u32, Bytes)>> = HashMap::new();
         let mut torque_cmds: HashMap<String, Vec<(u32, Bytes)>> = HashMap::new();
         let mut speed_cmds: HashMap<String, Vec<(u32, Bytes)>> = HashMap::new();
         let mut accel_cmds: HashMap<String, Vec<(u32, Bytes)>> = HashMap::new();
@@ -415,6 +437,12 @@ impl Inference {
 
         for cmd in &commands {
             match cmd.command {
+                MotorCommand::TorqueLimit(limit) => {
+                    torque_limit_cmds
+                        .entry(cmd.target_bus_id.clone())
+                        .or_default()
+                        .push((cmd.motor_id, Bytes::from(limit.to_le_bytes().to_vec())));
+                }
                 MotorCommand::Torque(torque) => {
                     torque_cmds
                         .entry(cmd.target_bus_id.clone())
@@ -442,8 +470,18 @@ impl Inference {
             }
         }
 
-        // Maintain order: torque → speed/accel → goal
-        // 1. Torque enable
+        // Maintain order: torque limit → torque enable → speed/accel → goal
+        // 1. Torque limit (so the very first torque-enable already respects it)
+        for (bus_id, motors) in torque_limit_cmds {
+            Self::add_sync_write_to_pack(
+                &mut pack,
+                bus_id,
+                st3215::protocol::RamRegister::TorqueLimit.address() as u32,
+                motors,
+            );
+        }
+
+        // 2. Torque enable
         for (bus_id, motors) in torque_cmds {
             Self::add_sync_write_to_pack(
                 &mut pack,
@@ -453,7 +491,7 @@ impl Inference {
             );
         }
 
-        // 2. Speed
+        // 3. Speed
         for (bus_id, motors) in speed_cmds {
             Self::add_sync_write_to_pack(
                 &mut pack,

--- a/software/drivers/motors-mirroring/src/inference/mod.rs
+++ b/software/drivers/motors-mirroring/src/inference/mod.rs
@@ -76,6 +76,12 @@ impl Inference {
         self.gravity_comp.get_gain(bus)
     }
 
+    /// Stops every currently-running gravity-comp task. Called during
+    /// graceful process shutdown.
+    pub fn stop_all_gravity_comp(&self) {
+        self.gravity_comp.stop_all(&self.normfs);
+    }
+
     pub fn start(&self, from: BusKey, to: Vec<BusKey>) {
         let mut state = self.state.write();
 

--- a/software/drivers/motors-mirroring/src/inference/mod.rs
+++ b/software/drivers/motors-mirroring/src/inference/mod.rs
@@ -46,20 +46,34 @@ impl Inference {
     }
 
     /// Starts gravity compensation for `bus`. No-op if already running.
-    /// `on_self_stop` is called if the control loop terminates itself for
-    /// safety reasons (stale data or sustained overcurrent), so the caller
-    /// can keep displayed mode state truthful.
-    pub fn start_gravity_comp<F>(&self, bus: BusKey, on_self_stop: F)
+    /// `initial_gain`, if provided, overrides the configured default gain
+    /// for this run (still hard-clamped either way). `on_self_stop` is
+    /// called if the control loop terminates itself for safety reasons
+    /// (stale data or sustained overcurrent), so the caller can keep
+    /// displayed mode state truthful.
+    pub fn start_gravity_comp<F>(&self, bus: BusKey, initial_gain: Option<f64>, on_self_stop: F)
     where
         F: Fn(BusKey) + Send + Sync + 'static,
     {
-        self.gravity_comp.start(bus, self.config.clone(), Arc::clone(&self.normfs), on_self_stop);
+        self.gravity_comp.start(bus, self.config.clone(), initial_gain, Arc::clone(&self.normfs), on_self_stop);
     }
 
     /// Stops gravity compensation for `bus` (if running) and disables torque
     /// on its arm motors.
     pub fn stop_gravity_comp(&self, bus: BusKey) {
         self.gravity_comp.stop(&bus, &self.normfs);
+    }
+
+    /// Live-updates the gravity-comp gain for `bus` without restarting it.
+    /// Returns `false` if gravity comp isn't currently running on that bus.
+    pub fn set_gravity_comp_gain(&self, bus: &BusKey, gain: f64) -> bool {
+        self.gravity_comp.set_gain(bus, gain)
+    }
+
+    /// Returns the currently active gravity-comp gain for `bus`, or `None`
+    /// if it isn't running on that bus.
+    pub fn get_gravity_comp_gain(&self, bus: &BusKey) -> Option<f64> {
+        self.gravity_comp.get_gain(bus)
     }
 
     pub fn start(&self, from: BusKey, to: Vec<BusKey>) {

--- a/software/drivers/motors-mirroring/src/inference/mod.rs
+++ b/software/drivers/motors-mirroring/src/inference/mod.rs
@@ -46,16 +46,22 @@ impl Inference {
     }
 
     /// Starts gravity compensation for `bus`. No-op if already running.
-    /// `initial_gain`, if provided, overrides the configured default gain
-    /// for this run (still hard-clamped either way). `on_self_stop` is
-    /// called if the control loop terminates itself for safety reasons
-    /// (stale data or sustained overcurrent), so the caller can keep
-    /// displayed mode state truthful.
-    pub fn start_gravity_comp<F>(&self, bus: BusKey, initial_gain: Option<f64>, on_self_stop: F)
-    where
+    /// `initial_gains`/`initial_torque_limit`, if provided (e.g. from
+    /// previously-saved settings), override the configured defaults for
+    /// this run (still hard-clamped either way). `on_self_stop` is called if
+    /// the control loop terminates itself for safety reasons (stale data or
+    /// sustained overcurrent), so the caller can keep displayed mode state
+    /// truthful.
+    pub fn start_gravity_comp<F>(
+        &self,
+        bus: BusKey,
+        initial_gains: Option<crate::gravity_comp::JointGains>,
+        initial_torque_limit: Option<u16>,
+        on_self_stop: F,
+    ) where
         F: Fn(BusKey) + Send + Sync + 'static,
     {
-        self.gravity_comp.start(bus, self.config.clone(), initial_gain, Arc::clone(&self.normfs), on_self_stop);
+        self.gravity_comp.start(bus, self.config.clone(), initial_gains, initial_torque_limit, Arc::clone(&self.normfs), on_self_stop);
     }
 
     /// Stops gravity compensation for `bus` (if running) and disables torque
@@ -64,22 +70,46 @@ impl Inference {
         self.gravity_comp.stop(&bus, &self.normfs);
     }
 
-    /// Live-updates the gravity-comp gain for `bus` without restarting it.
-    /// Returns `false` if gravity comp isn't currently running on that bus.
-    pub fn set_gravity_comp_gain(&self, bus: &BusKey, gain: f64) -> bool {
-        self.gravity_comp.set_gain(bus, gain)
+    /// Live-updates the gain of one arm joint (`motor_id`, 1-7) for `bus`
+    /// without restarting it. Returns `false` if gravity comp isn't
+    /// currently running on that bus, or `motor_id` isn't a compensated
+    /// joint.
+    pub fn set_gravity_comp_gain(&self, bus: &BusKey, motor_id: u8, gain: f64) -> bool {
+        self.gravity_comp.set_gain(bus, motor_id, gain)
     }
 
-    /// Returns the currently active gravity-comp gain for `bus`, or `None`
-    /// if it isn't running on that bus.
-    pub fn get_gravity_comp_gain(&self, bus: &BusKey) -> Option<f64> {
-        self.gravity_comp.get_gain(bus)
+    /// Live-updates the gravity-comp torque limit for `bus` without
+    /// restarting it. Returns `false` if gravity comp isn't currently
+    /// running on that bus.
+    pub fn set_gravity_comp_torque_limit(&self, bus: &BusKey, torque_limit: u16) -> bool {
+        self.gravity_comp.set_torque_limit(bus, torque_limit, &self.normfs)
+    }
+
+    /// Returns the currently active per-joint gravity-comp gains for `bus`,
+    /// or `None` if it isn't running on that bus.
+    pub fn get_gravity_comp_gains(&self, bus: &BusKey) -> Option<crate::gravity_comp::JointGains> {
+        self.gravity_comp.get_gains(bus)
+    }
+
+    /// Returns the currently active gravity-comp torque limit for `bus`, or
+    /// `None` if it isn't running on that bus.
+    pub fn get_gravity_comp_torque_limit(&self, bus: &BusKey) -> Option<u16> {
+        self.gravity_comp.get_torque_limit(bus)
     }
 
     /// Stops every currently-running gravity-comp task. Called during
     /// graceful process shutdown.
     pub fn stop_all_gravity_comp(&self) {
         self.gravity_comp.stop_all(&self.normfs);
+    }
+
+    /// The configured defaults (from YAML, or built-in if unset) for a bus
+    /// that has no running task and no staged/saved settings yet.
+    pub fn gravity_comp_defaults(&self) -> crate::gravity_comp::GravitySettings {
+        crate::gravity_comp::GravitySettings {
+            joint_gains: [self.config.gravity_comp.gain_rad_per_nm; 7],
+            torque_limit: self.config.gravity_comp.torque_limit,
+        }
     }
 
     pub fn start(&self, from: BusKey, to: Vec<BusKey>) {

--- a/software/drivers/motors-mirroring/src/lib.rs
+++ b/software/drivers/motors-mirroring/src/lib.rs
@@ -255,12 +255,16 @@ fn merge_modes(
         let gravity_bus_states = gravity_current
             .clone()
             .into_iter()
-            .map(|(key, value)| mirroring::GravityCompBusState {
-                id: Some(mirroring::MirroringBus {
-                    unique_id: key.bus_id,
-                    r#type: key.bus_type as i32,
-                }),
-                state: value as i32,
+            .map(|(key, value)| {
+                let gain_rad_per_nm = inference.get_gravity_comp_gain(&key);
+                mirroring::GravityCompBusState {
+                    id: Some(mirroring::MirroringBus {
+                        unique_id: key.bus_id,
+                        r#type: key.bus_type as i32,
+                    }),
+                    state: value as i32,
+                    gain_rad_per_nm,
+                }
             })
             .collect();
 
@@ -326,6 +330,8 @@ fn merge_modes(
                         handle_stop_gravity_comp(command, modes, gravity_modes, inference, normfs, rx_queue_id);
                     } else if command.r#type == mirroring::GravityCompCommandType::GctStartGravityComp as i32 {
                         handle_start_gravity_comp(command, modes, gravity_modes, inference, normfs, rx_queue_id);
+                    } else if command.r#type == mirroring::GravityCompCommandType::GctSetGain as i32 {
+                        handle_set_gravity_comp_gain(command, modes, gravity_modes, inference, normfs, rx_queue_id);
                     }
                 }
                 _ => continue,
@@ -486,7 +492,8 @@ fn merge_modes(
             }
         };
 
-        log::info!("Starting gravity compensation for bus: {:?}", bus_key);
+        let initial_gain = command.gain_rad_per_nm;
+        log::info!("Starting gravity compensation for bus: {:?} (initial_gain={:?})", bus_key, initial_gain);
 
         let cb_modes = Arc::clone(modes);
         let cb_gravity_modes = Arc::clone(gravity_modes);
@@ -494,7 +501,7 @@ fn merge_modes(
         let cb_normfs = Arc::clone(normfs);
         let cb_rx_queue_id = rx_queue_id.clone();
 
-        inference.start_gravity_comp(bus_key.clone(), move |bus| {
+        inference.start_gravity_comp(bus_key.clone(), initial_gain, move |bus| {
             log::warn!("Gravity comp on bus {:?} self-stopped for safety; updating mode state", bus);
             deactivate_gravity_comp(bus, &cb_modes, &cb_gravity_modes, &cb_inference, &cb_normfs, &cb_rx_queue_id, None);
         });
@@ -525,6 +532,47 @@ fn merge_modes(
 
         log::info!("Stopping gravity compensation for bus: {:?}", bus_key);
         deactivate_gravity_comp(bus_key, modes, gravity_modes, inference, normfs, rx_queue_id, Some(command));
+    }
+
+    /// Live-updates the gain of an already-running gravity-comp task (e.g.
+    /// from a UI slider), without restarting it. No-op (logged) if gravity
+    /// comp isn't running on the given bus, or if the command has no gain.
+    fn handle_set_gravity_comp_gain(
+        command: mirroring::GravityCompCommand,
+        modes: &Arc<RwLock<HashMap<BusKey, mirroring::BusMode>>>,
+        gravity_modes: &Arc<RwLock<HashMap<BusKey, mirroring::GravityCompState>>>,
+        inference: &Arc<Inference>,
+        normfs: &Arc<NormFS>,
+        rx_queue_id: &normfs::QueueId,
+    ) {
+        let bus_key = match decode_gravity_comp_bus(&command.bus) {
+            Some(bus_key) => bus_key,
+            None => {
+                log::warn!("Gravity comp set-gain command missing or invalid bus");
+                return;
+            }
+        };
+
+        let gain = match command.gain_rad_per_nm {
+            Some(gain) => gain,
+            None => {
+                log::warn!("Gravity comp set-gain command for bus {:?} missing gain value", bus_key);
+                return;
+            }
+        };
+
+        if !inference.set_gravity_comp_gain(&bus_key, gain) {
+            log::warn!("Gravity comp set-gain for bus {:?} ignored: not currently running", bus_key);
+            return;
+        }
+
+        log::info!("Gravity comp gain for bus {:?} set to {}", bus_key, gain);
+
+        // No mode transition here, but re-broadcast so the new gain shows up
+        // in InferenceState.gravity_comp for any connected UI.
+        let mut modes_guard = modes.write().unwrap();
+        let mut gravity_guard = gravity_modes.write().unwrap();
+        merge_modes(&mut modes_guard, &HashMap::new(), &mut gravity_guard, &HashMap::new(), inference, normfs, rx_queue_id, None, Some(command));
     }
 
     /// Shared teardown path for both an operator-issued stop command and a

--- a/software/drivers/motors-mirroring/src/lib.rs
+++ b/software/drivers/motors-mirroring/src/lib.rs
@@ -8,7 +8,12 @@ use normfs::NormFS;
 use tokio::sync::mpsc;
 use normfs::UintN;
 
-use crate::{inference::Inference, proto::mirroring::{self, ModeEnvelope, GravityCompModeEnvelope}};
+use crate::{
+    config::{clamp_gravity_comp_gain, clamp_gravity_comp_torque_limit},
+    gravity_comp::GravitySettings,
+    inference::Inference,
+    proto::mirroring::{self, ModeEnvelope, GravityCompModeEnvelope, GravityCompSettingsEnvelope},
+};
 
 pub mod proto {
     pub mod mirroring {
@@ -25,7 +30,12 @@ use r#types::BusKey;
 
 const MODES_QUEUE_ID: &str = "motors_mirroring/modes";
 const GRAVITY_MODES_QUEUE_ID: &str = "motors_mirroring/gravity_comp_modes";
+const GRAVITY_SETTINGS_QUEUE_ID: &str = "motors_mirroring/gravity_comp_settings";
 const RX_QUEUE_ID: &str = "inference/mirroring";
+
+type ModesMap = Arc<RwLock<HashMap<BusKey, mirroring::BusMode>>>;
+type GravityModesMap = Arc<RwLock<HashMap<BusKey, mirroring::GravityCompState>>>;
+type GravitySettingsMap = Arc<RwLock<HashMap<BusKey, GravitySettings>>>;
 
 /// Returns the shared `Inference` handle so callers (e.g. the station
 /// binary's shutdown sequence) can explicitly stop any running gravity-comp
@@ -39,10 +49,12 @@ pub async fn start<T: StationEngine>(
 ) -> Result<Arc<Inference>, normfs::Error> {
         let modes_queue_id = normfs.resolve(MODES_QUEUE_ID);
         let gravity_modes_queue_id = normfs.resolve(GRAVITY_MODES_QUEUE_ID);
+        let gravity_settings_queue_id = normfs.resolve(GRAVITY_SETTINGS_QUEUE_ID);
         let rx_queue_id = normfs.resolve(RX_QUEUE_ID);
 
         normfs.ensure_queue_exists_for_write(&modes_queue_id).await?;
         normfs.ensure_queue_exists_for_write(&gravity_modes_queue_id).await?;
+        normfs.ensure_queue_exists_for_write(&gravity_settings_queue_id).await?;
         normfs.ensure_queue_exists_for_write(&rx_queue_id).await?;
 
         station_engine.register_queue(
@@ -58,20 +70,29 @@ pub async fn start<T: StationEngine>(
         );
 
         station_engine.register_queue(
+            &gravity_settings_queue_id,
+            drivers::QueueDataType::QdtMotorMirroringGravityCompSettings,
+            vec![],
+        );
+
+        station_engine.register_queue(
             &rx_queue_id,
             drivers::QueueDataType::QdtMotorMirroringRx,
             vec![],
         );
 
-        let modes = Arc::new(RwLock::new(HashMap::new()));
-        let gravity_modes = Arc::new(RwLock::new(HashMap::new()));
+        let modes: ModesMap = Arc::new(RwLock::new(HashMap::new()));
+        let gravity_modes: GravityModesMap = Arc::new(RwLock::new(HashMap::new()));
+        let gravity_settings: GravitySettingsMap = Arc::new(RwLock::new(HashMap::new()));
 
         let task_modes = modes.clone();
         let task_gravity_modes = gravity_modes.clone();
         let reading_normfs = normfs.clone();
         let reading_gravity_normfs = normfs.clone();
+        let reading_gravity_settings_normfs = normfs.clone();
         let task_normfs = normfs.clone();
         let task_gravity_normfs = normfs.clone();
+        let task_gravity_settings_normfs = normfs.clone();
 
         let inf = Arc::new(inference::Inference::new(
             motor_config,
@@ -79,16 +100,20 @@ pub async fn start<T: StationEngine>(
         ));
         let read_inf = inf.clone();
         let read_gravity_inf = inf.clone();
+        let read_gravity_settings_inf = inf.clone();
 
         // Clone references for the command handler closure
         let cmd_modes = modes.clone();
         let cmd_gravity_modes = gravity_modes.clone();
+        let cmd_gravity_settings = gravity_settings.clone();
         let cmd_inf = inf.clone();
         let cmd_normfs = normfs.clone();
         let cmd_rx_queue_id = rx_queue_id.clone();
+        let cmd_gravity_settings_queue_id = gravity_settings_queue_id.clone();
 
         let modes_queue_id_clone = modes_queue_id.clone();
         let rx_queue_id_for_mirror_restore = rx_queue_id.clone();
+        let gravity_settings_for_mirror_restore = gravity_settings.clone();
         tokio::spawn(async move {
             let mut read_modes = HashMap::new();
 
@@ -127,11 +152,13 @@ pub async fn start<T: StationEngine>(
 
             let mut current_modes = task_modes.write().unwrap();
             let mut current_gravity_modes = task_gravity_modes.write().unwrap();
+            let gravity_settings_snapshot = gravity_settings_for_mirror_restore.read().unwrap().clone();
             merge_modes(
                 &mut current_modes,
                 &read_modes,
                 &mut current_gravity_modes,
                 &HashMap::new(),
+                &gravity_settings_snapshot,
                 &read_inf,
                 &task_normfs,
                 &rx_queue_id_for_mirror_restore,
@@ -152,6 +179,7 @@ pub async fn start<T: StationEngine>(
         let modes_for_gravity_restore = modes.clone();
         let gravity_modes_for_gravity_restore = gravity_modes.clone();
         let rx_queue_id_for_gravity_restore = rx_queue_id.clone();
+        let gravity_settings_for_gravity_restore = gravity_settings.clone();
         tokio::spawn(async move {
             let mut read_gravity_modes = HashMap::new();
 
@@ -193,14 +221,95 @@ pub async fn start<T: StationEngine>(
 
             let mut current_modes = modes_for_gravity_restore.write().unwrap();
             let mut current_gravity_modes = gravity_modes_for_gravity_restore.write().unwrap();
+            let gravity_settings_snapshot = gravity_settings_for_gravity_restore.read().unwrap().clone();
             merge_modes(
                 &mut current_modes,
                 &HashMap::new(),
                 &mut current_gravity_modes,
                 &read_gravity_modes,
+                &gravity_settings_snapshot,
                 &read_gravity_inf,
                 &task_gravity_normfs,
                 &rx_queue_id_for_gravity_restore,
+                None,
+                None,
+            );
+        });
+
+        // Restore saved per-joint gains/torque limit on boot - safe to load
+        // unconditionally (unlike the mode restore above): this only
+        // populates displayed/pre-fill data, it never starts anything.
+        let gravity_settings_queue_id_clone = gravity_settings_queue_id.clone();
+        let modes_for_settings_restore = modes.clone();
+        let gravity_modes_for_settings_restore = gravity_modes.clone();
+        let gravity_settings_for_settings_restore = gravity_settings.clone();
+        let rx_queue_id_for_settings_restore = rx_queue_id.clone();
+        tokio::spawn(async move {
+            let mut read_settings = HashMap::new();
+
+            let (tx, mut rx) = mpsc::channel(1);
+
+            tokio::spawn(async move {
+                let _ = reading_gravity_settings_normfs
+                    .read(&gravity_settings_queue_id_clone, normfs::ReadPosition::ShiftFromTail(UintN::from(1024u64)), 1024, 1, tx)
+                    .await;
+            });
+
+            while let Some(entry) = rx.recv().await {
+                match GravityCompSettingsEnvelope::decode(entry.data) {
+                    Ok(envelope) => {
+                        if let Some(bus) = envelope.bus {
+                            let bus_id = bus.unique_id.clone();
+                            let bus_type = match mirroring::BusType::try_from(bus.r#type) {
+                                Ok(bt) => bt,
+                                Err(_) => continue,
+                            };
+
+                            if envelope.joint_gains_rad_per_nm.len() != 7 {
+                                log::warn!(
+                                    "Skipping gravity comp settings for bus {} with {} joint gains (expected 7)",
+                                    bus_id,
+                                    envelope.joint_gains_rad_per_nm.len()
+                                );
+                                continue;
+                            }
+
+                            let mut joint_gains = [0.0f64; 7];
+                            joint_gains.copy_from_slice(&envelope.joint_gains_rad_per_nm);
+
+                            read_settings.insert(
+                                BusKey { bus_id, bus_type },
+                                GravitySettings {
+                                    joint_gains,
+                                    torque_limit: envelope.torque_limit as u16,
+                                },
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        log::error!("Error decoding gravity comp settings envelope at id {}: {:?}", entry.id, e);
+                    }
+                }
+            }
+
+            log::info!("Restored {} gravity comp settings from normfs", read_settings.len());
+
+            let mut current_settings = gravity_settings_for_settings_restore.write().unwrap();
+            for (key, value) in &read_settings {
+                current_settings.insert(key.clone(), *value);
+            }
+
+            let mut current_modes = modes_for_settings_restore.write().unwrap();
+            let mut current_gravity_modes = gravity_modes_for_settings_restore.write().unwrap();
+            merge_modes(
+                &mut current_modes,
+                &HashMap::new(),
+                &mut current_gravity_modes,
+                &HashMap::new(),
+                &current_settings,
+                &read_gravity_settings_inf,
+                &task_gravity_settings_normfs,
+                &rx_queue_id_for_settings_restore,
                 None,
                 None,
             );
@@ -214,9 +323,11 @@ pub async fn start<T: StationEngine>(
                         &pack,
                         &cmd_modes,
                         &cmd_gravity_modes,
+                        &cmd_gravity_settings,
                         &cmd_inf,
                         &cmd_normfs,
                         &cmd_rx_queue_id,
+                        &cmd_gravity_settings_queue_id,
                     );
                 }
             }
@@ -232,6 +343,7 @@ fn merge_modes(
         new_modes: &HashMap<BusKey, mirroring::BusMode>,
         gravity_current: &mut HashMap<BusKey, mirroring::GravityCompState>,
         new_gravity: &HashMap<BusKey, mirroring::GravityCompState>,
+        gravity_settings: &HashMap<BusKey, GravitySettings>,
         inference: &Inference,
         normfs: &Arc<NormFS>,
         rx_queue_id: &normfs::QueueId,
@@ -261,14 +373,18 @@ fn merge_modes(
             .clone()
             .into_iter()
             .map(|(key, value)| {
-                let gain_rad_per_nm = inference.get_gravity_comp_gain(&key);
+                let (joint_gains, torque_limit) = match gravity_settings.get(&key) {
+                    Some(settings) => (settings.joint_gains.to_vec(), Some(settings.torque_limit as u32)),
+                    None => (Vec::new(), None),
+                };
                 mirroring::GravityCompBusState {
                     id: Some(mirroring::MirroringBus {
                         unique_id: key.bus_id,
                         r#type: key.bus_type as i32,
                     }),
                     state: value as i32,
-                    gain_rad_per_nm,
+                    joint_gains_rad_per_nm: joint_gains,
+                    torque_limit,
                 }
             })
             .collect();
@@ -292,13 +408,16 @@ fn merge_modes(
         let _ = normfs.enqueue(rx_queue_id, rx_envelope.encode_to_vec().into());
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn process_command_pack(
         pack: &StationCommandsPack,
-        modes: &Arc<RwLock<HashMap<BusKey, mirroring::BusMode>>>,
-        gravity_modes: &Arc<RwLock<HashMap<BusKey, mirroring::GravityCompState>>>,
+        modes: &ModesMap,
+        gravity_modes: &GravityModesMap,
+        gravity_settings: &GravitySettingsMap,
         inference: &Arc<Inference>,
         normfs: &Arc<NormFS>,
         rx_queue_id: &normfs::QueueId,
+        gravity_settings_queue_id: &normfs::QueueId,
     ) {
         log::debug!("Received command pack: {:?}", pack.pack_id);
 
@@ -317,9 +436,9 @@ fn merge_modes(
                     };
 
                     if command.r#type == mirroring::CommandType::CtStopMirror as i32 {
-                        handle_stop_mirror(command, modes, gravity_modes, inference, normfs, rx_queue_id);
+                        handle_stop_mirror(command, modes, gravity_modes, gravity_settings, inference, normfs, rx_queue_id);
                     } else if command.r#type == mirroring::CommandType::CtStartMirror as i32 {
-                        handle_start_mirror(command, modes, gravity_modes, inference, normfs, rx_queue_id);
+                        handle_start_mirror(command, modes, gravity_modes, gravity_settings, inference, normfs, rx_queue_id);
                     }
                 }
                 station_iface::iface_proto::drivers::StationCommandType::StcGravityCompCommand => {
@@ -332,11 +451,15 @@ fn merge_modes(
                     };
 
                     if command.r#type == mirroring::GravityCompCommandType::GctStopGravityComp as i32 {
-                        handle_stop_gravity_comp(command, modes, gravity_modes, inference, normfs, rx_queue_id);
+                        handle_stop_gravity_comp(command, modes, gravity_modes, gravity_settings, inference, normfs, rx_queue_id);
                     } else if command.r#type == mirroring::GravityCompCommandType::GctStartGravityComp as i32 {
-                        handle_start_gravity_comp(command, modes, gravity_modes, inference, normfs, rx_queue_id);
+                        handle_start_gravity_comp(command, modes, gravity_modes, gravity_settings, inference, normfs, rx_queue_id);
                     } else if command.r#type == mirroring::GravityCompCommandType::GctSetGain as i32 {
-                        handle_set_gravity_comp_gain(command, modes, gravity_modes, inference, normfs, rx_queue_id);
+                        handle_set_gravity_comp_gain(command, modes, gravity_modes, gravity_settings, inference, normfs, rx_queue_id);
+                    } else if command.r#type == mirroring::GravityCompCommandType::GctSetTorqueLimit as i32 {
+                        handle_set_gravity_comp_torque_limit(command, modes, gravity_modes, gravity_settings, inference, normfs, rx_queue_id);
+                    } else if command.r#type == mirroring::GravityCompCommandType::GctSaveSettings as i32 {
+                        handle_save_gravity_comp_settings(command, gravity_settings, normfs, gravity_settings_queue_id);
                     }
                 }
                 _ => continue,
@@ -346,8 +469,9 @@ fn merge_modes(
 
     fn handle_stop_mirror(
         command: mirroring::Command,
-        modes: &Arc<RwLock<HashMap<BusKey, mirroring::BusMode>>>,
-        gravity_modes: &Arc<RwLock<HashMap<BusKey, mirroring::GravityCompState>>>,
+        modes: &ModesMap,
+        gravity_modes: &GravityModesMap,
+        gravity_settings: &GravitySettingsMap,
         inference: &Arc<Inference>,
         normfs: &Arc<NormFS>,
         rx_queue_id: &normfs::QueueId,
@@ -384,13 +508,15 @@ fn merge_modes(
 
         let mut modes_guard = modes.write().unwrap();
         let mut gravity_guard = gravity_modes.write().unwrap();
-        merge_modes(&mut modes_guard, &HashMap::new(), &mut gravity_guard, &HashMap::new(), inference, normfs, rx_queue_id, Some(command), None);
+        let gravity_settings_snapshot = gravity_settings.read().unwrap().clone();
+        merge_modes(&mut modes_guard, &HashMap::new(), &mut gravity_guard, &HashMap::new(), &gravity_settings_snapshot, inference, normfs, rx_queue_id, Some(command), None);
     }
 
     fn handle_start_mirror(
         command: mirroring::Command,
-        modes: &Arc<RwLock<HashMap<BusKey, mirroring::BusMode>>>,
-        gravity_modes: &Arc<RwLock<HashMap<BusKey, mirroring::GravityCompState>>>,
+        modes: &ModesMap,
+        gravity_modes: &GravityModesMap,
+        gravity_settings: &GravitySettingsMap,
         inference: &Arc<Inference>,
         normfs: &Arc<NormFS>,
         rx_queue_id: &normfs::QueueId,
@@ -462,7 +588,8 @@ fn merge_modes(
 
         let mut modes_guard = modes.write().unwrap();
         let mut gravity_guard = gravity_modes.write().unwrap();
-        merge_modes(&mut modes_guard, &new_modes, &mut gravity_guard, &HashMap::new(), inference, normfs, rx_queue_id, Some(command), None);
+        let gravity_settings_snapshot = gravity_settings.read().unwrap().clone();
+        merge_modes(&mut modes_guard, &new_modes, &mut gravity_guard, &HashMap::new(), &gravity_settings_snapshot, inference, normfs, rx_queue_id, Some(command), None);
     }
 
     fn decode_gravity_comp_bus(bus: &Option<mirroring::MirroringBus>) -> Option<BusKey> {
@@ -481,10 +608,22 @@ fn merge_modes(
         Some(BusKey { bus_id: bus.unique_id.clone(), bus_type })
     }
 
+    /// Gets or creates this bus's staged gravity settings entry, seeded from
+    /// the configured defaults if it doesn't exist yet.
+    fn ensure_gravity_settings(
+        gravity_settings: &GravitySettingsMap,
+        bus_key: &BusKey,
+        inference: &Inference,
+    ) -> GravitySettings {
+        let mut guard = gravity_settings.write().unwrap();
+        *guard.entry(bus_key.clone()).or_insert_with(|| inference.gravity_comp_defaults())
+    }
+
     fn handle_start_gravity_comp(
         command: mirroring::GravityCompCommand,
-        modes: &Arc<RwLock<HashMap<BusKey, mirroring::BusMode>>>,
-        gravity_modes: &Arc<RwLock<HashMap<BusKey, mirroring::GravityCompState>>>,
+        modes: &ModesMap,
+        gravity_modes: &GravityModesMap,
+        gravity_settings: &GravitySettingsMap,
         inference: &Arc<Inference>,
         normfs: &Arc<NormFS>,
         rx_queue_id: &normfs::QueueId,
@@ -497,18 +636,27 @@ fn merge_modes(
             }
         };
 
-        let initial_gain = command.gain_rad_per_nm;
-        log::info!("Starting gravity compensation for bus: {:?} (initial_gain={:?})", bus_key, initial_gain);
+        // Seed from whatever's already staged/saved for this bus (or the
+        // configured defaults if it's never been touched) rather than
+        // always resetting to config defaults on every start.
+        let settings = ensure_gravity_settings(gravity_settings, &bus_key, inference);
+        log::info!(
+            "Starting gravity compensation for bus: {:?} (gains={:?}, torque_limit={})",
+            bus_key,
+            settings.joint_gains,
+            settings.torque_limit
+        );
 
         let cb_modes = Arc::clone(modes);
         let cb_gravity_modes = Arc::clone(gravity_modes);
+        let cb_gravity_settings = Arc::clone(gravity_settings);
         let cb_inference = Arc::clone(inference);
         let cb_normfs = Arc::clone(normfs);
         let cb_rx_queue_id = rx_queue_id.clone();
 
-        inference.start_gravity_comp(bus_key.clone(), initial_gain, move |bus| {
+        inference.start_gravity_comp(bus_key.clone(), Some(settings.joint_gains), Some(settings.torque_limit), move |bus| {
             log::warn!("Gravity comp on bus {:?} self-stopped for safety; updating mode state", bus);
-            deactivate_gravity_comp(bus, &cb_modes, &cb_gravity_modes, &cb_inference, &cb_normfs, &cb_rx_queue_id, None);
+            deactivate_gravity_comp(bus, &cb_modes, &cb_gravity_modes, &cb_gravity_settings, &cb_inference, &cb_normfs, &cb_rx_queue_id, None);
         });
 
         let mut new_gravity = HashMap::new();
@@ -516,13 +664,15 @@ fn merge_modes(
 
         let mut modes_guard = modes.write().unwrap();
         let mut gravity_guard = gravity_modes.write().unwrap();
-        merge_modes(&mut modes_guard, &HashMap::new(), &mut gravity_guard, &new_gravity, inference, normfs, rx_queue_id, None, Some(command));
+        let gravity_settings_snapshot = gravity_settings.read().unwrap().clone();
+        merge_modes(&mut modes_guard, &HashMap::new(), &mut gravity_guard, &new_gravity, &gravity_settings_snapshot, inference, normfs, rx_queue_id, None, Some(command));
     }
 
     fn handle_stop_gravity_comp(
         command: mirroring::GravityCompCommand,
-        modes: &Arc<RwLock<HashMap<BusKey, mirroring::BusMode>>>,
-        gravity_modes: &Arc<RwLock<HashMap<BusKey, mirroring::GravityCompState>>>,
+        modes: &ModesMap,
+        gravity_modes: &GravityModesMap,
+        gravity_settings: &GravitySettingsMap,
         inference: &Arc<Inference>,
         normfs: &Arc<NormFS>,
         rx_queue_id: &normfs::QueueId,
@@ -536,16 +686,20 @@ fn merge_modes(
         };
 
         log::info!("Stopping gravity compensation for bus: {:?}", bus_key);
-        deactivate_gravity_comp(bus_key, modes, gravity_modes, inference, normfs, rx_queue_id, Some(command));
+        deactivate_gravity_comp(bus_key, modes, gravity_modes, gravity_settings, inference, normfs, rx_queue_id, Some(command));
     }
 
-    /// Live-updates the gain of an already-running gravity-comp task (e.g.
-    /// from a UI slider), without restarting it. No-op (logged) if gravity
-    /// comp isn't running on the given bus, or if the command has no gain.
+    /// Live-updates the gain of one arm joint on an already-running
+    /// gravity-comp task (e.g. from a table cell in the UI), without
+    /// restarting it. Always updates the staged settings (so the value is
+    /// remembered/shown even if not currently running); only actually
+    /// re-applies it to hardware if gravity comp is running on this bus.
+    #[allow(clippy::too_many_arguments)]
     fn handle_set_gravity_comp_gain(
         command: mirroring::GravityCompCommand,
-        modes: &Arc<RwLock<HashMap<BusKey, mirroring::BusMode>>>,
-        gravity_modes: &Arc<RwLock<HashMap<BusKey, mirroring::GravityCompState>>>,
+        modes: &ModesMap,
+        gravity_modes: &GravityModesMap,
+        gravity_settings: &GravitySettingsMap,
         inference: &Arc<Inference>,
         normfs: &Arc<NormFS>,
         rx_queue_id: &normfs::QueueId,
@@ -558,6 +712,14 @@ fn merge_modes(
             }
         };
 
+        let motor_id = match command.motor_id {
+            Some(id) if (1..=7).contains(&id) => id as u8,
+            _ => {
+                log::warn!("Gravity comp set-gain command for bus {:?} missing/invalid motor_id", bus_key);
+                return;
+            }
+        };
+
         let gain = match command.gain_rad_per_nm {
             Some(gain) => gain,
             None => {
@@ -566,18 +728,127 @@ fn merge_modes(
             }
         };
 
-        if !inference.set_gravity_comp_gain(&bus_key, gain) {
-            log::warn!("Gravity comp set-gain for bus {:?} ignored: not currently running", bus_key);
-            return;
+        let clamped_gain = clamp_gravity_comp_gain(gain);
+        {
+            let mut settings = ensure_gravity_settings(gravity_settings, &bus_key, inference);
+            settings.joint_gains[(motor_id - 1) as usize] = clamped_gain;
+            gravity_settings.write().unwrap().insert(bus_key.clone(), settings);
         }
 
-        log::info!("Gravity comp gain for bus {:?} set to {}", bus_key, gain);
+        let applied_live = inference.set_gravity_comp_gain(&bus_key, motor_id, gain);
+        log::info!(
+            "Gravity comp gain for bus {:?} motor {} set to {} (applied_live={})",
+            bus_key,
+            motor_id,
+            clamped_gain,
+            applied_live
+        );
 
         // No mode transition here, but re-broadcast so the new gain shows up
         // in InferenceState.gravity_comp for any connected UI.
         let mut modes_guard = modes.write().unwrap();
         let mut gravity_guard = gravity_modes.write().unwrap();
-        merge_modes(&mut modes_guard, &HashMap::new(), &mut gravity_guard, &HashMap::new(), inference, normfs, rx_queue_id, None, Some(command));
+        let gravity_settings_snapshot = gravity_settings.read().unwrap().clone();
+        merge_modes(&mut modes_guard, &HashMap::new(), &mut gravity_guard, &HashMap::new(), &gravity_settings_snapshot, inference, normfs, rx_queue_id, None, Some(command));
+    }
+
+    /// Live-updates the torque limit (all 7 arm motors) for an already-running
+    /// gravity-comp task, without restarting it. Same staged-vs-live handling
+    /// as `handle_set_gravity_comp_gain` above.
+    #[allow(clippy::too_many_arguments)]
+    fn handle_set_gravity_comp_torque_limit(
+        command: mirroring::GravityCompCommand,
+        modes: &ModesMap,
+        gravity_modes: &GravityModesMap,
+        gravity_settings: &GravitySettingsMap,
+        inference: &Arc<Inference>,
+        normfs: &Arc<NormFS>,
+        rx_queue_id: &normfs::QueueId,
+    ) {
+        let bus_key = match decode_gravity_comp_bus(&command.bus) {
+            Some(bus_key) => bus_key,
+            None => {
+                log::warn!("Gravity comp set-torque-limit command missing or invalid bus");
+                return;
+            }
+        };
+
+        let torque_limit = match command.torque_limit {
+            Some(t) => t as u16,
+            None => {
+                log::warn!("Gravity comp set-torque-limit command for bus {:?} missing torque_limit value", bus_key);
+                return;
+            }
+        };
+
+        let clamped = clamp_gravity_comp_torque_limit(torque_limit);
+        {
+            let mut settings = ensure_gravity_settings(gravity_settings, &bus_key, inference);
+            settings.torque_limit = clamped;
+            gravity_settings.write().unwrap().insert(bus_key.clone(), settings);
+        }
+
+        let applied_live = inference.set_gravity_comp_torque_limit(&bus_key, torque_limit);
+        log::info!(
+            "Gravity comp torque limit for bus {:?} set to {} (applied_live={})",
+            bus_key,
+            clamped,
+            applied_live
+        );
+
+        let mut modes_guard = modes.write().unwrap();
+        let mut gravity_guard = gravity_modes.write().unwrap();
+        let gravity_settings_snapshot = gravity_settings.read().unwrap().clone();
+        merge_modes(&mut modes_guard, &HashMap::new(), &mut gravity_guard, &HashMap::new(), &gravity_settings_snapshot, inference, normfs, rx_queue_id, None, Some(command));
+    }
+
+    /// Persists this bus's current staged gravity-comp settings (per-joint
+    /// gains + torque limit) to the `motors_mirroring/gravity_comp_settings`
+    /// queue, so they're restored as the defaults next time gravity comp is
+    /// started on this bus - even across a station restart. No-op (logged)
+    /// if there's nothing staged yet for this bus.
+    fn handle_save_gravity_comp_settings(
+        command: mirroring::GravityCompCommand,
+        gravity_settings: &GravitySettingsMap,
+        normfs: &Arc<NormFS>,
+        gravity_settings_queue_id: &normfs::QueueId,
+    ) {
+        let bus_key = match decode_gravity_comp_bus(&command.bus) {
+            Some(bus_key) => bus_key,
+            None => {
+                log::warn!("Gravity comp save-settings command missing or invalid bus");
+                return;
+            }
+        };
+
+        let settings = gravity_settings.read().unwrap().get(&bus_key).copied();
+        let settings = match settings {
+            Some(settings) => settings,
+            None => {
+                log::warn!("Gravity comp save-settings for bus {:?} ignored: nothing staged yet", bus_key);
+                return;
+            }
+        };
+
+        let envelope = mirroring::GravityCompSettingsEnvelope {
+            monotonic_stamp_ns: systime::get_monotonic_stamp_ns(),
+            local_stamp_ns: systime::get_local_stamp_ns(),
+            app_start_id: systime::get_app_start_id(),
+            bus: Some(mirroring::MirroringBus {
+                unique_id: bus_key.bus_id.clone(),
+                r#type: bus_key.bus_type as i32,
+            }),
+            joint_gains_rad_per_nm: settings.joint_gains.to_vec(),
+            torque_limit: settings.torque_limit as u32,
+        };
+
+        let _ = normfs.enqueue(gravity_settings_queue_id, envelope.encode_to_vec().into());
+        log::info!(
+            "Saved gravity comp settings for bus {:?}: gains={:?}, torque_limit={}",
+            bus_key,
+            settings.joint_gains,
+            settings.torque_limit
+        );
     }
 
     /// Shared teardown path for both an operator-issued stop command and a
@@ -585,10 +856,12 @@ fn merge_modes(
     /// overcurrent) - both must converge on the same task-registry cleanup
     /// and mode broadcast so displayed state never drifts from what's
     /// actually running.
+    #[allow(clippy::too_many_arguments)]
     fn deactivate_gravity_comp(
         bus_key: BusKey,
-        modes: &Arc<RwLock<HashMap<BusKey, mirroring::BusMode>>>,
-        gravity_modes: &Arc<RwLock<HashMap<BusKey, mirroring::GravityCompState>>>,
+        modes: &ModesMap,
+        gravity_modes: &GravityModesMap,
+        gravity_settings: &GravitySettingsMap,
         inference: &Arc<Inference>,
         normfs: &Arc<NormFS>,
         rx_queue_id: &normfs::QueueId,
@@ -601,5 +874,6 @@ fn merge_modes(
 
         let mut modes_guard = modes.write().unwrap();
         let mut gravity_guard = gravity_modes.write().unwrap();
-        merge_modes(&mut modes_guard, &HashMap::new(), &mut gravity_guard, &new_gravity, inference, normfs, rx_queue_id, None, command);
+        let gravity_settings_snapshot = gravity_settings.read().unwrap().clone();
+        merge_modes(&mut modes_guard, &HashMap::new(), &mut gravity_guard, &new_gravity, &gravity_settings_snapshot, inference, normfs, rx_queue_id, None, command);
     }

--- a/software/drivers/motors-mirroring/src/lib.rs
+++ b/software/drivers/motors-mirroring/src/lib.rs
@@ -18,7 +18,7 @@ pub mod proto {
 
 pub mod config;
 mod r#types;
-mod inference;
+pub mod inference;
 mod gravity_comp;
 
 use r#types::BusKey;
@@ -27,11 +27,16 @@ const MODES_QUEUE_ID: &str = "motors_mirroring/modes";
 const GRAVITY_MODES_QUEUE_ID: &str = "motors_mirroring/gravity_comp_modes";
 const RX_QUEUE_ID: &str = "inference/mirroring";
 
+/// Returns the shared `Inference` handle so callers (e.g. the station
+/// binary's shutdown sequence) can explicitly stop any running gravity-comp
+/// tasks - and thus disable torque on their buses - before the process
+/// exits, rather than leaving it to implicit task-drop when the runtime
+/// tears down.
 pub async fn start<T: StationEngine>(
     normfs: Arc<NormFS>,
     station_engine: Arc<T>,
     motor_config: config::MotorConfig,
-) -> Result<(), normfs::Error> {
+) -> Result<Arc<Inference>, normfs::Error> {
         let modes_queue_id = normfs.resolve(MODES_QUEUE_ID);
         let gravity_modes_queue_id = normfs.resolve(GRAVITY_MODES_QUEUE_ID);
         let rx_queue_id = normfs.resolve(RX_QUEUE_ID);
@@ -218,7 +223,7 @@ pub async fn start<T: StationEngine>(
             true
         }))?;
 
-        Ok(())
+        Ok(inf)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/software/drivers/motors-mirroring/src/lib.rs
+++ b/software/drivers/motors-mirroring/src/lib.rs
@@ -8,7 +8,7 @@ use normfs::NormFS;
 use tokio::sync::mpsc;
 use normfs::UintN;
 
-use crate::{inference::Inference, proto::mirroring::{self, ModeEnvelope}};
+use crate::{inference::Inference, proto::mirroring::{self, ModeEnvelope, GravityCompModeEnvelope}};
 
 pub mod proto {
     pub mod mirroring {
@@ -19,10 +19,12 @@ pub mod proto {
 pub mod config;
 mod r#types;
 mod inference;
+mod gravity_comp;
 
 use r#types::BusKey;
 
 const MODES_QUEUE_ID: &str = "motors_mirroring/modes";
+const GRAVITY_MODES_QUEUE_ID: &str = "motors_mirroring/gravity_comp_modes";
 const RX_QUEUE_ID: &str = "inference/mirroring";
 
 pub async fn start<T: StationEngine>(
@@ -31,14 +33,22 @@ pub async fn start<T: StationEngine>(
     motor_config: config::MotorConfig,
 ) -> Result<(), normfs::Error> {
         let modes_queue_id = normfs.resolve(MODES_QUEUE_ID);
+        let gravity_modes_queue_id = normfs.resolve(GRAVITY_MODES_QUEUE_ID);
         let rx_queue_id = normfs.resolve(RX_QUEUE_ID);
 
         normfs.ensure_queue_exists_for_write(&modes_queue_id).await?;
+        normfs.ensure_queue_exists_for_write(&gravity_modes_queue_id).await?;
         normfs.ensure_queue_exists_for_write(&rx_queue_id).await?;
 
         station_engine.register_queue(
             &modes_queue_id,
             drivers::QueueDataType::QdtMotorMirroringModes,
+            vec![],
+        );
+
+        station_engine.register_queue(
+            &gravity_modes_queue_id,
+            drivers::QueueDataType::QdtMotorMirroringGravityCompModes,
             vec![],
         );
 
@@ -49,24 +59,31 @@ pub async fn start<T: StationEngine>(
         );
 
         let modes = Arc::new(RwLock::new(HashMap::new()));
+        let gravity_modes = Arc::new(RwLock::new(HashMap::new()));
 
         let task_modes = modes.clone();
+        let task_gravity_modes = gravity_modes.clone();
         let reading_normfs = normfs.clone();
+        let reading_gravity_normfs = normfs.clone();
         let task_normfs = normfs.clone();
+        let task_gravity_normfs = normfs.clone();
 
         let inf = Arc::new(inference::Inference::new(
             motor_config,
             normfs.clone(),
         ));
         let read_inf = inf.clone();
+        let read_gravity_inf = inf.clone();
 
         // Clone references for the command handler closure
         let cmd_modes = modes.clone();
+        let cmd_gravity_modes = gravity_modes.clone();
         let cmd_inf = inf.clone();
         let cmd_normfs = normfs.clone();
         let cmd_rx_queue_id = rx_queue_id.clone();
 
         let modes_queue_id_clone = modes_queue_id.clone();
+        let rx_queue_id_for_mirror_restore = rx_queue_id.clone();
         tokio::spawn(async move {
             let mut read_modes = HashMap::new();
 
@@ -104,7 +121,84 @@ pub async fn start<T: StationEngine>(
             log::info!("Restored {} bus modes from normfs", read_modes.len());
 
             let mut current_modes = task_modes.write().unwrap();
-            merge_modes(&mut current_modes, &read_modes, &read_inf, &task_normfs, &rx_queue_id, None);
+            let mut current_gravity_modes = task_gravity_modes.write().unwrap();
+            merge_modes(
+                &mut current_modes,
+                &read_modes,
+                &mut current_gravity_modes,
+                &HashMap::new(),
+                &read_inf,
+                &task_normfs,
+                &rx_queue_id_for_mirror_restore,
+                None,
+                None,
+            );
+        });
+
+        // Restore gravity-comp mode *display* state on boot only - deliberately
+        // does NOT call `inference.start_gravity_comp()` for buses restored as
+        // enabled. Gravity comp actively drives motors the instant its control
+        // loop starts, unlike mirroring pairs (which are inert relationships
+        // until a live mirror() loop reads fresh leader data), so silently
+        // resuming it after a process restart with no fresh operator
+        // confirmation would be unsafe. An explicit start command is always
+        // required to actually (re-)arm it.
+        let gravity_modes_queue_id_clone = gravity_modes_queue_id.clone();
+        let modes_for_gravity_restore = modes.clone();
+        let gravity_modes_for_gravity_restore = gravity_modes.clone();
+        let rx_queue_id_for_gravity_restore = rx_queue_id.clone();
+        tokio::spawn(async move {
+            let mut read_gravity_modes = HashMap::new();
+
+            let (tx, mut rx) = mpsc::channel(1);
+
+            tokio::spawn(async move {
+                let _ = reading_gravity_normfs
+                    .read(&gravity_modes_queue_id_clone, normfs::ReadPosition::ShiftFromTail(UintN::from(1024u64)), 1024, 1, tx)
+                    .await;
+            });
+
+            while let Some(entry) = rx.recv().await {
+                match GravityCompModeEnvelope::decode(entry.data) {
+                    Ok(envelope) => {
+                        if let Some(bus) = envelope.bus {
+                            let bus_id = bus.unique_id.clone();
+                            let bus_type = match mirroring::BusType::try_from(bus.r#type) {
+                                Ok(bt) => bt,
+                                Err(_) => continue,
+                            };
+                            let state = match mirroring::GravityCompState::try_from(envelope.state) {
+                                Ok(s) => s,
+                                Err(_) => continue,
+                            };
+
+                            read_gravity_modes.insert(BusKey { bus_id, bus_type }, state);
+                        }
+                    }
+                    Err(e) => {
+                        log::error!("Error decoding gravity comp mode envelope at id {}: {:?}", entry.id, e);
+                    }
+                }
+            }
+
+            log::info!(
+                "Restored {} gravity comp bus modes from normfs (display only, not re-armed)",
+                read_gravity_modes.len()
+            );
+
+            let mut current_modes = modes_for_gravity_restore.write().unwrap();
+            let mut current_gravity_modes = gravity_modes_for_gravity_restore.write().unwrap();
+            merge_modes(
+                &mut current_modes,
+                &HashMap::new(),
+                &mut current_gravity_modes,
+                &read_gravity_modes,
+                &read_gravity_inf,
+                &task_gravity_normfs,
+                &rx_queue_id_for_gravity_restore,
+                None,
+                None,
+            );
         });
 
         let commands_queue_id = normfs.resolve("commands");
@@ -114,6 +208,7 @@ pub async fn start<T: StationEngine>(
                     process_command_pack(
                         &pack,
                         &cmd_modes,
+                        &cmd_gravity_modes,
                         &cmd_inf,
                         &cmd_normfs,
                         &cmd_rx_queue_id,
@@ -126,16 +221,23 @@ pub async fn start<T: StationEngine>(
         Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn merge_modes(
         current: &mut HashMap<BusKey, mirroring::BusMode>,
         new_modes: &HashMap<BusKey, mirroring::BusMode>,
+        gravity_current: &mut HashMap<BusKey, mirroring::GravityCompState>,
+        new_gravity: &HashMap<BusKey, mirroring::GravityCompState>,
         inference: &Inference,
         normfs: &Arc<NormFS>,
         rx_queue_id: &normfs::QueueId,
         command: Option<mirroring::Command>,
+        gravity_command: Option<mirroring::GravityCompCommand>,
     ) {
         for (key, value) in new_modes {
             current.insert(key.clone(), *value);
+        }
+        for (key, value) in new_gravity {
+            gravity_current.insert(key.clone(), *value);
         }
 
         let bus_modes = current
@@ -150,9 +252,22 @@ fn merge_modes(
             })
             .collect();
 
+        let gravity_bus_states = gravity_current
+            .clone()
+            .into_iter()
+            .map(|(key, value)| mirroring::GravityCompBusState {
+                id: Some(mirroring::MirroringBus {
+                    unique_id: key.bus_id,
+                    r#type: key.bus_type as i32,
+                }),
+                state: value as i32,
+            })
+            .collect();
+
         let inference_state = mirroring::InferenceState {
             modes: bus_modes,
             mirroring: inference.get_mirrorings(),
+            gravity_comp: gravity_bus_states,
         };
 
         // Create RxEnvelope and write to RX queue
@@ -162,6 +277,7 @@ fn merge_modes(
             app_start_id: systime::get_app_start_id(),
             state: Some(inference_state.clone()),
             command,
+            gravity_command,
         };
 
         let _ = normfs.enqueue(rx_queue_id, rx_envelope.encode_to_vec().into());
@@ -170,6 +286,7 @@ fn merge_modes(
     fn process_command_pack(
         pack: &StationCommandsPack,
         modes: &Arc<RwLock<HashMap<BusKey, mirroring::BusMode>>>,
+        gravity_modes: &Arc<RwLock<HashMap<BusKey, mirroring::GravityCompState>>>,
         inference: &Arc<Inference>,
         normfs: &Arc<NormFS>,
         rx_queue_id: &normfs::QueueId,
@@ -180,22 +297,38 @@ fn merge_modes(
             let command_type = command.r#type();
             let body = &command.body;
 
-            if command_type != station_iface::iface_proto::drivers::StationCommandType::StcMotorMirroringCommand {
-                continue;
-            }
+            match command_type {
+                station_iface::iface_proto::drivers::StationCommandType::StcMotorMirroringCommand => {
+                    let command = match mirroring::Command::decode(body.clone()) {
+                        Ok(command) => command,
+                        Err(e) => {
+                            log::error!("Failed to decode mirroring command: {}", e);
+                            continue;
+                        }
+                    };
 
-            let command = match mirroring::Command::decode(body.clone()) {
-                Ok(command) => command,
-                Err(e) => {
-                    log::error!("Failed to decode mirroring command: {}", e);
-                    continue;
+                    if command.r#type == mirroring::CommandType::CtStopMirror as i32 {
+                        handle_stop_mirror(command, modes, gravity_modes, inference, normfs, rx_queue_id);
+                    } else if command.r#type == mirroring::CommandType::CtStartMirror as i32 {
+                        handle_start_mirror(command, modes, gravity_modes, inference, normfs, rx_queue_id);
+                    }
                 }
-            };
+                station_iface::iface_proto::drivers::StationCommandType::StcGravityCompCommand => {
+                    let command = match mirroring::GravityCompCommand::decode(body.clone()) {
+                        Ok(command) => command,
+                        Err(e) => {
+                            log::error!("Failed to decode gravity comp command: {}", e);
+                            continue;
+                        }
+                    };
 
-            if command.r#type == mirroring::CommandType::CtStopMirror as i32 {
-                handle_stop_mirror(command, modes, inference, normfs, rx_queue_id);
-            } else if command.r#type == mirroring::CommandType::CtStartMirror as i32 {
-                handle_start_mirror(command, modes, inference, normfs, rx_queue_id);
+                    if command.r#type == mirroring::GravityCompCommandType::GctStopGravityComp as i32 {
+                        handle_stop_gravity_comp(command, modes, gravity_modes, inference, normfs, rx_queue_id);
+                    } else if command.r#type == mirroring::GravityCompCommandType::GctStartGravityComp as i32 {
+                        handle_start_gravity_comp(command, modes, gravity_modes, inference, normfs, rx_queue_id);
+                    }
+                }
+                _ => continue,
             }
         }
     }
@@ -203,6 +336,7 @@ fn merge_modes(
     fn handle_stop_mirror(
         command: mirroring::Command,
         modes: &Arc<RwLock<HashMap<BusKey, mirroring::BusMode>>>,
+        gravity_modes: &Arc<RwLock<HashMap<BusKey, mirroring::GravityCompState>>>,
         inference: &Arc<Inference>,
         normfs: &Arc<NormFS>,
         rx_queue_id: &normfs::QueueId,
@@ -238,12 +372,14 @@ fn merge_modes(
         inference.stop(source_bus);
 
         let mut modes_guard = modes.write().unwrap();
-        merge_modes(&mut modes_guard, &HashMap::new(), inference, normfs, rx_queue_id, Some(command));
+        let mut gravity_guard = gravity_modes.write().unwrap();
+        merge_modes(&mut modes_guard, &HashMap::new(), &mut gravity_guard, &HashMap::new(), inference, normfs, rx_queue_id, Some(command), None);
     }
 
     fn handle_start_mirror(
         command: mirroring::Command,
         modes: &Arc<RwLock<HashMap<BusKey, mirroring::BusMode>>>,
+        gravity_modes: &Arc<RwLock<HashMap<BusKey, mirroring::GravityCompState>>>,
         inference: &Arc<Inference>,
         normfs: &Arc<NormFS>,
         rx_queue_id: &normfs::QueueId,
@@ -314,5 +450,103 @@ fn merge_modes(
         inference.start(source, targets_keys);
 
         let mut modes_guard = modes.write().unwrap();
-        merge_modes(&mut modes_guard, &new_modes, inference, normfs, rx_queue_id, Some(command));
+        let mut gravity_guard = gravity_modes.write().unwrap();
+        merge_modes(&mut modes_guard, &new_modes, &mut gravity_guard, &HashMap::new(), inference, normfs, rx_queue_id, Some(command), None);
+    }
+
+    fn decode_gravity_comp_bus(bus: &Option<mirroring::MirroringBus>) -> Option<BusKey> {
+        let bus = bus.as_ref()?;
+        let bus_type = match mirroring::BusType::try_from(bus.r#type) {
+            Ok(bt) => bt,
+            Err(_) => {
+                log::warn!(
+                    "Unknown bus type for gravity comp command: bus_id={}, type={}",
+                    bus.unique_id,
+                    bus.r#type
+                );
+                return None;
+            }
+        };
+        Some(BusKey { bus_id: bus.unique_id.clone(), bus_type })
+    }
+
+    fn handle_start_gravity_comp(
+        command: mirroring::GravityCompCommand,
+        modes: &Arc<RwLock<HashMap<BusKey, mirroring::BusMode>>>,
+        gravity_modes: &Arc<RwLock<HashMap<BusKey, mirroring::GravityCompState>>>,
+        inference: &Arc<Inference>,
+        normfs: &Arc<NormFS>,
+        rx_queue_id: &normfs::QueueId,
+    ) {
+        let bus_key = match decode_gravity_comp_bus(&command.bus) {
+            Some(bus_key) => bus_key,
+            None => {
+                log::warn!("Gravity comp start command missing or invalid bus");
+                return;
+            }
+        };
+
+        log::info!("Starting gravity compensation for bus: {:?}", bus_key);
+
+        let cb_modes = Arc::clone(modes);
+        let cb_gravity_modes = Arc::clone(gravity_modes);
+        let cb_inference = Arc::clone(inference);
+        let cb_normfs = Arc::clone(normfs);
+        let cb_rx_queue_id = rx_queue_id.clone();
+
+        inference.start_gravity_comp(bus_key.clone(), move |bus| {
+            log::warn!("Gravity comp on bus {:?} self-stopped for safety; updating mode state", bus);
+            deactivate_gravity_comp(bus, &cb_modes, &cb_gravity_modes, &cb_inference, &cb_normfs, &cb_rx_queue_id, None);
+        });
+
+        let mut new_gravity = HashMap::new();
+        new_gravity.insert(bus_key, mirroring::GravityCompState::GcEnabled);
+
+        let mut modes_guard = modes.write().unwrap();
+        let mut gravity_guard = gravity_modes.write().unwrap();
+        merge_modes(&mut modes_guard, &HashMap::new(), &mut gravity_guard, &new_gravity, inference, normfs, rx_queue_id, None, Some(command));
+    }
+
+    fn handle_stop_gravity_comp(
+        command: mirroring::GravityCompCommand,
+        modes: &Arc<RwLock<HashMap<BusKey, mirroring::BusMode>>>,
+        gravity_modes: &Arc<RwLock<HashMap<BusKey, mirroring::GravityCompState>>>,
+        inference: &Arc<Inference>,
+        normfs: &Arc<NormFS>,
+        rx_queue_id: &normfs::QueueId,
+    ) {
+        let bus_key = match decode_gravity_comp_bus(&command.bus) {
+            Some(bus_key) => bus_key,
+            None => {
+                log::warn!("Gravity comp stop command missing or invalid bus");
+                return;
+            }
+        };
+
+        log::info!("Stopping gravity compensation for bus: {:?}", bus_key);
+        deactivate_gravity_comp(bus_key, modes, gravity_modes, inference, normfs, rx_queue_id, Some(command));
+    }
+
+    /// Shared teardown path for both an operator-issued stop command and a
+    /// control loop's own safety self-stop (stale data / sustained
+    /// overcurrent) - both must converge on the same task-registry cleanup
+    /// and mode broadcast so displayed state never drifts from what's
+    /// actually running.
+    fn deactivate_gravity_comp(
+        bus_key: BusKey,
+        modes: &Arc<RwLock<HashMap<BusKey, mirroring::BusMode>>>,
+        gravity_modes: &Arc<RwLock<HashMap<BusKey, mirroring::GravityCompState>>>,
+        inference: &Arc<Inference>,
+        normfs: &Arc<NormFS>,
+        rx_queue_id: &normfs::QueueId,
+        command: Option<mirroring::GravityCompCommand>,
+    ) {
+        inference.stop_gravity_comp(bus_key.clone());
+
+        let mut new_gravity = HashMap::new();
+        new_gravity.insert(bus_key, mirroring::GravityCompState::GcDisabled);
+
+        let mut modes_guard = modes.write().unwrap();
+        let mut gravity_guard = gravity_modes.write().unwrap();
+        merge_modes(&mut modes_guard, &HashMap::new(), &mut gravity_guard, &new_gravity, inference, normfs, rx_queue_id, None, command);
     }

--- a/software/drivers/motors-mirroring/src/types.rs
+++ b/software/drivers/motors-mirroring/src/types.rs
@@ -13,6 +13,7 @@ pub enum MotorCommand {
     Accel(u16),
     Goal(u16),
     Torque(u8),
+    TorqueLimit(u16),
 }
 
 #[derive(Hash, Eq, PartialEq, Clone, Debug)]

--- a/software/station/bin/station/src/main.rs
+++ b/software/station/bin/station/src/main.rs
@@ -81,6 +81,8 @@ struct Station {
 
     #[cfg(feature = "ov5647")]
     ov5647_handle: Mutex<Option<ov5647::Ov5647Handle>>,
+
+    motors_mirroring_inference: Mutex<Option<Arc<motors_mirroring::inference::Inference>>>,
 }
 
 struct Engine {
@@ -132,6 +134,7 @@ impl Station {
             usbvideo_instances: parking_lot::Mutex::new(Vec::new()),
             #[cfg(feature = "ov5647")]
             ov5647_handle: Mutex::new(None),
+            motors_mirroring_inference: Mutex::new(None),
         })
     }
 
@@ -234,11 +237,12 @@ impl Station {
             // Start motors mirroring driver
             let motor_config = motors_mirroring::config::MotorConfig::from(st3215);
 
-            motors_mirroring::start(
+            let mirroring_inference = motors_mirroring::start(
                 self.normfs.clone(),
                 self.engine.clone(),
                 motor_config,
             ).await?;
+            *self.motors_mirroring_inference.lock() = Some(mirroring_inference);
         } else {
             log::info!("No motor drivers available for mirroring");
         }
@@ -396,6 +400,11 @@ impl Station {
             log::info!("Stopping OV5647 driver...");
             handle.stop().await;
             log::info!("OV5647 driver stopped");
+        }
+
+        if let Some(mirroring_inference) = self.motors_mirroring_inference.lock().as_ref() {
+            log::info!("Stopping any active gravity compensation tasks...");
+            mirroring_inference.stop_all_gravity_comp();
         }
 
         log::info!("Closing NormFS (writing WAL)...");

--- a/software/station/clients/station-viewer/package-lock.json
+++ b/software/station/clients/station-viewer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@normacore/station-viewer",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@normacore/station-viewer",
-      "version": "0.1.0-beta.1",
+      "version": "0.1.0-beta.9",
       "license": "MIT",
       "dependencies": {
         "@types/three": "^0.184.0",
@@ -910,9 +910,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -930,9 +927,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -950,9 +944,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -970,9 +961,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -990,9 +978,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1010,9 +995,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1030,9 +1012,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1050,9 +1029,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1281,9 +1257,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1298,9 +1271,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1315,9 +1285,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1332,9 +1299,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1349,9 +1313,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1366,9 +1327,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1383,9 +1341,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1400,9 +1355,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1417,9 +1369,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1434,9 +1383,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1451,9 +1397,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1468,9 +1411,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1485,9 +1425,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1705,9 +1642,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1725,9 +1659,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1745,9 +1676,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1765,9 +1693,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2918,9 +2843,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2942,9 +2864,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2966,9 +2885,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2990,9 +2906,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/software/station/clients/station-viewer/src/api/commands.ts
+++ b/software/station/clients/station-viewer/src/api/commands.ts
@@ -56,6 +56,11 @@ export class CommandManager {
         await this.sendCommand(drivers.StationCommandType.STC_MOTOR_MIRRORING_COMMAND, body);
     }
 
+    public async sendGravityCompCommand(command: motors_mirroring.IGravityCompCommand): Promise<void> {
+        const body = motors_mirroring.GravityCompCommand.encode(command).finish();
+        await this.sendCommand(drivers.StationCommandType.STC_GRAVITY_COMP_COMMAND, body);
+    }
+
     public async sendInferenceTagCommand(command: inference_tags.ICommand): Promise<void> {
         const body = inference_tags.Command.encode(command).finish();
         await this.sendCommand(drivers.StationCommandType.STC_INFERENCE_TAG_COMMAND, body);

--- a/software/station/clients/station-viewer/src/api/proto.d.ts
+++ b/software/station/clients/station-viewer/src/api/proto.d.ts
@@ -246,6 +246,7 @@ export namespace drivers {
         QDT_INFERENCE_FRAMES = 22,
         QDT_MOTOR_MIRRORING_MODES = 30,
         QDT_MOTOR_MIRRORING_RX = 32,
+        QDT_MOTOR_MIRRORING_GRAVITY_COMP_MODES = 33,
         QDT_YAHBOOM_DOGZILLA_LITE_SERIAL_TX = 40,
         QDT_YAHBOOM_DOGZILLA_LITE_SERIAL_RX = 41,
         QDT_YAHBOOM_DOGZILLA_LITE_INFERENCE = 42
@@ -256,7 +257,8 @@ export namespace drivers {
         STC_ST3215_COMMAND = 0,
         STC_MOTOR_MIRRORING_COMMAND = 1,
         STC_INFERENCE_TAG_COMMAND = 2,
-        STC_YAHBOOM_DOGZILLA_LITE_COMMAND = 3
+        STC_YAHBOOM_DOGZILLA_LITE_COMMAND = 3,
+        STC_GRAVITY_COMP_COMMAND = 4
     }
 }
 
@@ -5049,6 +5051,9 @@ export namespace motors_mirroring {
 
         /** RxEnvelope command */
         command?: (motors_mirroring.ICommand|null);
+
+        /** RxEnvelope gravityCommand */
+        gravityCommand?: (motors_mirroring.IGravityCompCommand|null);
     }
 
     /** Represents a RxEnvelope. */
@@ -5074,6 +5079,9 @@ export namespace motors_mirroring {
 
         /** RxEnvelope command. */
         public command?: (motors_mirroring.ICommand|null);
+
+        /** RxEnvelope gravityCommand. */
+        public gravityCommand?: (motors_mirroring.IGravityCompCommand|null);
 
         /**
          * Creates a new RxEnvelope instance using the specified properties.
@@ -5161,6 +5169,9 @@ export namespace motors_mirroring {
 
         /** InferenceState mirroring */
         mirroring?: (motors_mirroring.InferenceState.IMirroring[]|null);
+
+        /** InferenceState gravityComp */
+        gravityComp?: (motors_mirroring.IGravityCompBusState[]|null);
     }
 
     /** Represents an InferenceState. */
@@ -5177,6 +5188,9 @@ export namespace motors_mirroring {
 
         /** InferenceState mirroring. */
         public mirroring: motors_mirroring.InferenceState.IMirroring[];
+
+        /** InferenceState gravityComp. */
+        public gravityComp: motors_mirroring.IGravityCompBusState[];
 
         /**
          * Creates a new InferenceState instance using the specified properties.
@@ -5463,6 +5477,346 @@ export namespace motors_mirroring {
              */
             public static getTypeUrl(typeUrlPrefix?: string): string;
         }
+    }
+
+    /** GravityCompState enum. */
+    enum GravityCompState {
+        GC_UNKNOWN = 0,
+        GC_DISABLED = 1,
+        GC_ENABLED = 2
+    }
+
+    /** Properties of a GravityCompModeEnvelope. */
+    interface IGravityCompModeEnvelope {
+
+        /** GravityCompModeEnvelope monotonicStampNs */
+        monotonicStampNs?: (Long|null);
+
+        /** GravityCompModeEnvelope localStampNs */
+        localStampNs?: (Long|null);
+
+        /** GravityCompModeEnvelope appStartId */
+        appStartId?: (Long|null);
+
+        /** GravityCompModeEnvelope bus */
+        bus?: (motors_mirroring.IMirroringBus|null);
+
+        /** GravityCompModeEnvelope state */
+        state?: (motors_mirroring.GravityCompState|null);
+    }
+
+    /** Represents a GravityCompModeEnvelope. */
+    class GravityCompModeEnvelope implements IGravityCompModeEnvelope {
+
+        /**
+         * Constructs a new GravityCompModeEnvelope.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: motors_mirroring.IGravityCompModeEnvelope);
+
+        /** GravityCompModeEnvelope monotonicStampNs. */
+        public monotonicStampNs: Long;
+
+        /** GravityCompModeEnvelope localStampNs. */
+        public localStampNs: Long;
+
+        /** GravityCompModeEnvelope appStartId. */
+        public appStartId: Long;
+
+        /** GravityCompModeEnvelope bus. */
+        public bus?: (motors_mirroring.IMirroringBus|null);
+
+        /** GravityCompModeEnvelope state. */
+        public state: motors_mirroring.GravityCompState;
+
+        /**
+         * Creates a new GravityCompModeEnvelope instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns GravityCompModeEnvelope instance
+         */
+        public static create(properties?: motors_mirroring.IGravityCompModeEnvelope): motors_mirroring.GravityCompModeEnvelope;
+
+        /**
+         * Encodes the specified GravityCompModeEnvelope message. Does not implicitly {@link motors_mirroring.GravityCompModeEnvelope.verify|verify} messages.
+         * @param message GravityCompModeEnvelope message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: motors_mirroring.IGravityCompModeEnvelope, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified GravityCompModeEnvelope message, length delimited. Does not implicitly {@link motors_mirroring.GravityCompModeEnvelope.verify|verify} messages.
+         * @param message GravityCompModeEnvelope message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: motors_mirroring.IGravityCompModeEnvelope, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a GravityCompModeEnvelope message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns GravityCompModeEnvelope
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): motors_mirroring.GravityCompModeEnvelope;
+
+        /**
+         * Decodes a GravityCompModeEnvelope message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns GravityCompModeEnvelope
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): motors_mirroring.GravityCompModeEnvelope;
+
+        /**
+         * Verifies a GravityCompModeEnvelope message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a GravityCompModeEnvelope message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns GravityCompModeEnvelope
+         */
+        public static fromObject(object: { [k: string]: any }): motors_mirroring.GravityCompModeEnvelope;
+
+        /**
+         * Creates a plain object from a GravityCompModeEnvelope message. Also converts values to other types if specified.
+         * @param message GravityCompModeEnvelope
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: motors_mirroring.GravityCompModeEnvelope, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this GravityCompModeEnvelope to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+
+        /**
+         * Gets the default type url for GravityCompModeEnvelope
+         * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns The default type url
+         */
+        public static getTypeUrl(typeUrlPrefix?: string): string;
+    }
+
+    /** GravityCompCommandType enum. */
+    enum GravityCompCommandType {
+        GCT_START_GRAVITY_COMP = 0,
+        GCT_STOP_GRAVITY_COMP = 1
+    }
+
+    /** Properties of a GravityCompCommand. */
+    interface IGravityCompCommand {
+
+        /** GravityCompCommand type */
+        type?: (motors_mirroring.GravityCompCommandType|null);
+
+        /** GravityCompCommand bus */
+        bus?: (motors_mirroring.IMirroringBus|null);
+    }
+
+    /** Represents a GravityCompCommand. */
+    class GravityCompCommand implements IGravityCompCommand {
+
+        /**
+         * Constructs a new GravityCompCommand.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: motors_mirroring.IGravityCompCommand);
+
+        /** GravityCompCommand type. */
+        public type: motors_mirroring.GravityCompCommandType;
+
+        /** GravityCompCommand bus. */
+        public bus?: (motors_mirroring.IMirroringBus|null);
+
+        /**
+         * Creates a new GravityCompCommand instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns GravityCompCommand instance
+         */
+        public static create(properties?: motors_mirroring.IGravityCompCommand): motors_mirroring.GravityCompCommand;
+
+        /**
+         * Encodes the specified GravityCompCommand message. Does not implicitly {@link motors_mirroring.GravityCompCommand.verify|verify} messages.
+         * @param message GravityCompCommand message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: motors_mirroring.IGravityCompCommand, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified GravityCompCommand message, length delimited. Does not implicitly {@link motors_mirroring.GravityCompCommand.verify|verify} messages.
+         * @param message GravityCompCommand message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: motors_mirroring.IGravityCompCommand, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a GravityCompCommand message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns GravityCompCommand
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): motors_mirroring.GravityCompCommand;
+
+        /**
+         * Decodes a GravityCompCommand message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns GravityCompCommand
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): motors_mirroring.GravityCompCommand;
+
+        /**
+         * Verifies a GravityCompCommand message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a GravityCompCommand message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns GravityCompCommand
+         */
+        public static fromObject(object: { [k: string]: any }): motors_mirroring.GravityCompCommand;
+
+        /**
+         * Creates a plain object from a GravityCompCommand message. Also converts values to other types if specified.
+         * @param message GravityCompCommand
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: motors_mirroring.GravityCompCommand, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this GravityCompCommand to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+
+        /**
+         * Gets the default type url for GravityCompCommand
+         * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns The default type url
+         */
+        public static getTypeUrl(typeUrlPrefix?: string): string;
+    }
+
+    /** Properties of a GravityCompBusState. */
+    interface IGravityCompBusState {
+
+        /** GravityCompBusState id */
+        id?: (motors_mirroring.IMirroringBus|null);
+
+        /** GravityCompBusState state */
+        state?: (motors_mirroring.GravityCompState|null);
+    }
+
+    /** Represents a GravityCompBusState. */
+    class GravityCompBusState implements IGravityCompBusState {
+
+        /**
+         * Constructs a new GravityCompBusState.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: motors_mirroring.IGravityCompBusState);
+
+        /** GravityCompBusState id. */
+        public id?: (motors_mirroring.IMirroringBus|null);
+
+        /** GravityCompBusState state. */
+        public state: motors_mirroring.GravityCompState;
+
+        /**
+         * Creates a new GravityCompBusState instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns GravityCompBusState instance
+         */
+        public static create(properties?: motors_mirroring.IGravityCompBusState): motors_mirroring.GravityCompBusState;
+
+        /**
+         * Encodes the specified GravityCompBusState message. Does not implicitly {@link motors_mirroring.GravityCompBusState.verify|verify} messages.
+         * @param message GravityCompBusState message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: motors_mirroring.IGravityCompBusState, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified GravityCompBusState message, length delimited. Does not implicitly {@link motors_mirroring.GravityCompBusState.verify|verify} messages.
+         * @param message GravityCompBusState message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: motors_mirroring.IGravityCompBusState, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a GravityCompBusState message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns GravityCompBusState
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): motors_mirroring.GravityCompBusState;
+
+        /**
+         * Decodes a GravityCompBusState message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns GravityCompBusState
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): motors_mirroring.GravityCompBusState;
+
+        /**
+         * Verifies a GravityCompBusState message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a GravityCompBusState message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns GravityCompBusState
+         */
+        public static fromObject(object: { [k: string]: any }): motors_mirroring.GravityCompBusState;
+
+        /**
+         * Creates a plain object from a GravityCompBusState message. Also converts values to other types if specified.
+         * @param message GravityCompBusState
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: motors_mirroring.GravityCompBusState, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this GravityCompBusState to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+
+        /**
+         * Gets the default type url for GravityCompBusState
+         * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns The default type url
+         */
+        public static getTypeUrl(typeUrlPrefix?: string): string;
     }
 }
 

--- a/software/station/clients/station-viewer/src/api/proto.d.ts
+++ b/software/station/clients/station-viewer/src/api/proto.d.ts
@@ -5610,7 +5610,8 @@ export namespace motors_mirroring {
     /** GravityCompCommandType enum. */
     enum GravityCompCommandType {
         GCT_START_GRAVITY_COMP = 0,
-        GCT_STOP_GRAVITY_COMP = 1
+        GCT_STOP_GRAVITY_COMP = 1,
+        GCT_SET_GAIN = 2
     }
 
     /** Properties of a GravityCompCommand. */
@@ -5621,6 +5622,9 @@ export namespace motors_mirroring {
 
         /** GravityCompCommand bus */
         bus?: (motors_mirroring.IMirroringBus|null);
+
+        /** GravityCompCommand gainRadPerNm */
+        gainRadPerNm?: (number|null);
     }
 
     /** Represents a GravityCompCommand. */
@@ -5637,6 +5641,9 @@ export namespace motors_mirroring {
 
         /** GravityCompCommand bus. */
         public bus?: (motors_mirroring.IMirroringBus|null);
+
+        /** GravityCompCommand gainRadPerNm. */
+        public gainRadPerNm?: (number|null);
 
         /**
          * Creates a new GravityCompCommand instance using the specified properties.
@@ -5724,6 +5731,9 @@ export namespace motors_mirroring {
 
         /** GravityCompBusState state */
         state?: (motors_mirroring.GravityCompState|null);
+
+        /** GravityCompBusState gainRadPerNm */
+        gainRadPerNm?: (number|null);
     }
 
     /** Represents a GravityCompBusState. */
@@ -5740,6 +5750,9 @@ export namespace motors_mirroring {
 
         /** GravityCompBusState state. */
         public state: motors_mirroring.GravityCompState;
+
+        /** GravityCompBusState gainRadPerNm. */
+        public gainRadPerNm?: (number|null);
 
         /**
          * Creates a new GravityCompBusState instance using the specified properties.

--- a/software/station/clients/station-viewer/src/api/proto.d.ts
+++ b/software/station/clients/station-viewer/src/api/proto.d.ts
@@ -247,6 +247,7 @@ export namespace drivers {
         QDT_MOTOR_MIRRORING_MODES = 30,
         QDT_MOTOR_MIRRORING_RX = 32,
         QDT_MOTOR_MIRRORING_GRAVITY_COMP_MODES = 33,
+        QDT_MOTOR_MIRRORING_GRAVITY_COMP_SETTINGS = 34,
         QDT_YAHBOOM_DOGZILLA_LITE_SERIAL_TX = 40,
         QDT_YAHBOOM_DOGZILLA_LITE_SERIAL_RX = 41,
         QDT_YAHBOOM_DOGZILLA_LITE_INFERENCE = 42
@@ -5611,7 +5612,9 @@ export namespace motors_mirroring {
     enum GravityCompCommandType {
         GCT_START_GRAVITY_COMP = 0,
         GCT_STOP_GRAVITY_COMP = 1,
-        GCT_SET_GAIN = 2
+        GCT_SET_GAIN = 2,
+        GCT_SET_TORQUE_LIMIT = 3,
+        GCT_SAVE_SETTINGS = 4
     }
 
     /** Properties of a GravityCompCommand. */
@@ -5625,6 +5628,12 @@ export namespace motors_mirroring {
 
         /** GravityCompCommand gainRadPerNm */
         gainRadPerNm?: (number|null);
+
+        /** GravityCompCommand motorId */
+        motorId?: (number|null);
+
+        /** GravityCompCommand torqueLimit */
+        torqueLimit?: (number|null);
     }
 
     /** Represents a GravityCompCommand. */
@@ -5644,6 +5653,12 @@ export namespace motors_mirroring {
 
         /** GravityCompCommand gainRadPerNm. */
         public gainRadPerNm?: (number|null);
+
+        /** GravityCompCommand motorId. */
+        public motorId?: (number|null);
+
+        /** GravityCompCommand torqueLimit. */
+        public torqueLimit?: (number|null);
 
         /**
          * Creates a new GravityCompCommand instance using the specified properties.
@@ -5732,8 +5747,11 @@ export namespace motors_mirroring {
         /** GravityCompBusState state */
         state?: (motors_mirroring.GravityCompState|null);
 
-        /** GravityCompBusState gainRadPerNm */
-        gainRadPerNm?: (number|null);
+        /** GravityCompBusState jointGainsRadPerNm */
+        jointGainsRadPerNm?: (number[]|null);
+
+        /** GravityCompBusState torqueLimit */
+        torqueLimit?: (number|null);
     }
 
     /** Represents a GravityCompBusState. */
@@ -5751,8 +5769,11 @@ export namespace motors_mirroring {
         /** GravityCompBusState state. */
         public state: motors_mirroring.GravityCompState;
 
-        /** GravityCompBusState gainRadPerNm. */
-        public gainRadPerNm?: (number|null);
+        /** GravityCompBusState jointGainsRadPerNm. */
+        public jointGainsRadPerNm: number[];
+
+        /** GravityCompBusState torqueLimit. */
+        public torqueLimit?: (number|null);
 
         /**
          * Creates a new GravityCompBusState instance using the specified properties.
@@ -5826,6 +5847,133 @@ export namespace motors_mirroring {
 
         /**
          * Gets the default type url for GravityCompBusState
+         * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns The default type url
+         */
+        public static getTypeUrl(typeUrlPrefix?: string): string;
+    }
+
+    /** Properties of a GravityCompSettingsEnvelope. */
+    interface IGravityCompSettingsEnvelope {
+
+        /** GravityCompSettingsEnvelope monotonicStampNs */
+        monotonicStampNs?: (Long|null);
+
+        /** GravityCompSettingsEnvelope localStampNs */
+        localStampNs?: (Long|null);
+
+        /** GravityCompSettingsEnvelope appStartId */
+        appStartId?: (Long|null);
+
+        /** GravityCompSettingsEnvelope bus */
+        bus?: (motors_mirroring.IMirroringBus|null);
+
+        /** GravityCompSettingsEnvelope jointGainsRadPerNm */
+        jointGainsRadPerNm?: (number[]|null);
+
+        /** GravityCompSettingsEnvelope torqueLimit */
+        torqueLimit?: (number|null);
+    }
+
+    /** Represents a GravityCompSettingsEnvelope. */
+    class GravityCompSettingsEnvelope implements IGravityCompSettingsEnvelope {
+
+        /**
+         * Constructs a new GravityCompSettingsEnvelope.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: motors_mirroring.IGravityCompSettingsEnvelope);
+
+        /** GravityCompSettingsEnvelope monotonicStampNs. */
+        public monotonicStampNs: Long;
+
+        /** GravityCompSettingsEnvelope localStampNs. */
+        public localStampNs: Long;
+
+        /** GravityCompSettingsEnvelope appStartId. */
+        public appStartId: Long;
+
+        /** GravityCompSettingsEnvelope bus. */
+        public bus?: (motors_mirroring.IMirroringBus|null);
+
+        /** GravityCompSettingsEnvelope jointGainsRadPerNm. */
+        public jointGainsRadPerNm: number[];
+
+        /** GravityCompSettingsEnvelope torqueLimit. */
+        public torqueLimit: number;
+
+        /**
+         * Creates a new GravityCompSettingsEnvelope instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns GravityCompSettingsEnvelope instance
+         */
+        public static create(properties?: motors_mirroring.IGravityCompSettingsEnvelope): motors_mirroring.GravityCompSettingsEnvelope;
+
+        /**
+         * Encodes the specified GravityCompSettingsEnvelope message. Does not implicitly {@link motors_mirroring.GravityCompSettingsEnvelope.verify|verify} messages.
+         * @param message GravityCompSettingsEnvelope message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: motors_mirroring.IGravityCompSettingsEnvelope, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified GravityCompSettingsEnvelope message, length delimited. Does not implicitly {@link motors_mirroring.GravityCompSettingsEnvelope.verify|verify} messages.
+         * @param message GravityCompSettingsEnvelope message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: motors_mirroring.IGravityCompSettingsEnvelope, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a GravityCompSettingsEnvelope message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns GravityCompSettingsEnvelope
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): motors_mirroring.GravityCompSettingsEnvelope;
+
+        /**
+         * Decodes a GravityCompSettingsEnvelope message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns GravityCompSettingsEnvelope
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): motors_mirroring.GravityCompSettingsEnvelope;
+
+        /**
+         * Verifies a GravityCompSettingsEnvelope message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a GravityCompSettingsEnvelope message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns GravityCompSettingsEnvelope
+         */
+        public static fromObject(object: { [k: string]: any }): motors_mirroring.GravityCompSettingsEnvelope;
+
+        /**
+         * Creates a plain object from a GravityCompSettingsEnvelope message. Also converts values to other types if specified.
+         * @param message GravityCompSettingsEnvelope
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: motors_mirroring.GravityCompSettingsEnvelope, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this GravityCompSettingsEnvelope to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+
+        /**
+         * Gets the default type url for GravityCompSettingsEnvelope
          * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
          * @returns The default type url
          */

--- a/software/station/clients/station-viewer/src/api/proto.js
+++ b/software/station/clients/station-viewer/src/api/proto.js
@@ -198,6 +198,7 @@ export const commands = $root.commands = (() => {
                 case 1:
                 case 2:
                 case 3:
+                case 4:
                     break;
                 }
             if (message.body != null && message.hasOwnProperty("body"))
@@ -249,6 +250,10 @@ export const commands = $root.commands = (() => {
             case "STC_YAHBOOM_DOGZILLA_LITE_COMMAND":
             case 3:
                 message.type = 3;
+                break;
+            case "STC_GRAVITY_COMP_COMMAND":
+            case 4:
+                message.type = 4;
                 break;
             }
             if (object.body != null)
@@ -700,6 +705,7 @@ export const drivers = $root.drivers = (() => {
      * @property {number} QDT_INFERENCE_FRAMES=22 QDT_INFERENCE_FRAMES value
      * @property {number} QDT_MOTOR_MIRRORING_MODES=30 QDT_MOTOR_MIRRORING_MODES value
      * @property {number} QDT_MOTOR_MIRRORING_RX=32 QDT_MOTOR_MIRRORING_RX value
+     * @property {number} QDT_MOTOR_MIRRORING_GRAVITY_COMP_MODES=33 QDT_MOTOR_MIRRORING_GRAVITY_COMP_MODES value
      * @property {number} QDT_YAHBOOM_DOGZILLA_LITE_SERIAL_TX=40 QDT_YAHBOOM_DOGZILLA_LITE_SERIAL_TX value
      * @property {number} QDT_YAHBOOM_DOGZILLA_LITE_SERIAL_RX=41 QDT_YAHBOOM_DOGZILLA_LITE_SERIAL_RX value
      * @property {number} QDT_YAHBOOM_DOGZILLA_LITE_INFERENCE=42 QDT_YAHBOOM_DOGZILLA_LITE_INFERENCE value
@@ -719,6 +725,7 @@ export const drivers = $root.drivers = (() => {
         values[valuesById[22] = "QDT_INFERENCE_FRAMES"] = 22;
         values[valuesById[30] = "QDT_MOTOR_MIRRORING_MODES"] = 30;
         values[valuesById[32] = "QDT_MOTOR_MIRRORING_RX"] = 32;
+        values[valuesById[33] = "QDT_MOTOR_MIRRORING_GRAVITY_COMP_MODES"] = 33;
         values[valuesById[40] = "QDT_YAHBOOM_DOGZILLA_LITE_SERIAL_TX"] = 40;
         values[valuesById[41] = "QDT_YAHBOOM_DOGZILLA_LITE_SERIAL_RX"] = 41;
         values[valuesById[42] = "QDT_YAHBOOM_DOGZILLA_LITE_INFERENCE"] = 42;
@@ -733,6 +740,7 @@ export const drivers = $root.drivers = (() => {
      * @property {number} STC_MOTOR_MIRRORING_COMMAND=1 STC_MOTOR_MIRRORING_COMMAND value
      * @property {number} STC_INFERENCE_TAG_COMMAND=2 STC_INFERENCE_TAG_COMMAND value
      * @property {number} STC_YAHBOOM_DOGZILLA_LITE_COMMAND=3 STC_YAHBOOM_DOGZILLA_LITE_COMMAND value
+     * @property {number} STC_GRAVITY_COMP_COMMAND=4 STC_GRAVITY_COMP_COMMAND value
      */
     drivers.StationCommandType = (function() {
         const valuesById = {}, values = Object.create(valuesById);
@@ -740,6 +748,7 @@ export const drivers = $root.drivers = (() => {
         values[valuesById[1] = "STC_MOTOR_MIRRORING_COMMAND"] = 1;
         values[valuesById[2] = "STC_INFERENCE_TAG_COMMAND"] = 2;
         values[valuesById[3] = "STC_YAHBOOM_DOGZILLA_LITE_COMMAND"] = 3;
+        values[valuesById[4] = "STC_GRAVITY_COMP_COMMAND"] = 4;
         return values;
     })();
 
@@ -1297,6 +1306,7 @@ export const inference = $root.inference = (() => {
                     case 22:
                     case 30:
                     case 32:
+                    case 33:
                     case 40:
                     case 41:
                     case 42:
@@ -1386,6 +1396,10 @@ export const inference = $root.inference = (() => {
                 case "QDT_MOTOR_MIRRORING_RX":
                 case 32:
                     message.type = 32;
+                    break;
+                case "QDT_MOTOR_MIRRORING_GRAVITY_COMP_MODES":
+                case 33:
+                    message.type = 33;
                     break;
                 case "QDT_YAHBOOM_DOGZILLA_LITE_SERIAL_TX":
                 case 40:
@@ -14436,6 +14450,7 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
          * @property {Long|null} [appStartId] RxEnvelope appStartId
          * @property {motors_mirroring.IInferenceState|null} [state] RxEnvelope state
          * @property {motors_mirroring.ICommand|null} [command] RxEnvelope command
+         * @property {motors_mirroring.IGravityCompCommand|null} [gravityCommand] RxEnvelope gravityCommand
          */
 
         /**
@@ -14494,6 +14509,14 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
         RxEnvelope.prototype.command = null;
 
         /**
+         * RxEnvelope gravityCommand.
+         * @member {motors_mirroring.IGravityCompCommand|null|undefined} gravityCommand
+         * @memberof motors_mirroring.RxEnvelope
+         * @instance
+         */
+        RxEnvelope.prototype.gravityCommand = null;
+
+        /**
          * Creates a new RxEnvelope instance using the specified properties.
          * @function create
          * @memberof motors_mirroring.RxEnvelope
@@ -14527,6 +14550,8 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                 $root.motors_mirroring.InferenceState.encode(message.state, writer.uint32(/* id 10, wireType 2 =*/82).fork()).ldelim();
             if (message.command != null && Object.hasOwnProperty.call(message, "command"))
                 $root.motors_mirroring.Command.encode(message.command, writer.uint32(/* id 11, wireType 2 =*/90).fork()).ldelim();
+            if (message.gravityCommand != null && Object.hasOwnProperty.call(message, "gravityCommand"))
+                $root.motors_mirroring.GravityCompCommand.encode(message.gravityCommand, writer.uint32(/* id 12, wireType 2 =*/98).fork()).ldelim();
             return writer;
         };
 
@@ -14587,6 +14612,10 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                         message.command = $root.motors_mirroring.Command.decode(reader, reader.uint32(), undefined, long + 1);
                         break;
                     }
+                case 12: {
+                        message.gravityCommand = $root.motors_mirroring.GravityCompCommand.decode(reader, reader.uint32(), undefined, long + 1);
+                        break;
+                    }
                 default:
                     reader.skipType(tag & 7, long);
                     break;
@@ -14645,6 +14674,11 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                 if (error)
                     return "command." + error;
             }
+            if (message.gravityCommand != null && message.hasOwnProperty("gravityCommand")) {
+                let error = $root.motors_mirroring.GravityCompCommand.verify(message.gravityCommand, long + 1);
+                if (error)
+                    return "gravityCommand." + error;
+            }
             return null;
         };
 
@@ -14701,6 +14735,11 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                     throw TypeError(".motors_mirroring.RxEnvelope.command: object expected");
                 message.command = $root.motors_mirroring.Command.fromObject(object.command, long + 1);
             }
+            if (object.gravityCommand != null) {
+                if (typeof object.gravityCommand !== "object")
+                    throw TypeError(".motors_mirroring.RxEnvelope.gravityCommand: object expected");
+                message.gravityCommand = $root.motors_mirroring.GravityCompCommand.fromObject(object.gravityCommand, long + 1);
+            }
             return message;
         };
 
@@ -14735,6 +14774,7 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                     object.appStartId = options.longs === String ? "0" : 0;
                 object.state = null;
                 object.command = null;
+                object.gravityCommand = null;
             }
             if (message.monotonicStampNs != null && message.hasOwnProperty("monotonicStampNs"))
                 if (typeof message.monotonicStampNs === "number")
@@ -14755,6 +14795,8 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                 object.state = $root.motors_mirroring.InferenceState.toObject(message.state, options);
             if (message.command != null && message.hasOwnProperty("command"))
                 object.command = $root.motors_mirroring.Command.toObject(message.command, options);
+            if (message.gravityCommand != null && message.hasOwnProperty("gravityCommand"))
+                object.gravityCommand = $root.motors_mirroring.GravityCompCommand.toObject(message.gravityCommand, options);
             return object;
         };
 
@@ -14795,6 +14837,7 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
          * @interface IInferenceState
          * @property {Array.<motors_mirroring.InferenceState.IBus>|null} [modes] InferenceState modes
          * @property {Array.<motors_mirroring.InferenceState.IMirroring>|null} [mirroring] InferenceState mirroring
+         * @property {Array.<motors_mirroring.IGravityCompBusState>|null} [gravityComp] InferenceState gravityComp
          */
 
         /**
@@ -14808,6 +14851,7 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
         function InferenceState(properties) {
             this.modes = [];
             this.mirroring = [];
+            this.gravityComp = [];
             if (properties)
                 for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
                     if (properties[keys[i]] != null && keys[i] !== "__proto__")
@@ -14829,6 +14873,14 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
          * @instance
          */
         InferenceState.prototype.mirroring = $util.emptyArray;
+
+        /**
+         * InferenceState gravityComp.
+         * @member {Array.<motors_mirroring.IGravityCompBusState>} gravityComp
+         * @memberof motors_mirroring.InferenceState
+         * @instance
+         */
+        InferenceState.prototype.gravityComp = $util.emptyArray;
 
         /**
          * Creates a new InferenceState instance using the specified properties.
@@ -14860,6 +14912,9 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
             if (message.mirroring != null && message.mirroring.length)
                 for (let i = 0; i < message.mirroring.length; ++i)
                     $root.motors_mirroring.InferenceState.Mirroring.encode(message.mirroring[i], writer.uint32(/* id 11, wireType 2 =*/90).fork()).ldelim();
+            if (message.gravityComp != null && message.gravityComp.length)
+                for (let i = 0; i < message.gravityComp.length; ++i)
+                    $root.motors_mirroring.GravityCompBusState.encode(message.gravityComp[i], writer.uint32(/* id 12, wireType 2 =*/98).fork()).ldelim();
             return writer;
         };
 
@@ -14910,6 +14965,12 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                         if (!(message.mirroring && message.mirroring.length))
                             message.mirroring = [];
                         message.mirroring.push($root.motors_mirroring.InferenceState.Mirroring.decode(reader, reader.uint32(), undefined, long + 1));
+                        break;
+                    }
+                case 12: {
+                        if (!(message.gravityComp && message.gravityComp.length))
+                            message.gravityComp = [];
+                        message.gravityComp.push($root.motors_mirroring.GravityCompBusState.decode(reader, reader.uint32(), undefined, long + 1));
                         break;
                     }
                 default:
@@ -14969,6 +15030,15 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                         return "mirroring." + error;
                 }
             }
+            if (message.gravityComp != null && message.hasOwnProperty("gravityComp")) {
+                if (!Array.isArray(message.gravityComp))
+                    return "gravityComp: array expected";
+                for (let i = 0; i < message.gravityComp.length; ++i) {
+                    let error = $root.motors_mirroring.GravityCompBusState.verify(message.gravityComp[i], long + 1);
+                    if (error)
+                        return "gravityComp." + error;
+                }
+            }
             return null;
         };
 
@@ -15008,6 +15078,16 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                     message.mirroring[i] = $root.motors_mirroring.InferenceState.Mirroring.fromObject(object.mirroring[i], long + 1);
                 }
             }
+            if (object.gravityComp) {
+                if (!Array.isArray(object.gravityComp))
+                    throw TypeError(".motors_mirroring.InferenceState.gravityComp: array expected");
+                message.gravityComp = [];
+                for (let i = 0; i < object.gravityComp.length; ++i) {
+                    if (typeof object.gravityComp[i] !== "object")
+                        throw TypeError(".motors_mirroring.InferenceState.gravityComp: object expected");
+                    message.gravityComp[i] = $root.motors_mirroring.GravityCompBusState.fromObject(object.gravityComp[i], long + 1);
+                }
+            }
             return message;
         };
 
@@ -15027,6 +15107,7 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
             if (options.arrays || options.defaults) {
                 object.modes = [];
                 object.mirroring = [];
+                object.gravityComp = [];
             }
             if (message.modes && message.modes.length) {
                 object.modes = [];
@@ -15037,6 +15118,11 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                 object.mirroring = [];
                 for (let j = 0; j < message.mirroring.length; ++j)
                     object.mirroring[j] = $root.motors_mirroring.InferenceState.Mirroring.toObject(message.mirroring[j], options);
+            }
+            if (message.gravityComp && message.gravityComp.length) {
+                object.gravityComp = [];
+                for (let j = 0; j < message.gravityComp.length; ++j)
+                    object.gravityComp[j] = $root.motors_mirroring.GravityCompBusState.toObject(message.gravityComp[j], options);
             }
             return object;
         };
@@ -15605,6 +15691,952 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
         })();
 
         return InferenceState;
+    })();
+
+    /**
+     * GravityCompState enum.
+     * @name motors_mirroring.GravityCompState
+     * @enum {number}
+     * @property {number} GC_UNKNOWN=0 GC_UNKNOWN value
+     * @property {number} GC_DISABLED=1 GC_DISABLED value
+     * @property {number} GC_ENABLED=2 GC_ENABLED value
+     */
+    motors_mirroring.GravityCompState = (function() {
+        const valuesById = {}, values = Object.create(valuesById);
+        values[valuesById[0] = "GC_UNKNOWN"] = 0;
+        values[valuesById[1] = "GC_DISABLED"] = 1;
+        values[valuesById[2] = "GC_ENABLED"] = 2;
+        return values;
+    })();
+
+    motors_mirroring.GravityCompModeEnvelope = (function() {
+
+        /**
+         * Properties of a GravityCompModeEnvelope.
+         * @memberof motors_mirroring
+         * @interface IGravityCompModeEnvelope
+         * @property {Long|null} [monotonicStampNs] GravityCompModeEnvelope monotonicStampNs
+         * @property {Long|null} [localStampNs] GravityCompModeEnvelope localStampNs
+         * @property {Long|null} [appStartId] GravityCompModeEnvelope appStartId
+         * @property {motors_mirroring.IMirroringBus|null} [bus] GravityCompModeEnvelope bus
+         * @property {motors_mirroring.GravityCompState|null} [state] GravityCompModeEnvelope state
+         */
+
+        /**
+         * Constructs a new GravityCompModeEnvelope.
+         * @memberof motors_mirroring
+         * @classdesc Represents a GravityCompModeEnvelope.
+         * @implements IGravityCompModeEnvelope
+         * @constructor
+         * @param {motors_mirroring.IGravityCompModeEnvelope=} [properties] Properties to set
+         */
+        function GravityCompModeEnvelope(properties) {
+            if (properties)
+                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null && keys[i] !== "__proto__")
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * GravityCompModeEnvelope monotonicStampNs.
+         * @member {Long} monotonicStampNs
+         * @memberof motors_mirroring.GravityCompModeEnvelope
+         * @instance
+         */
+        GravityCompModeEnvelope.prototype.monotonicStampNs = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
+
+        /**
+         * GravityCompModeEnvelope localStampNs.
+         * @member {Long} localStampNs
+         * @memberof motors_mirroring.GravityCompModeEnvelope
+         * @instance
+         */
+        GravityCompModeEnvelope.prototype.localStampNs = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
+
+        /**
+         * GravityCompModeEnvelope appStartId.
+         * @member {Long} appStartId
+         * @memberof motors_mirroring.GravityCompModeEnvelope
+         * @instance
+         */
+        GravityCompModeEnvelope.prototype.appStartId = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
+
+        /**
+         * GravityCompModeEnvelope bus.
+         * @member {motors_mirroring.IMirroringBus|null|undefined} bus
+         * @memberof motors_mirroring.GravityCompModeEnvelope
+         * @instance
+         */
+        GravityCompModeEnvelope.prototype.bus = null;
+
+        /**
+         * GravityCompModeEnvelope state.
+         * @member {motors_mirroring.GravityCompState} state
+         * @memberof motors_mirroring.GravityCompModeEnvelope
+         * @instance
+         */
+        GravityCompModeEnvelope.prototype.state = 0;
+
+        /**
+         * Creates a new GravityCompModeEnvelope instance using the specified properties.
+         * @function create
+         * @memberof motors_mirroring.GravityCompModeEnvelope
+         * @static
+         * @param {motors_mirroring.IGravityCompModeEnvelope=} [properties] Properties to set
+         * @returns {motors_mirroring.GravityCompModeEnvelope} GravityCompModeEnvelope instance
+         */
+        GravityCompModeEnvelope.create = function create(properties) {
+            return new GravityCompModeEnvelope(properties);
+        };
+
+        /**
+         * Encodes the specified GravityCompModeEnvelope message. Does not implicitly {@link motors_mirroring.GravityCompModeEnvelope.verify|verify} messages.
+         * @function encode
+         * @memberof motors_mirroring.GravityCompModeEnvelope
+         * @static
+         * @param {motors_mirroring.IGravityCompModeEnvelope} message GravityCompModeEnvelope message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        GravityCompModeEnvelope.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.monotonicStampNs != null && Object.hasOwnProperty.call(message, "monotonicStampNs"))
+                writer.uint32(/* id 1, wireType 0 =*/8).uint64(message.monotonicStampNs);
+            if (message.localStampNs != null && Object.hasOwnProperty.call(message, "localStampNs"))
+                writer.uint32(/* id 2, wireType 0 =*/16).uint64(message.localStampNs);
+            if (message.appStartId != null && Object.hasOwnProperty.call(message, "appStartId"))
+                writer.uint32(/* id 3, wireType 0 =*/24).uint64(message.appStartId);
+            if (message.bus != null && Object.hasOwnProperty.call(message, "bus"))
+                $root.motors_mirroring.MirroringBus.encode(message.bus, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+            if (message.state != null && Object.hasOwnProperty.call(message, "state"))
+                writer.uint32(/* id 5, wireType 0 =*/40).int32(message.state);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified GravityCompModeEnvelope message, length delimited. Does not implicitly {@link motors_mirroring.GravityCompModeEnvelope.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof motors_mirroring.GravityCompModeEnvelope
+         * @static
+         * @param {motors_mirroring.IGravityCompModeEnvelope} message GravityCompModeEnvelope message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        GravityCompModeEnvelope.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a GravityCompModeEnvelope message from the specified reader or buffer.
+         * @function decode
+         * @memberof motors_mirroring.GravityCompModeEnvelope
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {motors_mirroring.GravityCompModeEnvelope} GravityCompModeEnvelope
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        GravityCompModeEnvelope.decode = function decode(reader, length, error, long) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            if (long === undefined)
+                long = 0;
+            if (long > $Reader.recursionLimit)
+                throw Error("maximum nesting depth exceeded");
+            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.motors_mirroring.GravityCompModeEnvelope();
+            while (reader.pos < end) {
+                let tag = reader.uint32();
+                if (tag === error)
+                    break;
+                switch (tag >>> 3) {
+                case 1: {
+                        message.monotonicStampNs = reader.uint64();
+                        break;
+                    }
+                case 2: {
+                        message.localStampNs = reader.uint64();
+                        break;
+                    }
+                case 3: {
+                        message.appStartId = reader.uint64();
+                        break;
+                    }
+                case 4: {
+                        message.bus = $root.motors_mirroring.MirroringBus.decode(reader, reader.uint32(), undefined, long + 1);
+                        break;
+                    }
+                case 5: {
+                        message.state = reader.int32();
+                        break;
+                    }
+                default:
+                    reader.skipType(tag & 7, long);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a GravityCompModeEnvelope message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof motors_mirroring.GravityCompModeEnvelope
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {motors_mirroring.GravityCompModeEnvelope} GravityCompModeEnvelope
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        GravityCompModeEnvelope.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a GravityCompModeEnvelope message.
+         * @function verify
+         * @memberof motors_mirroring.GravityCompModeEnvelope
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        GravityCompModeEnvelope.verify = function verify(message, long) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (long === undefined)
+                long = 0;
+            if (long > $util.recursionLimit)
+                return "maximum nesting depth exceeded";
+            if (message.monotonicStampNs != null && message.hasOwnProperty("monotonicStampNs"))
+                if (!$util.isInteger(message.monotonicStampNs) && !(message.monotonicStampNs && $util.isInteger(message.monotonicStampNs.low) && $util.isInteger(message.monotonicStampNs.high)))
+                    return "monotonicStampNs: integer|Long expected";
+            if (message.localStampNs != null && message.hasOwnProperty("localStampNs"))
+                if (!$util.isInteger(message.localStampNs) && !(message.localStampNs && $util.isInteger(message.localStampNs.low) && $util.isInteger(message.localStampNs.high)))
+                    return "localStampNs: integer|Long expected";
+            if (message.appStartId != null && message.hasOwnProperty("appStartId"))
+                if (!$util.isInteger(message.appStartId) && !(message.appStartId && $util.isInteger(message.appStartId.low) && $util.isInteger(message.appStartId.high)))
+                    return "appStartId: integer|Long expected";
+            if (message.bus != null && message.hasOwnProperty("bus")) {
+                let error = $root.motors_mirroring.MirroringBus.verify(message.bus, long + 1);
+                if (error)
+                    return "bus." + error;
+            }
+            if (message.state != null && message.hasOwnProperty("state"))
+                switch (message.state) {
+                default:
+                    return "state: enum value expected";
+                case 0:
+                case 1:
+                case 2:
+                    break;
+                }
+            return null;
+        };
+
+        /**
+         * Creates a GravityCompModeEnvelope message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof motors_mirroring.GravityCompModeEnvelope
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {motors_mirroring.GravityCompModeEnvelope} GravityCompModeEnvelope
+         */
+        GravityCompModeEnvelope.fromObject = function fromObject(object, long) {
+            if (object instanceof $root.motors_mirroring.GravityCompModeEnvelope)
+                return object;
+            if (long === undefined)
+                long = 0;
+            if (long > $util.recursionLimit)
+                throw Error("maximum nesting depth exceeded");
+            let message = new $root.motors_mirroring.GravityCompModeEnvelope();
+            if (object.monotonicStampNs != null)
+                if ($util.Long)
+                    (message.monotonicStampNs = $util.Long.fromValue(object.monotonicStampNs)).unsigned = true;
+                else if (typeof object.monotonicStampNs === "string")
+                    message.monotonicStampNs = parseInt(object.monotonicStampNs, 10);
+                else if (typeof object.monotonicStampNs === "number")
+                    message.monotonicStampNs = object.monotonicStampNs;
+                else if (typeof object.monotonicStampNs === "object")
+                    message.monotonicStampNs = new $util.LongBits(object.monotonicStampNs.low >>> 0, object.monotonicStampNs.high >>> 0).toNumber(true);
+            if (object.localStampNs != null)
+                if ($util.Long)
+                    (message.localStampNs = $util.Long.fromValue(object.localStampNs)).unsigned = true;
+                else if (typeof object.localStampNs === "string")
+                    message.localStampNs = parseInt(object.localStampNs, 10);
+                else if (typeof object.localStampNs === "number")
+                    message.localStampNs = object.localStampNs;
+                else if (typeof object.localStampNs === "object")
+                    message.localStampNs = new $util.LongBits(object.localStampNs.low >>> 0, object.localStampNs.high >>> 0).toNumber(true);
+            if (object.appStartId != null)
+                if ($util.Long)
+                    (message.appStartId = $util.Long.fromValue(object.appStartId)).unsigned = true;
+                else if (typeof object.appStartId === "string")
+                    message.appStartId = parseInt(object.appStartId, 10);
+                else if (typeof object.appStartId === "number")
+                    message.appStartId = object.appStartId;
+                else if (typeof object.appStartId === "object")
+                    message.appStartId = new $util.LongBits(object.appStartId.low >>> 0, object.appStartId.high >>> 0).toNumber(true);
+            if (object.bus != null) {
+                if (typeof object.bus !== "object")
+                    throw TypeError(".motors_mirroring.GravityCompModeEnvelope.bus: object expected");
+                message.bus = $root.motors_mirroring.MirroringBus.fromObject(object.bus, long + 1);
+            }
+            switch (object.state) {
+            default:
+                if (typeof object.state === "number") {
+                    message.state = object.state;
+                    break;
+                }
+                break;
+            case "GC_UNKNOWN":
+            case 0:
+                message.state = 0;
+                break;
+            case "GC_DISABLED":
+            case 1:
+                message.state = 1;
+                break;
+            case "GC_ENABLED":
+            case 2:
+                message.state = 2;
+                break;
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a GravityCompModeEnvelope message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof motors_mirroring.GravityCompModeEnvelope
+         * @static
+         * @param {motors_mirroring.GravityCompModeEnvelope} message GravityCompModeEnvelope
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        GravityCompModeEnvelope.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            let object = {};
+            if (options.defaults) {
+                if ($util.Long) {
+                    let long = new $util.Long(0, 0, true);
+                    object.monotonicStampNs = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.monotonicStampNs = options.longs === String ? "0" : 0;
+                if ($util.Long) {
+                    let long = new $util.Long(0, 0, true);
+                    object.localStampNs = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.localStampNs = options.longs === String ? "0" : 0;
+                if ($util.Long) {
+                    let long = new $util.Long(0, 0, true);
+                    object.appStartId = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.appStartId = options.longs === String ? "0" : 0;
+                object.bus = null;
+                object.state = options.enums === String ? "GC_UNKNOWN" : 0;
+            }
+            if (message.monotonicStampNs != null && message.hasOwnProperty("monotonicStampNs"))
+                if (typeof message.monotonicStampNs === "number")
+                    object.monotonicStampNs = options.longs === String ? String(message.monotonicStampNs) : message.monotonicStampNs;
+                else
+                    object.monotonicStampNs = options.longs === String ? $util.Long.prototype.toString.call(message.monotonicStampNs) : options.longs === Number ? new $util.LongBits(message.monotonicStampNs.low >>> 0, message.monotonicStampNs.high >>> 0).toNumber(true) : message.monotonicStampNs;
+            if (message.localStampNs != null && message.hasOwnProperty("localStampNs"))
+                if (typeof message.localStampNs === "number")
+                    object.localStampNs = options.longs === String ? String(message.localStampNs) : message.localStampNs;
+                else
+                    object.localStampNs = options.longs === String ? $util.Long.prototype.toString.call(message.localStampNs) : options.longs === Number ? new $util.LongBits(message.localStampNs.low >>> 0, message.localStampNs.high >>> 0).toNumber(true) : message.localStampNs;
+            if (message.appStartId != null && message.hasOwnProperty("appStartId"))
+                if (typeof message.appStartId === "number")
+                    object.appStartId = options.longs === String ? String(message.appStartId) : message.appStartId;
+                else
+                    object.appStartId = options.longs === String ? $util.Long.prototype.toString.call(message.appStartId) : options.longs === Number ? new $util.LongBits(message.appStartId.low >>> 0, message.appStartId.high >>> 0).toNumber(true) : message.appStartId;
+            if (message.bus != null && message.hasOwnProperty("bus"))
+                object.bus = $root.motors_mirroring.MirroringBus.toObject(message.bus, options);
+            if (message.state != null && message.hasOwnProperty("state"))
+                object.state = options.enums === String ? $root.motors_mirroring.GravityCompState[message.state] === undefined ? message.state : $root.motors_mirroring.GravityCompState[message.state] : message.state;
+            return object;
+        };
+
+        /**
+         * Converts this GravityCompModeEnvelope to JSON.
+         * @function toJSON
+         * @memberof motors_mirroring.GravityCompModeEnvelope
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        GravityCompModeEnvelope.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        /**
+         * Gets the default type url for GravityCompModeEnvelope
+         * @function getTypeUrl
+         * @memberof motors_mirroring.GravityCompModeEnvelope
+         * @static
+         * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns {string} The default type url
+         */
+        GravityCompModeEnvelope.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
+            if (typeUrlPrefix === undefined) {
+                typeUrlPrefix = "type.googleapis.com";
+            }
+            return typeUrlPrefix + "/motors_mirroring.GravityCompModeEnvelope";
+        };
+
+        return GravityCompModeEnvelope;
+    })();
+
+    /**
+     * GravityCompCommandType enum.
+     * @name motors_mirroring.GravityCompCommandType
+     * @enum {number}
+     * @property {number} GCT_START_GRAVITY_COMP=0 GCT_START_GRAVITY_COMP value
+     * @property {number} GCT_STOP_GRAVITY_COMP=1 GCT_STOP_GRAVITY_COMP value
+     */
+    motors_mirroring.GravityCompCommandType = (function() {
+        const valuesById = {}, values = Object.create(valuesById);
+        values[valuesById[0] = "GCT_START_GRAVITY_COMP"] = 0;
+        values[valuesById[1] = "GCT_STOP_GRAVITY_COMP"] = 1;
+        return values;
+    })();
+
+    motors_mirroring.GravityCompCommand = (function() {
+
+        /**
+         * Properties of a GravityCompCommand.
+         * @memberof motors_mirroring
+         * @interface IGravityCompCommand
+         * @property {motors_mirroring.GravityCompCommandType|null} [type] GravityCompCommand type
+         * @property {motors_mirroring.IMirroringBus|null} [bus] GravityCompCommand bus
+         */
+
+        /**
+         * Constructs a new GravityCompCommand.
+         * @memberof motors_mirroring
+         * @classdesc Represents a GravityCompCommand.
+         * @implements IGravityCompCommand
+         * @constructor
+         * @param {motors_mirroring.IGravityCompCommand=} [properties] Properties to set
+         */
+        function GravityCompCommand(properties) {
+            if (properties)
+                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null && keys[i] !== "__proto__")
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * GravityCompCommand type.
+         * @member {motors_mirroring.GravityCompCommandType} type
+         * @memberof motors_mirroring.GravityCompCommand
+         * @instance
+         */
+        GravityCompCommand.prototype.type = 0;
+
+        /**
+         * GravityCompCommand bus.
+         * @member {motors_mirroring.IMirroringBus|null|undefined} bus
+         * @memberof motors_mirroring.GravityCompCommand
+         * @instance
+         */
+        GravityCompCommand.prototype.bus = null;
+
+        /**
+         * Creates a new GravityCompCommand instance using the specified properties.
+         * @function create
+         * @memberof motors_mirroring.GravityCompCommand
+         * @static
+         * @param {motors_mirroring.IGravityCompCommand=} [properties] Properties to set
+         * @returns {motors_mirroring.GravityCompCommand} GravityCompCommand instance
+         */
+        GravityCompCommand.create = function create(properties) {
+            return new GravityCompCommand(properties);
+        };
+
+        /**
+         * Encodes the specified GravityCompCommand message. Does not implicitly {@link motors_mirroring.GravityCompCommand.verify|verify} messages.
+         * @function encode
+         * @memberof motors_mirroring.GravityCompCommand
+         * @static
+         * @param {motors_mirroring.IGravityCompCommand} message GravityCompCommand message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        GravityCompCommand.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.type != null && Object.hasOwnProperty.call(message, "type"))
+                writer.uint32(/* id 1, wireType 0 =*/8).int32(message.type);
+            if (message.bus != null && Object.hasOwnProperty.call(message, "bus"))
+                $root.motors_mirroring.MirroringBus.encode(message.bus, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified GravityCompCommand message, length delimited. Does not implicitly {@link motors_mirroring.GravityCompCommand.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof motors_mirroring.GravityCompCommand
+         * @static
+         * @param {motors_mirroring.IGravityCompCommand} message GravityCompCommand message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        GravityCompCommand.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a GravityCompCommand message from the specified reader or buffer.
+         * @function decode
+         * @memberof motors_mirroring.GravityCompCommand
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {motors_mirroring.GravityCompCommand} GravityCompCommand
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        GravityCompCommand.decode = function decode(reader, length, error, long) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            if (long === undefined)
+                long = 0;
+            if (long > $Reader.recursionLimit)
+                throw Error("maximum nesting depth exceeded");
+            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.motors_mirroring.GravityCompCommand();
+            while (reader.pos < end) {
+                let tag = reader.uint32();
+                if (tag === error)
+                    break;
+                switch (tag >>> 3) {
+                case 1: {
+                        message.type = reader.int32();
+                        break;
+                    }
+                case 2: {
+                        message.bus = $root.motors_mirroring.MirroringBus.decode(reader, reader.uint32(), undefined, long + 1);
+                        break;
+                    }
+                default:
+                    reader.skipType(tag & 7, long);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a GravityCompCommand message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof motors_mirroring.GravityCompCommand
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {motors_mirroring.GravityCompCommand} GravityCompCommand
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        GravityCompCommand.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a GravityCompCommand message.
+         * @function verify
+         * @memberof motors_mirroring.GravityCompCommand
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        GravityCompCommand.verify = function verify(message, long) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (long === undefined)
+                long = 0;
+            if (long > $util.recursionLimit)
+                return "maximum nesting depth exceeded";
+            if (message.type != null && message.hasOwnProperty("type"))
+                switch (message.type) {
+                default:
+                    return "type: enum value expected";
+                case 0:
+                case 1:
+                    break;
+                }
+            if (message.bus != null && message.hasOwnProperty("bus")) {
+                let error = $root.motors_mirroring.MirroringBus.verify(message.bus, long + 1);
+                if (error)
+                    return "bus." + error;
+            }
+            return null;
+        };
+
+        /**
+         * Creates a GravityCompCommand message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof motors_mirroring.GravityCompCommand
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {motors_mirroring.GravityCompCommand} GravityCompCommand
+         */
+        GravityCompCommand.fromObject = function fromObject(object, long) {
+            if (object instanceof $root.motors_mirroring.GravityCompCommand)
+                return object;
+            if (long === undefined)
+                long = 0;
+            if (long > $util.recursionLimit)
+                throw Error("maximum nesting depth exceeded");
+            let message = new $root.motors_mirroring.GravityCompCommand();
+            switch (object.type) {
+            default:
+                if (typeof object.type === "number") {
+                    message.type = object.type;
+                    break;
+                }
+                break;
+            case "GCT_START_GRAVITY_COMP":
+            case 0:
+                message.type = 0;
+                break;
+            case "GCT_STOP_GRAVITY_COMP":
+            case 1:
+                message.type = 1;
+                break;
+            }
+            if (object.bus != null) {
+                if (typeof object.bus !== "object")
+                    throw TypeError(".motors_mirroring.GravityCompCommand.bus: object expected");
+                message.bus = $root.motors_mirroring.MirroringBus.fromObject(object.bus, long + 1);
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a GravityCompCommand message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof motors_mirroring.GravityCompCommand
+         * @static
+         * @param {motors_mirroring.GravityCompCommand} message GravityCompCommand
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        GravityCompCommand.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            let object = {};
+            if (options.defaults) {
+                object.type = options.enums === String ? "GCT_START_GRAVITY_COMP" : 0;
+                object.bus = null;
+            }
+            if (message.type != null && message.hasOwnProperty("type"))
+                object.type = options.enums === String ? $root.motors_mirroring.GravityCompCommandType[message.type] === undefined ? message.type : $root.motors_mirroring.GravityCompCommandType[message.type] : message.type;
+            if (message.bus != null && message.hasOwnProperty("bus"))
+                object.bus = $root.motors_mirroring.MirroringBus.toObject(message.bus, options);
+            return object;
+        };
+
+        /**
+         * Converts this GravityCompCommand to JSON.
+         * @function toJSON
+         * @memberof motors_mirroring.GravityCompCommand
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        GravityCompCommand.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        /**
+         * Gets the default type url for GravityCompCommand
+         * @function getTypeUrl
+         * @memberof motors_mirroring.GravityCompCommand
+         * @static
+         * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns {string} The default type url
+         */
+        GravityCompCommand.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
+            if (typeUrlPrefix === undefined) {
+                typeUrlPrefix = "type.googleapis.com";
+            }
+            return typeUrlPrefix + "/motors_mirroring.GravityCompCommand";
+        };
+
+        return GravityCompCommand;
+    })();
+
+    motors_mirroring.GravityCompBusState = (function() {
+
+        /**
+         * Properties of a GravityCompBusState.
+         * @memberof motors_mirroring
+         * @interface IGravityCompBusState
+         * @property {motors_mirroring.IMirroringBus|null} [id] GravityCompBusState id
+         * @property {motors_mirroring.GravityCompState|null} [state] GravityCompBusState state
+         */
+
+        /**
+         * Constructs a new GravityCompBusState.
+         * @memberof motors_mirroring
+         * @classdesc Represents a GravityCompBusState.
+         * @implements IGravityCompBusState
+         * @constructor
+         * @param {motors_mirroring.IGravityCompBusState=} [properties] Properties to set
+         */
+        function GravityCompBusState(properties) {
+            if (properties)
+                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null && keys[i] !== "__proto__")
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * GravityCompBusState id.
+         * @member {motors_mirroring.IMirroringBus|null|undefined} id
+         * @memberof motors_mirroring.GravityCompBusState
+         * @instance
+         */
+        GravityCompBusState.prototype.id = null;
+
+        /**
+         * GravityCompBusState state.
+         * @member {motors_mirroring.GravityCompState} state
+         * @memberof motors_mirroring.GravityCompBusState
+         * @instance
+         */
+        GravityCompBusState.prototype.state = 0;
+
+        /**
+         * Creates a new GravityCompBusState instance using the specified properties.
+         * @function create
+         * @memberof motors_mirroring.GravityCompBusState
+         * @static
+         * @param {motors_mirroring.IGravityCompBusState=} [properties] Properties to set
+         * @returns {motors_mirroring.GravityCompBusState} GravityCompBusState instance
+         */
+        GravityCompBusState.create = function create(properties) {
+            return new GravityCompBusState(properties);
+        };
+
+        /**
+         * Encodes the specified GravityCompBusState message. Does not implicitly {@link motors_mirroring.GravityCompBusState.verify|verify} messages.
+         * @function encode
+         * @memberof motors_mirroring.GravityCompBusState
+         * @static
+         * @param {motors_mirroring.IGravityCompBusState} message GravityCompBusState message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        GravityCompBusState.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                $root.motors_mirroring.MirroringBus.encode(message.id, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            if (message.state != null && Object.hasOwnProperty.call(message, "state"))
+                writer.uint32(/* id 2, wireType 0 =*/16).int32(message.state);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified GravityCompBusState message, length delimited. Does not implicitly {@link motors_mirroring.GravityCompBusState.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof motors_mirroring.GravityCompBusState
+         * @static
+         * @param {motors_mirroring.IGravityCompBusState} message GravityCompBusState message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        GravityCompBusState.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a GravityCompBusState message from the specified reader or buffer.
+         * @function decode
+         * @memberof motors_mirroring.GravityCompBusState
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {motors_mirroring.GravityCompBusState} GravityCompBusState
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        GravityCompBusState.decode = function decode(reader, length, error, long) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            if (long === undefined)
+                long = 0;
+            if (long > $Reader.recursionLimit)
+                throw Error("maximum nesting depth exceeded");
+            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.motors_mirroring.GravityCompBusState();
+            while (reader.pos < end) {
+                let tag = reader.uint32();
+                if (tag === error)
+                    break;
+                switch (tag >>> 3) {
+                case 1: {
+                        message.id = $root.motors_mirroring.MirroringBus.decode(reader, reader.uint32(), undefined, long + 1);
+                        break;
+                    }
+                case 2: {
+                        message.state = reader.int32();
+                        break;
+                    }
+                default:
+                    reader.skipType(tag & 7, long);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a GravityCompBusState message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof motors_mirroring.GravityCompBusState
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {motors_mirroring.GravityCompBusState} GravityCompBusState
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        GravityCompBusState.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a GravityCompBusState message.
+         * @function verify
+         * @memberof motors_mirroring.GravityCompBusState
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        GravityCompBusState.verify = function verify(message, long) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (long === undefined)
+                long = 0;
+            if (long > $util.recursionLimit)
+                return "maximum nesting depth exceeded";
+            if (message.id != null && message.hasOwnProperty("id")) {
+                let error = $root.motors_mirroring.MirroringBus.verify(message.id, long + 1);
+                if (error)
+                    return "id." + error;
+            }
+            if (message.state != null && message.hasOwnProperty("state"))
+                switch (message.state) {
+                default:
+                    return "state: enum value expected";
+                case 0:
+                case 1:
+                case 2:
+                    break;
+                }
+            return null;
+        };
+
+        /**
+         * Creates a GravityCompBusState message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof motors_mirroring.GravityCompBusState
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {motors_mirroring.GravityCompBusState} GravityCompBusState
+         */
+        GravityCompBusState.fromObject = function fromObject(object, long) {
+            if (object instanceof $root.motors_mirroring.GravityCompBusState)
+                return object;
+            if (long === undefined)
+                long = 0;
+            if (long > $util.recursionLimit)
+                throw Error("maximum nesting depth exceeded");
+            let message = new $root.motors_mirroring.GravityCompBusState();
+            if (object.id != null) {
+                if (typeof object.id !== "object")
+                    throw TypeError(".motors_mirroring.GravityCompBusState.id: object expected");
+                message.id = $root.motors_mirroring.MirroringBus.fromObject(object.id, long + 1);
+            }
+            switch (object.state) {
+            default:
+                if (typeof object.state === "number") {
+                    message.state = object.state;
+                    break;
+                }
+                break;
+            case "GC_UNKNOWN":
+            case 0:
+                message.state = 0;
+                break;
+            case "GC_DISABLED":
+            case 1:
+                message.state = 1;
+                break;
+            case "GC_ENABLED":
+            case 2:
+                message.state = 2;
+                break;
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a GravityCompBusState message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof motors_mirroring.GravityCompBusState
+         * @static
+         * @param {motors_mirroring.GravityCompBusState} message GravityCompBusState
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        GravityCompBusState.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            let object = {};
+            if (options.defaults) {
+                object.id = null;
+                object.state = options.enums === String ? "GC_UNKNOWN" : 0;
+            }
+            if (message.id != null && message.hasOwnProperty("id"))
+                object.id = $root.motors_mirroring.MirroringBus.toObject(message.id, options);
+            if (message.state != null && message.hasOwnProperty("state"))
+                object.state = options.enums === String ? $root.motors_mirroring.GravityCompState[message.state] === undefined ? message.state : $root.motors_mirroring.GravityCompState[message.state] : message.state;
+            return object;
+        };
+
+        /**
+         * Converts this GravityCompBusState to JSON.
+         * @function toJSON
+         * @memberof motors_mirroring.GravityCompBusState
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        GravityCompBusState.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        /**
+         * Gets the default type url for GravityCompBusState
+         * @function getTypeUrl
+         * @memberof motors_mirroring.GravityCompBusState
+         * @static
+         * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns {string} The default type url
+         */
+        GravityCompBusState.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
+            if (typeUrlPrefix === undefined) {
+                typeUrlPrefix = "type.googleapis.com";
+            }
+            return typeUrlPrefix + "/motors_mirroring.GravityCompBusState";
+        };
+
+        return GravityCompBusState;
     })();
 
     return motors_mirroring;

--- a/software/station/clients/station-viewer/src/api/proto.js
+++ b/software/station/clients/station-viewer/src/api/proto.js
@@ -706,6 +706,7 @@ export const drivers = $root.drivers = (() => {
      * @property {number} QDT_MOTOR_MIRRORING_MODES=30 QDT_MOTOR_MIRRORING_MODES value
      * @property {number} QDT_MOTOR_MIRRORING_RX=32 QDT_MOTOR_MIRRORING_RX value
      * @property {number} QDT_MOTOR_MIRRORING_GRAVITY_COMP_MODES=33 QDT_MOTOR_MIRRORING_GRAVITY_COMP_MODES value
+     * @property {number} QDT_MOTOR_MIRRORING_GRAVITY_COMP_SETTINGS=34 QDT_MOTOR_MIRRORING_GRAVITY_COMP_SETTINGS value
      * @property {number} QDT_YAHBOOM_DOGZILLA_LITE_SERIAL_TX=40 QDT_YAHBOOM_DOGZILLA_LITE_SERIAL_TX value
      * @property {number} QDT_YAHBOOM_DOGZILLA_LITE_SERIAL_RX=41 QDT_YAHBOOM_DOGZILLA_LITE_SERIAL_RX value
      * @property {number} QDT_YAHBOOM_DOGZILLA_LITE_INFERENCE=42 QDT_YAHBOOM_DOGZILLA_LITE_INFERENCE value
@@ -726,6 +727,7 @@ export const drivers = $root.drivers = (() => {
         values[valuesById[30] = "QDT_MOTOR_MIRRORING_MODES"] = 30;
         values[valuesById[32] = "QDT_MOTOR_MIRRORING_RX"] = 32;
         values[valuesById[33] = "QDT_MOTOR_MIRRORING_GRAVITY_COMP_MODES"] = 33;
+        values[valuesById[34] = "QDT_MOTOR_MIRRORING_GRAVITY_COMP_SETTINGS"] = 34;
         values[valuesById[40] = "QDT_YAHBOOM_DOGZILLA_LITE_SERIAL_TX"] = 40;
         values[valuesById[41] = "QDT_YAHBOOM_DOGZILLA_LITE_SERIAL_RX"] = 41;
         values[valuesById[42] = "QDT_YAHBOOM_DOGZILLA_LITE_INFERENCE"] = 42;
@@ -1307,6 +1309,7 @@ export const inference = $root.inference = (() => {
                     case 30:
                     case 32:
                     case 33:
+                    case 34:
                     case 40:
                     case 41:
                     case 42:
@@ -1400,6 +1403,10 @@ export const inference = $root.inference = (() => {
                 case "QDT_MOTOR_MIRRORING_GRAVITY_COMP_MODES":
                 case 33:
                     message.type = 33;
+                    break;
+                case "QDT_MOTOR_MIRRORING_GRAVITY_COMP_SETTINGS":
+                case 34:
+                    message.type = 34;
                     break;
                 case "QDT_YAHBOOM_DOGZILLA_LITE_SERIAL_TX":
                 case 40:
@@ -16097,12 +16104,16 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
      * @property {number} GCT_START_GRAVITY_COMP=0 GCT_START_GRAVITY_COMP value
      * @property {number} GCT_STOP_GRAVITY_COMP=1 GCT_STOP_GRAVITY_COMP value
      * @property {number} GCT_SET_GAIN=2 GCT_SET_GAIN value
+     * @property {number} GCT_SET_TORQUE_LIMIT=3 GCT_SET_TORQUE_LIMIT value
+     * @property {number} GCT_SAVE_SETTINGS=4 GCT_SAVE_SETTINGS value
      */
     motors_mirroring.GravityCompCommandType = (function() {
         const valuesById = {}, values = Object.create(valuesById);
         values[valuesById[0] = "GCT_START_GRAVITY_COMP"] = 0;
         values[valuesById[1] = "GCT_STOP_GRAVITY_COMP"] = 1;
         values[valuesById[2] = "GCT_SET_GAIN"] = 2;
+        values[valuesById[3] = "GCT_SET_TORQUE_LIMIT"] = 3;
+        values[valuesById[4] = "GCT_SAVE_SETTINGS"] = 4;
         return values;
     })();
 
@@ -16115,6 +16126,8 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
          * @property {motors_mirroring.GravityCompCommandType|null} [type] GravityCompCommand type
          * @property {motors_mirroring.IMirroringBus|null} [bus] GravityCompCommand bus
          * @property {number|null} [gainRadPerNm] GravityCompCommand gainRadPerNm
+         * @property {number|null} [motorId] GravityCompCommand motorId
+         * @property {number|null} [torqueLimit] GravityCompCommand torqueLimit
          */
 
         /**
@@ -16156,12 +16169,40 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
          */
         GravityCompCommand.prototype.gainRadPerNm = null;
 
+        /**
+         * GravityCompCommand motorId.
+         * @member {number|null|undefined} motorId
+         * @memberof motors_mirroring.GravityCompCommand
+         * @instance
+         */
+        GravityCompCommand.prototype.motorId = null;
+
+        /**
+         * GravityCompCommand torqueLimit.
+         * @member {number|null|undefined} torqueLimit
+         * @memberof motors_mirroring.GravityCompCommand
+         * @instance
+         */
+        GravityCompCommand.prototype.torqueLimit = null;
+
         // OneOf field names bound to virtual getters and setters
         let $oneOfFields;
 
         // Virtual OneOf for proto3 optional field
         Object.defineProperty(GravityCompCommand.prototype, "_gainRadPerNm", {
             get: $util.oneOfGetter($oneOfFields = ["gainRadPerNm"]),
+            set: $util.oneOfSetter($oneOfFields)
+        });
+
+        // Virtual OneOf for proto3 optional field
+        Object.defineProperty(GravityCompCommand.prototype, "_motorId", {
+            get: $util.oneOfGetter($oneOfFields = ["motorId"]),
+            set: $util.oneOfSetter($oneOfFields)
+        });
+
+        // Virtual OneOf for proto3 optional field
+        Object.defineProperty(GravityCompCommand.prototype, "_torqueLimit", {
+            get: $util.oneOfGetter($oneOfFields = ["torqueLimit"]),
             set: $util.oneOfSetter($oneOfFields)
         });
 
@@ -16195,6 +16236,10 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                 $root.motors_mirroring.MirroringBus.encode(message.bus, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
             if (message.gainRadPerNm != null && Object.hasOwnProperty.call(message, "gainRadPerNm"))
                 writer.uint32(/* id 3, wireType 1 =*/25).double(message.gainRadPerNm);
+            if (message.motorId != null && Object.hasOwnProperty.call(message, "motorId"))
+                writer.uint32(/* id 4, wireType 0 =*/32).uint32(message.motorId);
+            if (message.torqueLimit != null && Object.hasOwnProperty.call(message, "torqueLimit"))
+                writer.uint32(/* id 5, wireType 0 =*/40).uint32(message.torqueLimit);
             return writer;
         };
 
@@ -16247,6 +16292,14 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                         message.gainRadPerNm = reader.double();
                         break;
                     }
+                case 4: {
+                        message.motorId = reader.uint32();
+                        break;
+                    }
+                case 5: {
+                        message.torqueLimit = reader.uint32();
+                        break;
+                    }
                 default:
                     reader.skipType(tag & 7, long);
                     break;
@@ -16294,6 +16347,8 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                 case 0:
                 case 1:
                 case 2:
+                case 3:
+                case 4:
                     break;
                 }
             if (message.bus != null && message.hasOwnProperty("bus")) {
@@ -16305,6 +16360,16 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                 properties._gainRadPerNm = 1;
                 if (typeof message.gainRadPerNm !== "number")
                     return "gainRadPerNm: number expected";
+            }
+            if (message.motorId != null && message.hasOwnProperty("motorId")) {
+                properties._motorId = 1;
+                if (!$util.isInteger(message.motorId))
+                    return "motorId: integer expected";
+            }
+            if (message.torqueLimit != null && message.hasOwnProperty("torqueLimit")) {
+                properties._torqueLimit = 1;
+                if (!$util.isInteger(message.torqueLimit))
+                    return "torqueLimit: integer expected";
             }
             return null;
         };
@@ -16344,6 +16409,14 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
             case 2:
                 message.type = 2;
                 break;
+            case "GCT_SET_TORQUE_LIMIT":
+            case 3:
+                message.type = 3;
+                break;
+            case "GCT_SAVE_SETTINGS":
+            case 4:
+                message.type = 4;
+                break;
             }
             if (object.bus != null) {
                 if (typeof object.bus !== "object")
@@ -16352,6 +16425,10 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
             }
             if (object.gainRadPerNm != null)
                 message.gainRadPerNm = Number(object.gainRadPerNm);
+            if (object.motorId != null)
+                message.motorId = object.motorId >>> 0;
+            if (object.torqueLimit != null)
+                message.torqueLimit = object.torqueLimit >>> 0;
             return message;
         };
 
@@ -16380,6 +16457,16 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                 object.gainRadPerNm = options.json && !isFinite(message.gainRadPerNm) ? String(message.gainRadPerNm) : message.gainRadPerNm;
                 if (options.oneofs)
                     object._gainRadPerNm = "gainRadPerNm";
+            }
+            if (message.motorId != null && message.hasOwnProperty("motorId")) {
+                object.motorId = message.motorId;
+                if (options.oneofs)
+                    object._motorId = "motorId";
+            }
+            if (message.torqueLimit != null && message.hasOwnProperty("torqueLimit")) {
+                object.torqueLimit = message.torqueLimit;
+                if (options.oneofs)
+                    object._torqueLimit = "torqueLimit";
             }
             return object;
         };
@@ -16421,7 +16508,8 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
          * @interface IGravityCompBusState
          * @property {motors_mirroring.IMirroringBus|null} [id] GravityCompBusState id
          * @property {motors_mirroring.GravityCompState|null} [state] GravityCompBusState state
-         * @property {number|null} [gainRadPerNm] GravityCompBusState gainRadPerNm
+         * @property {Array.<number>|null} [jointGainsRadPerNm] GravityCompBusState jointGainsRadPerNm
+         * @property {number|null} [torqueLimit] GravityCompBusState torqueLimit
          */
 
         /**
@@ -16433,6 +16521,7 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
          * @param {motors_mirroring.IGravityCompBusState=} [properties] Properties to set
          */
         function GravityCompBusState(properties) {
+            this.jointGainsRadPerNm = [];
             if (properties)
                 for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
                     if (properties[keys[i]] != null && keys[i] !== "__proto__")
@@ -16456,19 +16545,27 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
         GravityCompBusState.prototype.state = 0;
 
         /**
-         * GravityCompBusState gainRadPerNm.
-         * @member {number|null|undefined} gainRadPerNm
+         * GravityCompBusState jointGainsRadPerNm.
+         * @member {Array.<number>} jointGainsRadPerNm
          * @memberof motors_mirroring.GravityCompBusState
          * @instance
          */
-        GravityCompBusState.prototype.gainRadPerNm = null;
+        GravityCompBusState.prototype.jointGainsRadPerNm = $util.emptyArray;
+
+        /**
+         * GravityCompBusState torqueLimit.
+         * @member {number|null|undefined} torqueLimit
+         * @memberof motors_mirroring.GravityCompBusState
+         * @instance
+         */
+        GravityCompBusState.prototype.torqueLimit = null;
 
         // OneOf field names bound to virtual getters and setters
         let $oneOfFields;
 
         // Virtual OneOf for proto3 optional field
-        Object.defineProperty(GravityCompBusState.prototype, "_gainRadPerNm", {
-            get: $util.oneOfGetter($oneOfFields = ["gainRadPerNm"]),
+        Object.defineProperty(GravityCompBusState.prototype, "_torqueLimit", {
+            get: $util.oneOfGetter($oneOfFields = ["torqueLimit"]),
             set: $util.oneOfSetter($oneOfFields)
         });
 
@@ -16500,8 +16597,14 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                 $root.motors_mirroring.MirroringBus.encode(message.id, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
             if (message.state != null && Object.hasOwnProperty.call(message, "state"))
                 writer.uint32(/* id 2, wireType 0 =*/16).int32(message.state);
-            if (message.gainRadPerNm != null && Object.hasOwnProperty.call(message, "gainRadPerNm"))
-                writer.uint32(/* id 3, wireType 1 =*/25).double(message.gainRadPerNm);
+            if (message.jointGainsRadPerNm != null && message.jointGainsRadPerNm.length) {
+                writer.uint32(/* id 4, wireType 2 =*/34).fork();
+                for (let i = 0; i < message.jointGainsRadPerNm.length; ++i)
+                    writer.double(message.jointGainsRadPerNm[i]);
+                writer.ldelim();
+            }
+            if (message.torqueLimit != null && Object.hasOwnProperty.call(message, "torqueLimit"))
+                writer.uint32(/* id 5, wireType 0 =*/40).uint32(message.torqueLimit);
             return writer;
         };
 
@@ -16550,8 +16653,19 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                         message.state = reader.int32();
                         break;
                     }
-                case 3: {
-                        message.gainRadPerNm = reader.double();
+                case 4: {
+                        if (!(message.jointGainsRadPerNm && message.jointGainsRadPerNm.length))
+                            message.jointGainsRadPerNm = [];
+                        if ((tag & 7) === 2) {
+                            let end2 = reader.uint32() + reader.pos;
+                            while (reader.pos < end2)
+                                message.jointGainsRadPerNm.push(reader.double());
+                        } else
+                            message.jointGainsRadPerNm.push(reader.double());
+                        break;
+                    }
+                case 5: {
+                        message.torqueLimit = reader.uint32();
                         break;
                     }
                 default:
@@ -16608,10 +16722,17 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                 case 2:
                     break;
                 }
-            if (message.gainRadPerNm != null && message.hasOwnProperty("gainRadPerNm")) {
-                properties._gainRadPerNm = 1;
-                if (typeof message.gainRadPerNm !== "number")
-                    return "gainRadPerNm: number expected";
+            if (message.jointGainsRadPerNm != null && message.hasOwnProperty("jointGainsRadPerNm")) {
+                if (!Array.isArray(message.jointGainsRadPerNm))
+                    return "jointGainsRadPerNm: array expected";
+                for (let i = 0; i < message.jointGainsRadPerNm.length; ++i)
+                    if (typeof message.jointGainsRadPerNm[i] !== "number")
+                        return "jointGainsRadPerNm: number[] expected";
+            }
+            if (message.torqueLimit != null && message.hasOwnProperty("torqueLimit")) {
+                properties._torqueLimit = 1;
+                if (!$util.isInteger(message.torqueLimit))
+                    return "torqueLimit: integer expected";
             }
             return null;
         };
@@ -16657,8 +16778,15 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                 message.state = 2;
                 break;
             }
-            if (object.gainRadPerNm != null)
-                message.gainRadPerNm = Number(object.gainRadPerNm);
+            if (object.jointGainsRadPerNm) {
+                if (!Array.isArray(object.jointGainsRadPerNm))
+                    throw TypeError(".motors_mirroring.GravityCompBusState.jointGainsRadPerNm: array expected");
+                message.jointGainsRadPerNm = [];
+                for (let i = 0; i < object.jointGainsRadPerNm.length; ++i)
+                    message.jointGainsRadPerNm[i] = Number(object.jointGainsRadPerNm[i]);
+            }
+            if (object.torqueLimit != null)
+                message.torqueLimit = object.torqueLimit >>> 0;
             return message;
         };
 
@@ -16675,6 +16803,8 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
             if (!options)
                 options = {};
             let object = {};
+            if (options.arrays || options.defaults)
+                object.jointGainsRadPerNm = [];
             if (options.defaults) {
                 object.id = null;
                 object.state = options.enums === String ? "GC_UNKNOWN" : 0;
@@ -16683,10 +16813,15 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                 object.id = $root.motors_mirroring.MirroringBus.toObject(message.id, options);
             if (message.state != null && message.hasOwnProperty("state"))
                 object.state = options.enums === String ? $root.motors_mirroring.GravityCompState[message.state] === undefined ? message.state : $root.motors_mirroring.GravityCompState[message.state] : message.state;
-            if (message.gainRadPerNm != null && message.hasOwnProperty("gainRadPerNm")) {
-                object.gainRadPerNm = options.json && !isFinite(message.gainRadPerNm) ? String(message.gainRadPerNm) : message.gainRadPerNm;
+            if (message.jointGainsRadPerNm && message.jointGainsRadPerNm.length) {
+                object.jointGainsRadPerNm = [];
+                for (let j = 0; j < message.jointGainsRadPerNm.length; ++j)
+                    object.jointGainsRadPerNm[j] = options.json && !isFinite(message.jointGainsRadPerNm[j]) ? String(message.jointGainsRadPerNm[j]) : message.jointGainsRadPerNm[j];
+            }
+            if (message.torqueLimit != null && message.hasOwnProperty("torqueLimit")) {
+                object.torqueLimit = message.torqueLimit;
                 if (options.oneofs)
-                    object._gainRadPerNm = "gainRadPerNm";
+                    object._torqueLimit = "torqueLimit";
             }
             return object;
         };
@@ -16718,6 +16853,411 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
         };
 
         return GravityCompBusState;
+    })();
+
+    motors_mirroring.GravityCompSettingsEnvelope = (function() {
+
+        /**
+         * Properties of a GravityCompSettingsEnvelope.
+         * @memberof motors_mirroring
+         * @interface IGravityCompSettingsEnvelope
+         * @property {Long|null} [monotonicStampNs] GravityCompSettingsEnvelope monotonicStampNs
+         * @property {Long|null} [localStampNs] GravityCompSettingsEnvelope localStampNs
+         * @property {Long|null} [appStartId] GravityCompSettingsEnvelope appStartId
+         * @property {motors_mirroring.IMirroringBus|null} [bus] GravityCompSettingsEnvelope bus
+         * @property {Array.<number>|null} [jointGainsRadPerNm] GravityCompSettingsEnvelope jointGainsRadPerNm
+         * @property {number|null} [torqueLimit] GravityCompSettingsEnvelope torqueLimit
+         */
+
+        /**
+         * Constructs a new GravityCompSettingsEnvelope.
+         * @memberof motors_mirroring
+         * @classdesc Represents a GravityCompSettingsEnvelope.
+         * @implements IGravityCompSettingsEnvelope
+         * @constructor
+         * @param {motors_mirroring.IGravityCompSettingsEnvelope=} [properties] Properties to set
+         */
+        function GravityCompSettingsEnvelope(properties) {
+            this.jointGainsRadPerNm = [];
+            if (properties)
+                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null && keys[i] !== "__proto__")
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * GravityCompSettingsEnvelope monotonicStampNs.
+         * @member {Long} monotonicStampNs
+         * @memberof motors_mirroring.GravityCompSettingsEnvelope
+         * @instance
+         */
+        GravityCompSettingsEnvelope.prototype.monotonicStampNs = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
+
+        /**
+         * GravityCompSettingsEnvelope localStampNs.
+         * @member {Long} localStampNs
+         * @memberof motors_mirroring.GravityCompSettingsEnvelope
+         * @instance
+         */
+        GravityCompSettingsEnvelope.prototype.localStampNs = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
+
+        /**
+         * GravityCompSettingsEnvelope appStartId.
+         * @member {Long} appStartId
+         * @memberof motors_mirroring.GravityCompSettingsEnvelope
+         * @instance
+         */
+        GravityCompSettingsEnvelope.prototype.appStartId = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
+
+        /**
+         * GravityCompSettingsEnvelope bus.
+         * @member {motors_mirroring.IMirroringBus|null|undefined} bus
+         * @memberof motors_mirroring.GravityCompSettingsEnvelope
+         * @instance
+         */
+        GravityCompSettingsEnvelope.prototype.bus = null;
+
+        /**
+         * GravityCompSettingsEnvelope jointGainsRadPerNm.
+         * @member {Array.<number>} jointGainsRadPerNm
+         * @memberof motors_mirroring.GravityCompSettingsEnvelope
+         * @instance
+         */
+        GravityCompSettingsEnvelope.prototype.jointGainsRadPerNm = $util.emptyArray;
+
+        /**
+         * GravityCompSettingsEnvelope torqueLimit.
+         * @member {number} torqueLimit
+         * @memberof motors_mirroring.GravityCompSettingsEnvelope
+         * @instance
+         */
+        GravityCompSettingsEnvelope.prototype.torqueLimit = 0;
+
+        /**
+         * Creates a new GravityCompSettingsEnvelope instance using the specified properties.
+         * @function create
+         * @memberof motors_mirroring.GravityCompSettingsEnvelope
+         * @static
+         * @param {motors_mirroring.IGravityCompSettingsEnvelope=} [properties] Properties to set
+         * @returns {motors_mirroring.GravityCompSettingsEnvelope} GravityCompSettingsEnvelope instance
+         */
+        GravityCompSettingsEnvelope.create = function create(properties) {
+            return new GravityCompSettingsEnvelope(properties);
+        };
+
+        /**
+         * Encodes the specified GravityCompSettingsEnvelope message. Does not implicitly {@link motors_mirroring.GravityCompSettingsEnvelope.verify|verify} messages.
+         * @function encode
+         * @memberof motors_mirroring.GravityCompSettingsEnvelope
+         * @static
+         * @param {motors_mirroring.IGravityCompSettingsEnvelope} message GravityCompSettingsEnvelope message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        GravityCompSettingsEnvelope.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.monotonicStampNs != null && Object.hasOwnProperty.call(message, "monotonicStampNs"))
+                writer.uint32(/* id 1, wireType 0 =*/8).uint64(message.monotonicStampNs);
+            if (message.localStampNs != null && Object.hasOwnProperty.call(message, "localStampNs"))
+                writer.uint32(/* id 2, wireType 0 =*/16).uint64(message.localStampNs);
+            if (message.appStartId != null && Object.hasOwnProperty.call(message, "appStartId"))
+                writer.uint32(/* id 3, wireType 0 =*/24).uint64(message.appStartId);
+            if (message.bus != null && Object.hasOwnProperty.call(message, "bus"))
+                $root.motors_mirroring.MirroringBus.encode(message.bus, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+            if (message.jointGainsRadPerNm != null && message.jointGainsRadPerNm.length) {
+                writer.uint32(/* id 5, wireType 2 =*/42).fork();
+                for (let i = 0; i < message.jointGainsRadPerNm.length; ++i)
+                    writer.double(message.jointGainsRadPerNm[i]);
+                writer.ldelim();
+            }
+            if (message.torqueLimit != null && Object.hasOwnProperty.call(message, "torqueLimit"))
+                writer.uint32(/* id 6, wireType 0 =*/48).uint32(message.torqueLimit);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified GravityCompSettingsEnvelope message, length delimited. Does not implicitly {@link motors_mirroring.GravityCompSettingsEnvelope.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof motors_mirroring.GravityCompSettingsEnvelope
+         * @static
+         * @param {motors_mirroring.IGravityCompSettingsEnvelope} message GravityCompSettingsEnvelope message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        GravityCompSettingsEnvelope.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a GravityCompSettingsEnvelope message from the specified reader or buffer.
+         * @function decode
+         * @memberof motors_mirroring.GravityCompSettingsEnvelope
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {motors_mirroring.GravityCompSettingsEnvelope} GravityCompSettingsEnvelope
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        GravityCompSettingsEnvelope.decode = function decode(reader, length, error, long) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            if (long === undefined)
+                long = 0;
+            if (long > $Reader.recursionLimit)
+                throw Error("maximum nesting depth exceeded");
+            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.motors_mirroring.GravityCompSettingsEnvelope();
+            while (reader.pos < end) {
+                let tag = reader.uint32();
+                if (tag === error)
+                    break;
+                switch (tag >>> 3) {
+                case 1: {
+                        message.monotonicStampNs = reader.uint64();
+                        break;
+                    }
+                case 2: {
+                        message.localStampNs = reader.uint64();
+                        break;
+                    }
+                case 3: {
+                        message.appStartId = reader.uint64();
+                        break;
+                    }
+                case 4: {
+                        message.bus = $root.motors_mirroring.MirroringBus.decode(reader, reader.uint32(), undefined, long + 1);
+                        break;
+                    }
+                case 5: {
+                        if (!(message.jointGainsRadPerNm && message.jointGainsRadPerNm.length))
+                            message.jointGainsRadPerNm = [];
+                        if ((tag & 7) === 2) {
+                            let end2 = reader.uint32() + reader.pos;
+                            while (reader.pos < end2)
+                                message.jointGainsRadPerNm.push(reader.double());
+                        } else
+                            message.jointGainsRadPerNm.push(reader.double());
+                        break;
+                    }
+                case 6: {
+                        message.torqueLimit = reader.uint32();
+                        break;
+                    }
+                default:
+                    reader.skipType(tag & 7, long);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a GravityCompSettingsEnvelope message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof motors_mirroring.GravityCompSettingsEnvelope
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {motors_mirroring.GravityCompSettingsEnvelope} GravityCompSettingsEnvelope
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        GravityCompSettingsEnvelope.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a GravityCompSettingsEnvelope message.
+         * @function verify
+         * @memberof motors_mirroring.GravityCompSettingsEnvelope
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        GravityCompSettingsEnvelope.verify = function verify(message, long) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (long === undefined)
+                long = 0;
+            if (long > $util.recursionLimit)
+                return "maximum nesting depth exceeded";
+            if (message.monotonicStampNs != null && message.hasOwnProperty("monotonicStampNs"))
+                if (!$util.isInteger(message.monotonicStampNs) && !(message.monotonicStampNs && $util.isInteger(message.monotonicStampNs.low) && $util.isInteger(message.monotonicStampNs.high)))
+                    return "monotonicStampNs: integer|Long expected";
+            if (message.localStampNs != null && message.hasOwnProperty("localStampNs"))
+                if (!$util.isInteger(message.localStampNs) && !(message.localStampNs && $util.isInteger(message.localStampNs.low) && $util.isInteger(message.localStampNs.high)))
+                    return "localStampNs: integer|Long expected";
+            if (message.appStartId != null && message.hasOwnProperty("appStartId"))
+                if (!$util.isInteger(message.appStartId) && !(message.appStartId && $util.isInteger(message.appStartId.low) && $util.isInteger(message.appStartId.high)))
+                    return "appStartId: integer|Long expected";
+            if (message.bus != null && message.hasOwnProperty("bus")) {
+                let error = $root.motors_mirroring.MirroringBus.verify(message.bus, long + 1);
+                if (error)
+                    return "bus." + error;
+            }
+            if (message.jointGainsRadPerNm != null && message.hasOwnProperty("jointGainsRadPerNm")) {
+                if (!Array.isArray(message.jointGainsRadPerNm))
+                    return "jointGainsRadPerNm: array expected";
+                for (let i = 0; i < message.jointGainsRadPerNm.length; ++i)
+                    if (typeof message.jointGainsRadPerNm[i] !== "number")
+                        return "jointGainsRadPerNm: number[] expected";
+            }
+            if (message.torqueLimit != null && message.hasOwnProperty("torqueLimit"))
+                if (!$util.isInteger(message.torqueLimit))
+                    return "torqueLimit: integer expected";
+            return null;
+        };
+
+        /**
+         * Creates a GravityCompSettingsEnvelope message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof motors_mirroring.GravityCompSettingsEnvelope
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {motors_mirroring.GravityCompSettingsEnvelope} GravityCompSettingsEnvelope
+         */
+        GravityCompSettingsEnvelope.fromObject = function fromObject(object, long) {
+            if (object instanceof $root.motors_mirroring.GravityCompSettingsEnvelope)
+                return object;
+            if (long === undefined)
+                long = 0;
+            if (long > $util.recursionLimit)
+                throw Error("maximum nesting depth exceeded");
+            let message = new $root.motors_mirroring.GravityCompSettingsEnvelope();
+            if (object.monotonicStampNs != null)
+                if ($util.Long)
+                    (message.monotonicStampNs = $util.Long.fromValue(object.monotonicStampNs)).unsigned = true;
+                else if (typeof object.monotonicStampNs === "string")
+                    message.monotonicStampNs = parseInt(object.monotonicStampNs, 10);
+                else if (typeof object.monotonicStampNs === "number")
+                    message.monotonicStampNs = object.monotonicStampNs;
+                else if (typeof object.monotonicStampNs === "object")
+                    message.monotonicStampNs = new $util.LongBits(object.monotonicStampNs.low >>> 0, object.monotonicStampNs.high >>> 0).toNumber(true);
+            if (object.localStampNs != null)
+                if ($util.Long)
+                    (message.localStampNs = $util.Long.fromValue(object.localStampNs)).unsigned = true;
+                else if (typeof object.localStampNs === "string")
+                    message.localStampNs = parseInt(object.localStampNs, 10);
+                else if (typeof object.localStampNs === "number")
+                    message.localStampNs = object.localStampNs;
+                else if (typeof object.localStampNs === "object")
+                    message.localStampNs = new $util.LongBits(object.localStampNs.low >>> 0, object.localStampNs.high >>> 0).toNumber(true);
+            if (object.appStartId != null)
+                if ($util.Long)
+                    (message.appStartId = $util.Long.fromValue(object.appStartId)).unsigned = true;
+                else if (typeof object.appStartId === "string")
+                    message.appStartId = parseInt(object.appStartId, 10);
+                else if (typeof object.appStartId === "number")
+                    message.appStartId = object.appStartId;
+                else if (typeof object.appStartId === "object")
+                    message.appStartId = new $util.LongBits(object.appStartId.low >>> 0, object.appStartId.high >>> 0).toNumber(true);
+            if (object.bus != null) {
+                if (typeof object.bus !== "object")
+                    throw TypeError(".motors_mirroring.GravityCompSettingsEnvelope.bus: object expected");
+                message.bus = $root.motors_mirroring.MirroringBus.fromObject(object.bus, long + 1);
+            }
+            if (object.jointGainsRadPerNm) {
+                if (!Array.isArray(object.jointGainsRadPerNm))
+                    throw TypeError(".motors_mirroring.GravityCompSettingsEnvelope.jointGainsRadPerNm: array expected");
+                message.jointGainsRadPerNm = [];
+                for (let i = 0; i < object.jointGainsRadPerNm.length; ++i)
+                    message.jointGainsRadPerNm[i] = Number(object.jointGainsRadPerNm[i]);
+            }
+            if (object.torqueLimit != null)
+                message.torqueLimit = object.torqueLimit >>> 0;
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a GravityCompSettingsEnvelope message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof motors_mirroring.GravityCompSettingsEnvelope
+         * @static
+         * @param {motors_mirroring.GravityCompSettingsEnvelope} message GravityCompSettingsEnvelope
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        GravityCompSettingsEnvelope.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            let object = {};
+            if (options.arrays || options.defaults)
+                object.jointGainsRadPerNm = [];
+            if (options.defaults) {
+                if ($util.Long) {
+                    let long = new $util.Long(0, 0, true);
+                    object.monotonicStampNs = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.monotonicStampNs = options.longs === String ? "0" : 0;
+                if ($util.Long) {
+                    let long = new $util.Long(0, 0, true);
+                    object.localStampNs = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.localStampNs = options.longs === String ? "0" : 0;
+                if ($util.Long) {
+                    let long = new $util.Long(0, 0, true);
+                    object.appStartId = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.appStartId = options.longs === String ? "0" : 0;
+                object.bus = null;
+                object.torqueLimit = 0;
+            }
+            if (message.monotonicStampNs != null && message.hasOwnProperty("monotonicStampNs"))
+                if (typeof message.monotonicStampNs === "number")
+                    object.monotonicStampNs = options.longs === String ? String(message.monotonicStampNs) : message.monotonicStampNs;
+                else
+                    object.monotonicStampNs = options.longs === String ? $util.Long.prototype.toString.call(message.monotonicStampNs) : options.longs === Number ? new $util.LongBits(message.monotonicStampNs.low >>> 0, message.monotonicStampNs.high >>> 0).toNumber(true) : message.monotonicStampNs;
+            if (message.localStampNs != null && message.hasOwnProperty("localStampNs"))
+                if (typeof message.localStampNs === "number")
+                    object.localStampNs = options.longs === String ? String(message.localStampNs) : message.localStampNs;
+                else
+                    object.localStampNs = options.longs === String ? $util.Long.prototype.toString.call(message.localStampNs) : options.longs === Number ? new $util.LongBits(message.localStampNs.low >>> 0, message.localStampNs.high >>> 0).toNumber(true) : message.localStampNs;
+            if (message.appStartId != null && message.hasOwnProperty("appStartId"))
+                if (typeof message.appStartId === "number")
+                    object.appStartId = options.longs === String ? String(message.appStartId) : message.appStartId;
+                else
+                    object.appStartId = options.longs === String ? $util.Long.prototype.toString.call(message.appStartId) : options.longs === Number ? new $util.LongBits(message.appStartId.low >>> 0, message.appStartId.high >>> 0).toNumber(true) : message.appStartId;
+            if (message.bus != null && message.hasOwnProperty("bus"))
+                object.bus = $root.motors_mirroring.MirroringBus.toObject(message.bus, options);
+            if (message.jointGainsRadPerNm && message.jointGainsRadPerNm.length) {
+                object.jointGainsRadPerNm = [];
+                for (let j = 0; j < message.jointGainsRadPerNm.length; ++j)
+                    object.jointGainsRadPerNm[j] = options.json && !isFinite(message.jointGainsRadPerNm[j]) ? String(message.jointGainsRadPerNm[j]) : message.jointGainsRadPerNm[j];
+            }
+            if (message.torqueLimit != null && message.hasOwnProperty("torqueLimit"))
+                object.torqueLimit = message.torqueLimit;
+            return object;
+        };
+
+        /**
+         * Converts this GravityCompSettingsEnvelope to JSON.
+         * @function toJSON
+         * @memberof motors_mirroring.GravityCompSettingsEnvelope
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        GravityCompSettingsEnvelope.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        /**
+         * Gets the default type url for GravityCompSettingsEnvelope
+         * @function getTypeUrl
+         * @memberof motors_mirroring.GravityCompSettingsEnvelope
+         * @static
+         * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns {string} The default type url
+         */
+        GravityCompSettingsEnvelope.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
+            if (typeUrlPrefix === undefined) {
+                typeUrlPrefix = "type.googleapis.com";
+            }
+            return typeUrlPrefix + "/motors_mirroring.GravityCompSettingsEnvelope";
+        };
+
+        return GravityCompSettingsEnvelope;
     })();
 
     return motors_mirroring;

--- a/software/station/clients/station-viewer/src/api/proto.js
+++ b/software/station/clients/station-viewer/src/api/proto.js
@@ -16096,11 +16096,13 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
      * @enum {number}
      * @property {number} GCT_START_GRAVITY_COMP=0 GCT_START_GRAVITY_COMP value
      * @property {number} GCT_STOP_GRAVITY_COMP=1 GCT_STOP_GRAVITY_COMP value
+     * @property {number} GCT_SET_GAIN=2 GCT_SET_GAIN value
      */
     motors_mirroring.GravityCompCommandType = (function() {
         const valuesById = {}, values = Object.create(valuesById);
         values[valuesById[0] = "GCT_START_GRAVITY_COMP"] = 0;
         values[valuesById[1] = "GCT_STOP_GRAVITY_COMP"] = 1;
+        values[valuesById[2] = "GCT_SET_GAIN"] = 2;
         return values;
     })();
 
@@ -16112,6 +16114,7 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
          * @interface IGravityCompCommand
          * @property {motors_mirroring.GravityCompCommandType|null} [type] GravityCompCommand type
          * @property {motors_mirroring.IMirroringBus|null} [bus] GravityCompCommand bus
+         * @property {number|null} [gainRadPerNm] GravityCompCommand gainRadPerNm
          */
 
         /**
@@ -16146,6 +16149,23 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
         GravityCompCommand.prototype.bus = null;
 
         /**
+         * GravityCompCommand gainRadPerNm.
+         * @member {number|null|undefined} gainRadPerNm
+         * @memberof motors_mirroring.GravityCompCommand
+         * @instance
+         */
+        GravityCompCommand.prototype.gainRadPerNm = null;
+
+        // OneOf field names bound to virtual getters and setters
+        let $oneOfFields;
+
+        // Virtual OneOf for proto3 optional field
+        Object.defineProperty(GravityCompCommand.prototype, "_gainRadPerNm", {
+            get: $util.oneOfGetter($oneOfFields = ["gainRadPerNm"]),
+            set: $util.oneOfSetter($oneOfFields)
+        });
+
+        /**
          * Creates a new GravityCompCommand instance using the specified properties.
          * @function create
          * @memberof motors_mirroring.GravityCompCommand
@@ -16173,6 +16193,8 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                 writer.uint32(/* id 1, wireType 0 =*/8).int32(message.type);
             if (message.bus != null && Object.hasOwnProperty.call(message, "bus"))
                 $root.motors_mirroring.MirroringBus.encode(message.bus, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            if (message.gainRadPerNm != null && Object.hasOwnProperty.call(message, "gainRadPerNm"))
+                writer.uint32(/* id 3, wireType 1 =*/25).double(message.gainRadPerNm);
             return writer;
         };
 
@@ -16221,6 +16243,10 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                         message.bus = $root.motors_mirroring.MirroringBus.decode(reader, reader.uint32(), undefined, long + 1);
                         break;
                     }
+                case 3: {
+                        message.gainRadPerNm = reader.double();
+                        break;
+                    }
                 default:
                     reader.skipType(tag & 7, long);
                     break;
@@ -16260,18 +16286,25 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                 long = 0;
             if (long > $util.recursionLimit)
                 return "maximum nesting depth exceeded";
+            let properties = {};
             if (message.type != null && message.hasOwnProperty("type"))
                 switch (message.type) {
                 default:
                     return "type: enum value expected";
                 case 0:
                 case 1:
+                case 2:
                     break;
                 }
             if (message.bus != null && message.hasOwnProperty("bus")) {
                 let error = $root.motors_mirroring.MirroringBus.verify(message.bus, long + 1);
                 if (error)
                     return "bus." + error;
+            }
+            if (message.gainRadPerNm != null && message.hasOwnProperty("gainRadPerNm")) {
+                properties._gainRadPerNm = 1;
+                if (typeof message.gainRadPerNm !== "number")
+                    return "gainRadPerNm: number expected";
             }
             return null;
         };
@@ -16307,12 +16340,18 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
             case 1:
                 message.type = 1;
                 break;
+            case "GCT_SET_GAIN":
+            case 2:
+                message.type = 2;
+                break;
             }
             if (object.bus != null) {
                 if (typeof object.bus !== "object")
                     throw TypeError(".motors_mirroring.GravityCompCommand.bus: object expected");
                 message.bus = $root.motors_mirroring.MirroringBus.fromObject(object.bus, long + 1);
             }
+            if (object.gainRadPerNm != null)
+                message.gainRadPerNm = Number(object.gainRadPerNm);
             return message;
         };
 
@@ -16337,6 +16376,11 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                 object.type = options.enums === String ? $root.motors_mirroring.GravityCompCommandType[message.type] === undefined ? message.type : $root.motors_mirroring.GravityCompCommandType[message.type] : message.type;
             if (message.bus != null && message.hasOwnProperty("bus"))
                 object.bus = $root.motors_mirroring.MirroringBus.toObject(message.bus, options);
+            if (message.gainRadPerNm != null && message.hasOwnProperty("gainRadPerNm")) {
+                object.gainRadPerNm = options.json && !isFinite(message.gainRadPerNm) ? String(message.gainRadPerNm) : message.gainRadPerNm;
+                if (options.oneofs)
+                    object._gainRadPerNm = "gainRadPerNm";
+            }
             return object;
         };
 
@@ -16377,6 +16421,7 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
          * @interface IGravityCompBusState
          * @property {motors_mirroring.IMirroringBus|null} [id] GravityCompBusState id
          * @property {motors_mirroring.GravityCompState|null} [state] GravityCompBusState state
+         * @property {number|null} [gainRadPerNm] GravityCompBusState gainRadPerNm
          */
 
         /**
@@ -16411,6 +16456,23 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
         GravityCompBusState.prototype.state = 0;
 
         /**
+         * GravityCompBusState gainRadPerNm.
+         * @member {number|null|undefined} gainRadPerNm
+         * @memberof motors_mirroring.GravityCompBusState
+         * @instance
+         */
+        GravityCompBusState.prototype.gainRadPerNm = null;
+
+        // OneOf field names bound to virtual getters and setters
+        let $oneOfFields;
+
+        // Virtual OneOf for proto3 optional field
+        Object.defineProperty(GravityCompBusState.prototype, "_gainRadPerNm", {
+            get: $util.oneOfGetter($oneOfFields = ["gainRadPerNm"]),
+            set: $util.oneOfSetter($oneOfFields)
+        });
+
+        /**
          * Creates a new GravityCompBusState instance using the specified properties.
          * @function create
          * @memberof motors_mirroring.GravityCompBusState
@@ -16438,6 +16500,8 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                 $root.motors_mirroring.MirroringBus.encode(message.id, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
             if (message.state != null && Object.hasOwnProperty.call(message, "state"))
                 writer.uint32(/* id 2, wireType 0 =*/16).int32(message.state);
+            if (message.gainRadPerNm != null && Object.hasOwnProperty.call(message, "gainRadPerNm"))
+                writer.uint32(/* id 3, wireType 1 =*/25).double(message.gainRadPerNm);
             return writer;
         };
 
@@ -16486,6 +16550,10 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                         message.state = reader.int32();
                         break;
                     }
+                case 3: {
+                        message.gainRadPerNm = reader.double();
+                        break;
+                    }
                 default:
                     reader.skipType(tag & 7, long);
                     break;
@@ -16525,6 +16593,7 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                 long = 0;
             if (long > $util.recursionLimit)
                 return "maximum nesting depth exceeded";
+            let properties = {};
             if (message.id != null && message.hasOwnProperty("id")) {
                 let error = $root.motors_mirroring.MirroringBus.verify(message.id, long + 1);
                 if (error)
@@ -16539,6 +16608,11 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                 case 2:
                     break;
                 }
+            if (message.gainRadPerNm != null && message.hasOwnProperty("gainRadPerNm")) {
+                properties._gainRadPerNm = 1;
+                if (typeof message.gainRadPerNm !== "number")
+                    return "gainRadPerNm: number expected";
+            }
             return null;
         };
 
@@ -16583,6 +16657,8 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                 message.state = 2;
                 break;
             }
+            if (object.gainRadPerNm != null)
+                message.gainRadPerNm = Number(object.gainRadPerNm);
             return message;
         };
 
@@ -16607,6 +16683,11 @@ export const motors_mirroring = $root.motors_mirroring = (() => {
                 object.id = $root.motors_mirroring.MirroringBus.toObject(message.id, options);
             if (message.state != null && message.hasOwnProperty("state"))
                 object.state = options.enums === String ? $root.motors_mirroring.GravityCompState[message.state] === undefined ? message.state : $root.motors_mirroring.GravityCompState[message.state] : message.state;
+            if (message.gainRadPerNm != null && message.hasOwnProperty("gainRadPerNm")) {
+                object.gainRadPerNm = options.json && !isFinite(message.gainRadPerNm) ? String(message.gainRadPerNm) : message.gainRadPerNm;
+                if (options.oneofs)
+                    object._gainRadPerNm = "gainRadPerNm";
+            }
             return object;
         };
 

--- a/software/station/clients/station-viewer/src/devices/registry.ts
+++ b/software/station/clients/station-viewer/src/devices/registry.ts
@@ -86,3 +86,11 @@ export function findSt3215DeviceKinematicConfig(
 export function supportsSt3215Device(bus: st3215.InferenceState.IBusState): boolean {
   return findSt3215DeviceDefinition(bus) !== null;
 }
+
+// Gravity compensation depends on a mass/inertia model that today only
+// exists for ElRobot (see hardware/elrobot/simulation/elrobot_follower.urdf).
+// Gated here, not in shared st3215/ components, per this package's rule
+// against hardcoding device names outside the registry.
+export function supportsGravityComp(bus: st3215.InferenceState.IBusState): boolean {
+  return findSt3215DeviceDefinition(bus)?.id === ELROBOT_DEVICE_ID;
+}

--- a/software/station/clients/station-viewer/src/st3215/BusCard.tsx
+++ b/software/station/clients/station-viewer/src/st3215/BusCard.tsx
@@ -32,6 +32,11 @@ const MIN_CALIBRATED_RANGE = 100;
 const WEB_CONTROL_STORAGE_TTL_MS = 60_000;
 const WEB_CONTROL_MIRROR_IGNORE_AFTER_LOCAL_REQUEST_MS = 5_000;
 const WEB_CONTROL_MIRROR_CONFIRM_MS = 800;
+// Matches motors-mirroring's GravityCompConfig default and hard ceiling
+// (software/drivers/motors-mirroring/src/config.rs) - needs empirical
+// tuning on real hardware, this is just a starting point.
+const DEFAULT_GRAVITY_COMP_GAIN = 0.05;
+const MAX_GRAVITY_COMP_GAIN = 1.0;
 
 type RobotViewMode = 'model' | 'camera';
 type CameraLayoutMode = 'pip' | 'side-by-side' | 'stacked';
@@ -130,6 +135,29 @@ const BusCard: React.FC<BusCardProps> = ({
   const isFollowerBus = mirroringState?.modes?.some(
     (m) => m.id?.uniqueId === busSerialNumber && m.mode === motors_mirroring.BusMode.BR_FOLLOWER,
   );
+
+  const [gravityCompGain, setGravityCompGain] = useState<number>(DEFAULT_GRAVITY_COMP_GAIN);
+  const isEditingGravityCompGainRef = useRef(false);
+
+  useEffect(() => {
+    if (isEditingGravityCompGainRef.current) {
+      return;
+    }
+    if (typeof gravityCompEntry?.gainRadPerNm === 'number') {
+      setGravityCompGain(gravityCompEntry.gainRadPerNm);
+    }
+  }, [gravityCompEntry?.gainRadPerNm]);
+
+  useEffect(() => {
+    if (!busSerialNumber || !supportsGravityComp(bus)) {
+      return;
+    }
+    console.log('[GravityComp] state', {
+      bus: busSerialNumber,
+      enabled: isGravityCompEnabled,
+      gainRadPerNm: gravityCompEntry?.gainRadPerNm,
+    });
+  }, [bus, busSerialNumber, isGravityCompEnabled, gravityCompEntry?.gainRadPerNm]);
 
   const setWebControlledState = useCallback((nextState: boolean) => {
     setIsWebControlled(nextState);
@@ -364,11 +392,49 @@ const BusCard: React.FC<BusCardProps> = ({
       uniqueId: busSerialNumber,
     };
 
+    const command: motors_mirroring.IGravityCompCommand = isGravityCompEnabled
+      ? {
+          type: motors_mirroring.GravityCompCommandType.GCT_STOP_GRAVITY_COMP,
+          bus: target,
+        }
+      : {
+          type: motors_mirroring.GravityCompCommandType.GCT_START_GRAVITY_COMP,
+          bus: target,
+          gainRadPerNm: gravityCompGain,
+        };
+
+    console.log('[GravityComp] sending command', command);
+    await commandManager.sendGravityCompCommand(command);
+  }, [busSerialNumber, isGravityCompEnabled, gravityCompGain]);
+
+  const commitGravityCompGain = useCallback(async (nextGain: number) => {
+    if (!busSerialNumber) {
+      return;
+    }
+
+    const clamped = Math.min(Math.max(nextGain, 0), MAX_GRAVITY_COMP_GAIN);
+    setGravityCompGain(clamped);
+
+    if (!isGravityCompEnabled) {
+      // Not running yet - the value is just held locally and sent as the
+      // initial gain on the next Start command.
+      console.log('[GravityComp] gain updated locally (will apply on next start)', {
+        bus: busSerialNumber,
+        gainRadPerNm: clamped,
+      });
+      return;
+    }
+
+    const target: motors_mirroring.IMirroringBus = {
+      type: motors_mirroring.BusType.MBT_ST3215,
+      uniqueId: busSerialNumber,
+    };
+
+    console.log('[GravityComp] sending live gain update', { bus: busSerialNumber, gainRadPerNm: clamped });
     await commandManager.sendGravityCompCommand({
-      type: isGravityCompEnabled
-        ? motors_mirroring.GravityCompCommandType.GCT_STOP_GRAVITY_COMP
-        : motors_mirroring.GravityCompCommandType.GCT_START_GRAVITY_COMP,
+      type: motors_mirroring.GravityCompCommandType.GCT_SET_GAIN,
       bus: target,
+      gainRadPerNm: clamped,
     });
   }, [busSerialNumber, isGravityCompEnabled]);
 
@@ -482,25 +548,51 @@ const BusCard: React.FC<BusCardProps> = ({
             </button>
           </div>
           {supportsGravityComp(bus) && (
-            <button
-              type="button"
-              onClick={handleGravityCompToggle}
-              disabled={!busSerialNumber || isFollowerBus}
-              className={`flex h-9 items-center justify-center rounded-md border px-3 text-xs font-bold transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${
-                isGravityCompEnabled
-                  ? "border-accent-success-deep bg-accent-success-bg text-text-primary"
-                  : "border-border-subtle bg-surface-primary text-text-muted hover:text-text-primary"
-              }`}
-              title={
-                isFollowerBus
-                  ? "Gravity compensation is only available on a self-controlled or leader arm"
-                  : isGravityCompEnabled
-                    ? "Disable gravity compensation"
-                    : "Enable gravity compensation"
-              }
-            >
-              Gravity Comp
-            </button>
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                onClick={handleGravityCompToggle}
+                disabled={!busSerialNumber || isFollowerBus}
+                className={`flex h-9 items-center justify-center rounded-md border px-3 text-xs font-bold transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${
+                  isGravityCompEnabled
+                    ? "border-accent-success-deep bg-accent-success-bg text-text-primary"
+                    : "border-border-subtle bg-surface-primary text-text-muted hover:text-text-primary"
+                }`}
+                title={
+                  isFollowerBus
+                    ? "Gravity compensation is only available on a self-controlled or leader arm"
+                    : isGravityCompEnabled
+                      ? "Disable gravity compensation"
+                      : "Enable gravity compensation"
+                }
+              >
+                Gravity Comp
+              </button>
+              <input
+                type="number"
+                min={0}
+                max={MAX_GRAVITY_COMP_GAIN}
+                step={0.01}
+                value={gravityCompGain}
+                disabled={!busSerialNumber || isFollowerBus}
+                onFocus={() => {
+                  isEditingGravityCompGainRef.current = true;
+                }}
+                onChange={(e) => setGravityCompGain(Number(e.target.value))}
+                onBlur={(e) => {
+                  isEditingGravityCompGainRef.current = false;
+                  void commitGravityCompGain(Number(e.target.value));
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    (e.target as HTMLInputElement).blur();
+                  }
+                }}
+                className="h-9 w-16 rounded-md border border-border-subtle bg-surface-primary px-2 text-xs text-text-primary disabled:cursor-not-allowed disabled:opacity-60"
+                title="Gravity comp gain (rad/Nm) - tune empirically on hardware; applies live while enabled"
+                aria-label="Gravity compensation gain"
+              />
+            </div>
           )}
           <select
             value={

--- a/software/station/clients/station-viewer/src/st3215/BusCard.tsx
+++ b/software/station/clients/station-viewer/src/st3215/BusCard.tsx
@@ -135,6 +135,7 @@ const BusCard: React.FC<BusCardProps> = ({
   const isFollowerBus = mirroringState?.modes?.some(
     (m) => m.id?.uniqueId === busSerialNumber && m.mode === motors_mirroring.BusMode.BR_FOLLOWER,
   );
+  const gravityCompSupported = supportsGravityComp(bus);
 
   const [gravityCompGain, setGravityCompGain] = useState<number>(DEFAULT_GRAVITY_COMP_GAIN);
   const isEditingGravityCompGainRef = useRef(false);
@@ -149,15 +150,19 @@ const BusCard: React.FC<BusCardProps> = ({
   }, [gravityCompEntry?.gainRadPerNm]);
 
   useEffect(() => {
-    if (!busSerialNumber || !supportsGravityComp(bus)) {
+    if (!busSerialNumber || !gravityCompSupported) {
       return;
     }
+    // Deliberately excludes `bus` from deps - it's a new object reference
+    // every poll (~50Hz), which would fire this on every frame regardless
+    // of whether anything actually changed. This only logs on real
+    // transitions.
     console.log('[GravityComp] state', {
       bus: busSerialNumber,
       enabled: isGravityCompEnabled,
       gainRadPerNm: gravityCompEntry?.gainRadPerNm,
     });
-  }, [bus, busSerialNumber, isGravityCompEnabled, gravityCompEntry?.gainRadPerNm]);
+  }, [gravityCompSupported, busSerialNumber, isGravityCompEnabled, gravityCompEntry?.gainRadPerNm]);
 
   const setWebControlledState = useCallback((nextState: boolean) => {
     setIsWebControlled(nextState);
@@ -314,6 +319,18 @@ const BusCard: React.FC<BusCardProps> = ({
       return;
     }
 
+    // Gravity comp and any other control source (web-controlled or
+    // mirroring) both continuously write GoalPosition to this bus's own
+    // motors - if gravity comp were left running, it would fight whatever
+    // this control source tries to do 20ms later. Stop it first.
+    if (isGravityCompEnabled) {
+      console.log('[GravityComp] stopping: control source changed', { bus: busSerialNumber, sourceBusSerial });
+      await commandManager.sendGravityCompCommand({
+        type: motors_mirroring.GravityCompCommandType.GCT_STOP_GRAVITY_COMP,
+        bus: { type: motors_mirroring.BusType.MBT_ST3215, uniqueId: busSerialNumber },
+      });
+    }
+
     if (sourceBusSerial === 'web-controlled') {
       const target: motors_mirroring.IMirroringBus = {
         type: motors_mirroring.BusType.MBT_ST3215,
@@ -380,7 +397,7 @@ const BusCard: React.FC<BusCardProps> = ({
       });
       setWebControlledState(false);
     }
-  }, [bus.motors, busSerialNumber, setWebControlledState]);
+  }, [bus.motors, busSerialNumber, isGravityCompEnabled, setWebControlledState]);
 
   const handleGravityCompToggle = useCallback(async () => {
     if (!busSerialNumber) {
@@ -547,7 +564,7 @@ const BusCard: React.FC<BusCardProps> = ({
               <Camera className="h-4 w-4" aria-hidden="true" />
             </button>
           </div>
-          {supportsGravityComp(bus) && (
+          {gravityCompSupported && (
             <div className="flex items-center gap-1">
               <button
                 type="button"

--- a/software/station/clients/station-viewer/src/st3215/BusCard.tsx
+++ b/software/station/clients/station-viewer/src/st3215/BusCard.tsx
@@ -32,11 +32,13 @@ const MIN_CALIBRATED_RANGE = 100;
 const WEB_CONTROL_STORAGE_TTL_MS = 60_000;
 const WEB_CONTROL_MIRROR_IGNORE_AFTER_LOCAL_REQUEST_MS = 5_000;
 const WEB_CONTROL_MIRROR_CONFIRM_MS = 800;
-// Matches motors-mirroring's GravityCompConfig default and hard ceiling
+// Matches motors-mirroring's GravityCompConfig defaults and hard ceilings
 // (software/drivers/motors-mirroring/src/config.rs) - needs empirical
-// tuning on real hardware, this is just a starting point.
+// tuning on real hardware, these are just starting points.
 const DEFAULT_GRAVITY_COMP_GAIN = 0.05;
 const MAX_GRAVITY_COMP_GAIN = 1.0;
+const DEFAULT_GRAVITY_COMP_TORQUE_LIMIT = 100;
+const MAX_GRAVITY_COMP_TORQUE_LIMIT = 150;
 
 type RobotViewMode = 'model' | 'camera';
 type CameraLayoutMode = 'pip' | 'side-by-side' | 'stacked';
@@ -137,17 +139,28 @@ const BusCard: React.FC<BusCardProps> = ({
   );
   const gravityCompSupported = supportsGravityComp(bus);
 
-  const [gravityCompGain, setGravityCompGain] = useState<number>(DEFAULT_GRAVITY_COMP_GAIN);
-  const isEditingGravityCompGainRef = useRef(false);
+  // Per-joint gains (motor 1-7 -> gain), falling back to the built-in
+  // default for any joint the backend hasn't reported yet (e.g. never
+  // touched on this bus).
+  const gravityCompJointGains = useMemo(() => {
+    const gains: Record<number, number> = {};
+    for (let motorId = 1; motorId <= 7; motorId++) {
+      gains[motorId] = gravityCompEntry?.jointGainsRadPerNm?.[motorId - 1] ?? DEFAULT_GRAVITY_COMP_GAIN;
+    }
+    return gains;
+  }, [gravityCompEntry?.jointGainsRadPerNm]);
+
+  const [gravityCompTorqueLimit, setGravityCompTorqueLimit] = useState<number>(DEFAULT_GRAVITY_COMP_TORQUE_LIMIT);
+  const isEditingTorqueLimitRef = useRef(false);
 
   useEffect(() => {
-    if (isEditingGravityCompGainRef.current) {
+    if (isEditingTorqueLimitRef.current) {
       return;
     }
-    if (typeof gravityCompEntry?.gainRadPerNm === 'number') {
-      setGravityCompGain(gravityCompEntry.gainRadPerNm);
+    if (typeof gravityCompEntry?.torqueLimit === 'number') {
+      setGravityCompTorqueLimit(gravityCompEntry.torqueLimit);
     }
-  }, [gravityCompEntry?.gainRadPerNm]);
+  }, [gravityCompEntry?.torqueLimit]);
 
   useEffect(() => {
     if (!busSerialNumber || !gravityCompSupported) {
@@ -160,9 +173,10 @@ const BusCard: React.FC<BusCardProps> = ({
     console.log('[GravityComp] state', {
       bus: busSerialNumber,
       enabled: isGravityCompEnabled,
-      gainRadPerNm: gravityCompEntry?.gainRadPerNm,
+      jointGainsRadPerNm: gravityCompEntry?.jointGainsRadPerNm,
+      torqueLimit: gravityCompEntry?.torqueLimit,
     });
-  }, [gravityCompSupported, busSerialNumber, isGravityCompEnabled, gravityCompEntry?.gainRadPerNm]);
+  }, [gravityCompSupported, busSerialNumber, isGravityCompEnabled, gravityCompEntry?.jointGainsRadPerNm, gravityCompEntry?.torqueLimit]);
 
   const setWebControlledState = useCallback((nextState: boolean) => {
     setIsWebControlled(nextState);
@@ -409,36 +423,68 @@ const BusCard: React.FC<BusCardProps> = ({
       uniqueId: busSerialNumber,
     };
 
-    const command: motors_mirroring.IGravityCompCommand = isGravityCompEnabled
-      ? {
-          type: motors_mirroring.GravityCompCommandType.GCT_STOP_GRAVITY_COMP,
-          bus: target,
-        }
-      : {
-          type: motors_mirroring.GravityCompCommandType.GCT_START_GRAVITY_COMP,
-          bus: target,
-          gainRadPerNm: gravityCompGain,
-        };
+    // No gain/torque-limit payload needed on start - the backend seeds the
+    // running task from whatever's already staged/saved for this bus (or
+    // its configured defaults), so per-joint table edits and the torque
+    // limit field made before pressing this button already take effect.
+    const command: motors_mirroring.IGravityCompCommand = {
+      type: isGravityCompEnabled
+        ? motors_mirroring.GravityCompCommandType.GCT_STOP_GRAVITY_COMP
+        : motors_mirroring.GravityCompCommandType.GCT_START_GRAVITY_COMP,
+      bus: target,
+    };
 
     console.log('[GravityComp] sending command', command);
     await commandManager.sendGravityCompCommand(command);
-  }, [busSerialNumber, isGravityCompEnabled, gravityCompGain]);
+  }, [busSerialNumber, isGravityCompEnabled]);
 
-  const commitGravityCompGain = useCallback(async (nextGain: number) => {
+  // Per-joint gain edit (from the "Gravity" column in MotorDataTable).
+  // Applies live if gravity comp is running, and is always remembered
+  // (staged) server-side regardless, ready for the next Start or an
+  // explicit Save.
+  const handleGravityCompJointGainChange = useCallback(async (motorId: number, nextGain: number) => {
     if (!busSerialNumber) {
       return;
     }
 
     const clamped = Math.min(Math.max(nextGain, 0), MAX_GRAVITY_COMP_GAIN);
-    setGravityCompGain(clamped);
+    const target: motors_mirroring.IMirroringBus = {
+      type: motors_mirroring.BusType.MBT_ST3215,
+      uniqueId: busSerialNumber,
+    };
 
-    if (!isGravityCompEnabled) {
-      // Not running yet - the value is just held locally and sent as the
-      // initial gain on the next Start command.
-      console.log('[GravityComp] gain updated locally (will apply on next start)', {
-        bus: busSerialNumber,
-        gainRadPerNm: clamped,
-      });
+    console.log('[GravityComp] setting joint gain', { bus: busSerialNumber, motorId, gainRadPerNm: clamped });
+    await commandManager.sendGravityCompCommand({
+      type: motors_mirroring.GravityCompCommandType.GCT_SET_GAIN,
+      bus: target,
+      motorId,
+      gainRadPerNm: clamped,
+    });
+  }, [busSerialNumber]);
+
+  const commitGravityCompTorqueLimit = useCallback(async (nextValue: number) => {
+    if (!busSerialNumber) {
+      return;
+    }
+
+    const clamped = Math.min(Math.max(Math.round(nextValue), 0), MAX_GRAVITY_COMP_TORQUE_LIMIT);
+    setGravityCompTorqueLimit(clamped);
+
+    const target: motors_mirroring.IMirroringBus = {
+      type: motors_mirroring.BusType.MBT_ST3215,
+      uniqueId: busSerialNumber,
+    };
+
+    console.log('[GravityComp] setting torque limit', { bus: busSerialNumber, torqueLimit: clamped });
+    await commandManager.sendGravityCompCommand({
+      type: motors_mirroring.GravityCompCommandType.GCT_SET_TORQUE_LIMIT,
+      bus: target,
+      torqueLimit: clamped,
+    });
+  }, [busSerialNumber]);
+
+  const handleSaveGravitySettings = useCallback(async () => {
+    if (!busSerialNumber) {
       return;
     }
 
@@ -447,13 +493,12 @@ const BusCard: React.FC<BusCardProps> = ({
       uniqueId: busSerialNumber,
     };
 
-    console.log('[GravityComp] sending live gain update', { bus: busSerialNumber, gainRadPerNm: clamped });
+    console.log('[GravityComp] saving settings', { bus: busSerialNumber });
     await commandManager.sendGravityCompCommand({
-      type: motors_mirroring.GravityCompCommandType.GCT_SET_GAIN,
+      type: motors_mirroring.GravityCompCommandType.GCT_SAVE_SETTINGS,
       bus: target,
-      gainRadPerNm: clamped,
     });
-  }, [busSerialNumber, isGravityCompEnabled]);
+  }, [busSerialNumber]);
 
   // Function to calculate moving average for latency (15 second window)
   const getMovingAverageLatency = (
@@ -589,30 +634,46 @@ const BusCard: React.FC<BusCardProps> = ({
                 />
                 {isGravityCompEnabled ? "Gravity Comp: ON" : "Gravity Comp"}
               </button>
-              <input
-                type="number"
-                min={0}
-                max={MAX_GRAVITY_COMP_GAIN}
-                step={0.01}
-                value={gravityCompGain}
+              <label
+                className="flex items-center gap-1 text-[10px] font-semibold uppercase text-text-muted"
+                htmlFor={`gravity-comp-torque-limit-${busSerialNumber ?? "unknown"}`}
+              >
+                Torque
+                <input
+                  id={`gravity-comp-torque-limit-${busSerialNumber ?? "unknown"}`}
+                  type="number"
+                  min={0}
+                  max={MAX_GRAVITY_COMP_TORQUE_LIMIT}
+                  step={1}
+                  value={gravityCompTorqueLimit}
+                  disabled={!busSerialNumber || isFollowerBus}
+                  onFocus={() => {
+                    isEditingTorqueLimitRef.current = true;
+                  }}
+                  onChange={(e) => setGravityCompTorqueLimit(Number(e.target.value))}
+                  onBlur={(e) => {
+                    isEditingTorqueLimitRef.current = false;
+                    void commitGravityCompTorqueLimit(Number(e.target.value));
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      (e.target as HTMLInputElement).blur();
+                    }
+                  }}
+                  className="h-9 w-16 rounded-md border border-border-subtle bg-surface-primary px-2 text-xs font-normal normal-case text-text-primary disabled:cursor-not-allowed disabled:opacity-60"
+                  title="Gravity comp torque limit (global, all arm motors) - hard-capped in firmware regardless of value entered here"
+                  aria-label="Gravity compensation torque limit"
+                />
+              </label>
+              <button
+                type="button"
+                onClick={() => void handleSaveGravitySettings()}
                 disabled={!busSerialNumber || isFollowerBus}
-                onFocus={() => {
-                  isEditingGravityCompGainRef.current = true;
-                }}
-                onChange={(e) => setGravityCompGain(Number(e.target.value))}
-                onBlur={(e) => {
-                  isEditingGravityCompGainRef.current = false;
-                  void commitGravityCompGain(Number(e.target.value));
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    (e.target as HTMLInputElement).blur();
-                  }
-                }}
-                className="h-9 w-16 rounded-md border border-border-subtle bg-surface-primary px-2 text-xs text-text-primary disabled:cursor-not-allowed disabled:opacity-60"
-                title="Gravity comp gain (rad/Nm) - tune empirically on hardware; applies live while enabled"
-                aria-label="Gravity compensation gain"
-              />
+                className="flex h-9 items-center rounded-md border border-border-subtle bg-surface-primary px-2 text-xs font-bold text-text-muted transition-colors hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-60"
+                title="Persist the current per-joint gains and torque limit so they're restored after a restart"
+              >
+                Save Gravity
+              </button>
             </div>
           )}
           <select
@@ -756,6 +817,8 @@ const BusCard: React.FC<BusCardProps> = ({
               secondaryCameraFit={secondaryCameraFit}
               onPrimaryCameraFitToggle={() => setPrimaryCameraFit((fit) => (fit === "contain" ? "cover" : "contain"))}
               onSecondaryCameraFitToggle={() => setSecondaryCameraFit((fit) => (fit === "contain" ? "cover" : "contain"))}
+              gravityCompJointGains={gravityCompSupported ? gravityCompJointGains : undefined}
+              onGravityCompJointGainChange={handleGravityCompJointGainChange}
             />
             <CameraHudControls
               cameraLayout={cameraLayout}
@@ -782,6 +845,8 @@ const BusCard: React.FC<BusCardProps> = ({
             showCalibrateButton={true}
             needsCalibration={needsCalibration}
             isWebControlled={isWebControlled}
+            gravityCompJointGains={gravityCompSupported ? gravityCompJointGains : undefined}
+            onGravityCompJointGainChange={handleGravityCompJointGainChange}
           />
         ) : (
           <>
@@ -833,6 +898,8 @@ const BusCard: React.FC<BusCardProps> = ({
                   bus={bus}
                   busIndex={busIndex}
                   isWebControlled={isWebControlled}
+                  gravityCompJointGains={gravityCompSupported ? gravityCompJointGains : undefined}
+                  onGravityCompJointGainChange={handleGravityCompJointGainChange}
                 />
               </div>
             </div>

--- a/software/station/clients/station-viewer/src/st3215/BusCard.tsx
+++ b/software/station/clients/station-viewer/src/st3215/BusCard.tsx
@@ -3,7 +3,7 @@ import Long from 'long';
 import { Camera } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { commandManager } from '@/api/commands';
-import { supportsSt3215Device } from '@/devices/registry';
+import { supportsGravityComp, supportsSt3215Device } from '@/devices/registry';
 import { FrameEntry } from '@/api/frame-parser';
 import { useElementFullscreen } from '@/hooks/useElementFullscreen';
 import { motors_mirroring, st3215, usbvideo } from '@/api/proto.js';
@@ -121,6 +121,14 @@ const BusCard: React.FC<BusCardProps> = ({
 
   const currentMirror = mirroringState?.mirroring?.find((m) =>
     m.targets?.some((t) => t.id?.uniqueId === busSerialNumber),
+  );
+
+  const gravityCompEntry = mirroringState?.gravityComp?.find(
+    (g) => g.id?.uniqueId === busSerialNumber,
+  );
+  const isGravityCompEnabled = gravityCompEntry?.state === motors_mirroring.GravityCompState.GC_ENABLED;
+  const isFollowerBus = mirroringState?.modes?.some(
+    (m) => m.id?.uniqueId === busSerialNumber && m.mode === motors_mirroring.BusMode.BR_FOLLOWER,
   );
 
   const setWebControlledState = useCallback((nextState: boolean) => {
@@ -346,6 +354,24 @@ const BusCard: React.FC<BusCardProps> = ({
     }
   }, [bus.motors, busSerialNumber, setWebControlledState]);
 
+  const handleGravityCompToggle = useCallback(async () => {
+    if (!busSerialNumber) {
+      return;
+    }
+
+    const target: motors_mirroring.IMirroringBus = {
+      type: motors_mirroring.BusType.MBT_ST3215,
+      uniqueId: busSerialNumber,
+    };
+
+    await commandManager.sendGravityCompCommand({
+      type: isGravityCompEnabled
+        ? motors_mirroring.GravityCompCommandType.GCT_STOP_GRAVITY_COMP
+        : motors_mirroring.GravityCompCommandType.GCT_START_GRAVITY_COMP,
+      bus: target,
+    });
+  }, [busSerialNumber, isGravityCompEnabled]);
+
   // Function to calculate moving average for latency (15 second window)
   const getMovingAverageLatency = (
     key: string,
@@ -455,6 +481,27 @@ const BusCard: React.FC<BusCardProps> = ({
               <Camera className="h-4 w-4" aria-hidden="true" />
             </button>
           </div>
+          {supportsGravityComp(bus) && (
+            <button
+              type="button"
+              onClick={handleGravityCompToggle}
+              disabled={!busSerialNumber || isFollowerBus}
+              className={`flex h-9 items-center justify-center rounded-md border px-3 text-xs font-bold transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${
+                isGravityCompEnabled
+                  ? "border-accent-success-deep bg-accent-success-bg text-text-primary"
+                  : "border-border-subtle bg-surface-primary text-text-muted hover:text-text-primary"
+              }`}
+              title={
+                isFollowerBus
+                  ? "Gravity compensation is only available on a self-controlled or leader arm"
+                  : isGravityCompEnabled
+                    ? "Disable gravity compensation"
+                    : "Enable gravity compensation"
+              }
+            >
+              Gravity Comp
+            </button>
+          )}
           <select
             value={
               isWebControlled

--- a/software/station/clients/station-viewer/src/st3215/BusCard.tsx
+++ b/software/station/clients/station-viewer/src/st3215/BusCard.tsx
@@ -570,9 +570,9 @@ const BusCard: React.FC<BusCardProps> = ({
                 type="button"
                 onClick={handleGravityCompToggle}
                 disabled={!busSerialNumber || isFollowerBus}
-                className={`flex h-9 items-center justify-center rounded-md border px-3 text-xs font-bold transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${
+                className={`flex h-9 items-center gap-1.5 rounded-md border px-3 text-xs font-bold transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${
                   isGravityCompEnabled
-                    ? "border-accent-success-deep bg-accent-success-bg text-text-primary"
+                    ? "border-accent-warning-deep bg-accent-warning-deep text-surface-base"
                     : "border-border-subtle bg-surface-primary text-text-muted hover:text-text-primary"
                 }`}
                 title={
@@ -583,7 +583,11 @@ const BusCard: React.FC<BusCardProps> = ({
                       : "Enable gravity compensation"
                 }
               >
-                Gravity Comp
+                <span
+                  className={`h-2 w-2 rounded-full ${isGravityCompEnabled ? "animate-pulse bg-surface-base" : "bg-text-muted"}`}
+                  aria-hidden="true"
+                />
+                {isGravityCompEnabled ? "Gravity Comp: ON" : "Gravity Comp"}
               </button>
               <input
                 type="number"

--- a/software/station/clients/station-viewer/src/st3215/BusWebGLRenderer.tsx
+++ b/software/station/clients/station-viewer/src/st3215/BusWebGLRenderer.tsx
@@ -17,6 +17,8 @@ interface BusWebGLRendererProps {
   isLeader?: boolean;
   inCalibrationView?: boolean;
   isWebControlled?: boolean;
+  gravityCompJointGains?: Record<number, number>;
+  onGravityCompJointGainChange?: (motorId: number, value: number) => void;
 }
 
 export interface BusWebGLRendererRef {
@@ -32,7 +34,7 @@ const BusWebGLRendererComponent = forwardRef<BusWebGLRendererRef, BusWebGLRender
     },
   }));
 
-  const { bus, showMotorData, busIndex, isWebControlled, selectedVideoSourceId, showCalibrateButton, needsCalibration, inCalibrationView } = props;
+  const { bus, showMotorData, busIndex, isWebControlled, selectedVideoSourceId, showCalibrateButton, needsCalibration, inCalibrationView, gravityCompJointGains, onGravityCompJointGainChange } = props;
 
   return (
     <div className="relative w-full h-full">
@@ -40,7 +42,13 @@ const BusWebGLRendererComponent = forwardRef<BusWebGLRendererRef, BusWebGLRender
       <div className="absolute inset-0 w-full h-full z-20 pointer-events-none">
         {showMotorData &&
           <div className="pointer-events-auto">
-            <MotorDataTable bus={bus} busIndex={busIndex} isWebControlled={isWebControlled} />
+            <MotorDataTable
+              bus={bus}
+              busIndex={busIndex}
+              isWebControlled={isWebControlled}
+              gravityCompJointGains={gravityCompJointGains}
+              onGravityCompJointGainChange={onGravityCompJointGainChange}
+            />
           </div>
         }
         {selectedVideoSourceId && (

--- a/software/station/clients/station-viewer/src/st3215/MotorDataTable.tsx
+++ b/software/station/clients/station-viewer/src/st3215/MotorDataTable.tsx
@@ -22,6 +22,8 @@ interface MotorDataTableProps {
   busIndex: number;
   isWebControlled?: boolean;
   layout?: 'overlay' | 'panel';
+  gravityCompJointGains?: Record<number, number>;
+  onGravityCompJointGainChange?: (motorId: number, value: number) => void;
 }
 
 interface MotorControlState {
@@ -35,6 +37,8 @@ const MotorDataTable: React.FC<MotorDataTableProps> = ({
   busIndex,
   isWebControlled = false,
   layout = 'overlay',
+  gravityCompJointGains,
+  onGravityCompJointGainChange,
 }) => {
   const now = Date.now();
   const latencyHistoryRef = useRef<Map<string, LatencyReading[]>>(new Map());
@@ -42,6 +46,16 @@ const MotorDataTable: React.FC<MotorDataTableProps> = ({
   const [hoveredMotor, setHoveredMotor] = useState<number | null>(null);
   const buttonIntervalRef = useRef<{ [key: string]: NodeJS.Timeout | null }>({});
   const forceFullServoRange = (bus.motors?.length ?? 0) === 1;
+  const showGravityColumn = !!gravityCompJointGains;
+  const [editedGravityGains, setEditedGravityGains] = useState<Map<number, number>>(new Map());
+  const editingGravityMotorsRef = useRef<Set<number>>(new Set());
+
+  const getGravityGainDisplayValue = useCallback((motorId: number): number => {
+    if (editingGravityMotorsRef.current.has(motorId)) {
+      return editedGravityGains.get(motorId) ?? gravityCompJointGains?.[motorId] ?? 0;
+    }
+    return gravityCompJointGains?.[motorId] ?? 0;
+  }, [editedGravityGains, gravityCompJointGains]);
 
   // Function to calculate moving average for latency (15 second window)
   const getMovingAverageLatency = (key: string, currentLatency: number): LatencyStats => {
@@ -312,6 +326,7 @@ const MotorDataTable: React.FC<MotorDataTableProps> = ({
             <th className="px-2 py-1 text-right">TEMP</th>
             <th className="px-2 py-1 text-right">LAG</th>
             <th className="px-2 py-1 text-right">MAX</th>
+            {showGravityColumn && <th className="px-2 py-1 text-right">GRAV</th>}
             <th className="px-2 py-1 text-left" colSpan={2}>STATUS</th>
           </tr>
         </thead>
@@ -473,7 +488,43 @@ const MotorDataTable: React.FC<MotorDataTableProps> = ({
                     : `${(latencyAvg.max/1000).toFixed(1)}s`
                   }
                 </td>
-                
+
+                {/* Gravity comp gain (per joint, motors 1-7 only) */}
+                {showGravityColumn && (
+                  <td className="px-2 py-1.5 text-right">
+                    {motor.id && motor.id <= 7 ? (
+                      <input
+                        type="number"
+                        min={0}
+                        max={1}
+                        step={0.01}
+                        value={getGravityGainDisplayValue(motor.id)}
+                        onFocus={() => {
+                          editingGravityMotorsRef.current.add(motor.id!);
+                        }}
+                        onChange={(e) => {
+                          const nextValue = Number(e.target.value);
+                          setEditedGravityGains(prev => new Map(prev).set(motor.id!, nextValue));
+                        }}
+                        onBlur={(e) => {
+                          editingGravityMotorsRef.current.delete(motor.id!);
+                          onGravityCompJointGainChange?.(motor.id!, Number(e.target.value));
+                        }}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') {
+                            (e.target as HTMLInputElement).blur();
+                          }
+                        }}
+                        className="h-6 w-14 rounded border border-border-subtle bg-surface-primary px-1 text-xs text-text-primary text-right disabled:cursor-not-allowed disabled:opacity-60"
+                        title="Gravity comp gain (rad/Nm) for this joint"
+                        aria-label={`Gravity compensation gain for motor ${motor.id}`}
+                      />
+                    ) : (
+                      <span className="text-text-muted">-</span>
+                    )}
+                  </td>
+                )}
+
                 {/* Status and Error */}
                 <td className={`px-2 py-1.5 font-bold ${getMotorStatusTextColor(latency, hasError)}`} colSpan={2}>
                   {motor.error ? (

--- a/software/station/clients/station-viewer/src/usbvideo/RobotCameraView.tsx
+++ b/software/station/clients/station-viewer/src/usbvideo/RobotCameraView.tsx
@@ -24,6 +24,8 @@ interface RobotCameraViewProps {
   showMotorData?: boolean;
   showCalibrateButton?: boolean;
   needsCalibration?: boolean;
+  gravityCompJointGains?: Record<number, number>;
+  onGravityCompJointGainChange?: (motorId: number, value: number) => void;
 }
 
 const RobotCameraView = memo(function RobotCameraView({
@@ -40,6 +42,8 @@ const RobotCameraView = memo(function RobotCameraView({
   showMotorData = true,
   showCalibrateButton,
   needsCalibration,
+  gravityCompJointGains,
+  onGravityCompJointGainChange,
 }: RobotCameraViewProps) {
   const motorCount = bus.motors?.length ?? 0;
   const motorPanelHeight =
@@ -57,6 +61,8 @@ const RobotCameraView = memo(function RobotCameraView({
         busIndex={busIndex}
         isWebControlled={isWebControlled}
         layout="panel"
+        gravityCompJointGains={gravityCompJointGains}
+        onGravityCompJointGainChange={onGravityCompJointGainChange}
       />
     ) : (
       <CameraMotorStrip bus={bus} />

--- a/software/station/shared/station-iface/src/config.rs
+++ b/software/station/shared/station-iface/src/config.rs
@@ -88,6 +88,11 @@ pub struct St3215Config {
     /// and goal to trigger movement. Default is 20.
     #[serde(default = "default_deadband")]
     pub deadband: u16,
+
+    /// Gravity compensation tuning for the leader arm (ElRobot only). Optional -
+    /// if not specified, gravity compensation uses conservative built-in defaults.
+    #[serde(rename = "gravity-comp", default, skip_serializing_if = "Option::is_none")]
+    pub gravity_comp: Option<GravityCompConfig>,
 }
 
 fn default_st3215_enabled() -> bool {
@@ -109,6 +114,62 @@ impl Default for St3215Config {
             current_threshold: 100,
             motor_current_thresholds: None,
             deadband: 20,
+            gravity_comp: None,
+        }
+    }
+}
+
+/// Gravity compensation tuning. `gain_rad_per_nm` cannot be derived from the
+/// servo's internal PID coefficients (undocumented firmware units) - it must
+/// be tuned empirically on real hardware. `torque_limit` and `max_offset_ticks`
+/// are hard-clamped to safety ceilings in the motors-mirroring crate
+/// regardless of what's configured here.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct GravityCompConfig {
+    #[serde(rename = "gain-rad-per-nm", default = "default_gravity_comp_gain")]
+    pub gain_rad_per_nm: f64,
+
+    #[serde(rename = "max-offset-ticks", default = "default_gravity_comp_max_offset_ticks")]
+    pub max_offset_ticks: u16,
+
+    #[serde(rename = "torque-limit", default = "default_gravity_comp_torque_limit")]
+    pub torque_limit: u16,
+
+    #[serde(rename = "current-cutoff", default = "default_gravity_comp_current_cutoff")]
+    pub current_cutoff: u16,
+
+    #[serde(rename = "stale-cutoff-cycles", default = "default_gravity_comp_stale_cutoff_cycles")]
+    pub stale_cutoff_cycles: u32,
+}
+
+fn default_gravity_comp_gain() -> f64 {
+    0.05
+}
+
+fn default_gravity_comp_max_offset_ticks() -> u16 {
+    60
+}
+
+fn default_gravity_comp_torque_limit() -> u16 {
+    100
+}
+
+fn default_gravity_comp_current_cutoff() -> u16 {
+    60
+}
+
+fn default_gravity_comp_stale_cutoff_cycles() -> u32 {
+    5
+}
+
+impl Default for GravityCompConfig {
+    fn default() -> Self {
+        Self {
+            gain_rad_per_nm: default_gravity_comp_gain(),
+            max_offset_ticks: default_gravity_comp_max_offset_ticks(),
+            torque_limit: default_gravity_comp_torque_limit(),
+            current_cutoff: default_gravity_comp_current_cutoff(),
+            stale_cutoff_cycles: default_gravity_comp_stale_cutoff_cycles(),
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds opt-in gravity compensation for the ElRobot leader arm (7-DOF + gripper, Feetech ST3215 servos), so an operator can hold the arm's pose against gravity by hand-feel instead of it always going fully limp. Since ST3215 servos have no native torque/current-setpoint register, this is approximated by continuously computing each joint's static gravity torque (forward kinematics + virtual-work/Jacobian-transpose over the URDF mass/CoM data) and nudging `GoalPosition` by a proportional offset, using the servo's own position loop as an implicit spring.

- Per-joint tunable gain (`[f64; 7]`) plus a global torque-limit field, editable live from the UI (new "GRAV" column in the motor table, between MAX and STATUS) and persisted on demand via a "SAVE GRAVITY" button.
- Safety cutoffs: staleness and overcurrent hard-torque-off, a hard-coded torque-limit ceiling (150/1000, well below the arm's normal 500) independent of any configured/UI value, and per-cycle offset clamping.
- Mode/settings state is restored on restart for display only — an explicit operator command is always required to actually (re-)drive motors.
- `GRAVITY_COMPENSATION.md` documents the math, control law, architecture, UI, and settings read/write flow, plus lessons learned tuning on real hardware (notably: a single global gain can't satisfy every joint, and joints saturated at the offset ceiling can drag neighboring joints through the kinematic chain — hence per-joint gains).

This PR contains only the gravity-compensation-related commits, cherry-picked out of a larger branch that also included unrelated CI/CD and other-hardware work.

## Test plan

- [x] `cargo build` / `cargo test -p motors-mirroring` (9 unit tests covering the dynamics/control math, e.g. sign conventions and torque growing with horizontal reach)
- [x] `npm run type-check` in `station-viewer`
- [x] Validated on real ElRobot leader-arm hardware: enable/disable toggle, per-joint gain tuning, torque-limit adjustment, save/restore of settings, and the arm holding a pose against gravity while remaining easy to move by hand

🤖 Generated with [Claude Code](https://claude.com/claude-code)