### PR TITLE
Enable ARMv8 AES and PMULL backends on boards

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+# aes 0.8 and polyval 0.6 keep their ARMv8 backends behind these cfgs, so
+# without them the boards run AES-GCM in software. Both detect the crypto
+# extensions at runtime on Linux, so a board without them still works.
+[build]
+rustflags = ["--cfg", "aes_armv8", "--cfg", "polyval_armv8"]


### PR DESCRIPTION
`aes 0.8` and `polyval 0.6` keep their ARMv8 backends behind the `aes_armv8` and `polyval_armv8` cfgs. Nothing in the repo sets them, so every board build so far has run AES-GCM through the software path while the crypto extensions sat idle.

Checked with `--emit asm` for `aarch64-unknown-linux-gnu`, same aes-gcm features normfs-crypto uses: 0 `aese`/`pmull` instructions without the cfgs, 79 with them.

Both crates autodetect the extensions at runtime on Linux, so a board without them keeps working on the software path. The cfgs are inert on x86_64, which is why they sit in `[build]` rather than a per-target table (the arm64 build passes a glibc-suffixed triple to zigbuild).

Worth a benchmark on a real board before merging, the numbers here only prove the instructions are emitted, not what they buy.
