### PR TITLE
fix(st3215): stop disconnect grace timer from resetting every tick

### DIFF
--- a/software/drivers/st3215/src/port.rs
+++ b/software/drivers/st3215/src/port.rs
@@ -369,8 +369,13 @@ impl St3215Port {
         // not evict a known-good motor.
         const DISCONNECT_GRACE_MS: u128 = 100;
         let now = Instant::now();
+        // Motors that genuinely responded this tick, captured before the grace path below
+        // re-inserts still-missing motors into `currently_seen_motors`. Only these should
+        // have their grace timer cleared — otherwise a motor kept alive purely to retry
+        // would reset its timer every tick and never accumulate the grace window.
+        let responded_motors = currently_seen_motors.clone();
         let missing: Vec<u8> = last_seen_motors
-            .difference(&currently_seen_motors)
+            .difference(&responded_motors)
             .copied()
             .collect();
         for motor_id in missing {
@@ -383,11 +388,13 @@ impl St3215Port {
                 }
             } else {
                 // Still within grace — keep the motor in last_seen so we retry next tick.
+                // Its `missing_since` timer is intentionally preserved so the grace window
+                // can actually elapse.
                 currently_seen_motors.insert(motor_id);
             }
         }
-        // Clear grace tracker for motors that are responding again.
-        for motor_id in &currently_seen_motors {
+        // Clear grace tracker only for motors that actually responded this tick.
+        for motor_id in &responded_motors {
             missing_since.remove(motor_id);
         }
 

--- a/software/drivers/st3215/src/port.rs
+++ b/software/drivers/st3215/src/port.rs
@@ -369,10 +369,6 @@ impl St3215Port {
         // not evict a known-good motor.
         const DISCONNECT_GRACE_MS: u128 = 100;
         let now = Instant::now();
-        // Motors that genuinely responded this tick, captured before the grace path below
-        // re-inserts still-missing motors into `currently_seen_motors`. Only these should
-        // have their grace timer cleared — otherwise a motor kept alive purely to retry
-        // would reset its timer every tick and never accumulate the grace window.
         let responded_motors = currently_seen_motors.clone();
         let missing: Vec<u8> = last_seen_motors
             .difference(&responded_motors)
@@ -388,12 +384,10 @@ impl St3215Port {
                 }
             } else {
                 // Still within grace — keep the motor in last_seen so we retry next tick.
-                // Its `missing_since` timer is intentionally preserved so the grace window
-                // can actually elapse.
                 currently_seen_motors.insert(motor_id);
             }
         }
-        // Clear grace tracker only for motors that actually responded this tick.
+        // Clear grace tracker for motors that responded this tick.
         for motor_id in &responded_motors {
             missing_since.remove(motor_id);
         }


### PR DESCRIPTION
## Problem

The 100ms disconnect hysteresis in `St3215Port::scan_motors` was a no-op —
motors that stopped responding were never disconnected.

For a motor that misses a poll:

1. `missing_since.entry(id).or_insert(now)` records `t0`.
2. Grace hasn't elapsed, so the motor is re-inserted into
   `currently_seen_motors` to be retried next tick.
3. The trailing "clear grace tracker" loop iterates `currently_seen_motors`
   — which now contains that motor — and removes its `missing_since` entry.
4. Next tick, `or_insert(now)` records `t1`, and the cycle repeats.

`now - first_missed` never reached `DISCONNECT_GRACE_MS`, so the grace
window was infinite rather than 100ms.

**Impact:** 
1. an unplugged or dead motor was never evicted. No
`send_drive_disconnect_envelope` reached downstream consumers, its EEPROM
cache entry was never dropped, and it remained in `last_seen_motors`,
consuming a 20ms serial timeout on every tick and slowing the scan for
every healthy motor on the bus.
2. Configure motor ID become broken.

## Fix

Snapshot the motors that genuinely responded this tick *before* the grace
branch mutates `currently_seen_motors`, and clear `missing_since` only for
that snapshot. A motor kept in the set purely so it gets retried now
preserves its timer and is disconnected after the full grace window
(~5 consecutive failed ticks at the 20ms poll interval).