### PR TITLE
fix(station-viewer): preserve calibration when canceling reset

### DIFF
--- a/software/station/clients/station-viewer/src/pages/St3215BusCalibrationPage.test.ts
+++ b/software/station/clients/station-viewer/src/pages/St3215BusCalibrationPage.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, expect, it, vi } from 'vitest';
+import St3215BusCalibrationPage from './St3215BusCalibrationPage';
+
+const mocks = vi.hoisted(() => ({
+  bus: {
+    bus: { serialNumber: 'calibrated-arm' },
+    motors: Array.from({ length: 6 }, () => ({
+      rangeMin: 100,
+      rangeMax: 900,
+      rangeFreezed: true,
+    })),
+  },
+  sendMirroringCommand: vi.fn(),
+  sendSt3215Command: vi.fn(),
+}));
+
+vi.mock('../api/websocket', () => ({
+  default: {
+    commands: {
+      sendMirroringCommand: mocks.sendMirroringCommand,
+      sendSt3215Command: mocks.sendSt3215Command,
+    },
+  },
+}));
+
+vi.mock('../hooks', () => ({
+  useInferenceState: () => null,
+  useWakeLock: () => undefined,
+}));
+
+vi.mock('../st3215/BusWebGLRenderer', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/devices/st3215-models', () => ({
+  supportsSt3215Bus: () => true,
+}));
+
+let root: Root | null = null;
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => root?.unmount());
+    root = null;
+  }
+  document.body.replaceChildren();
+  vi.unstubAllGlobals();
+});
+
+it('does not reset an existing calibration when the page opens', async () => {
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  const container = document.createElement('div');
+  document.body.append(container);
+  root = createRoot(container);
+
+  await act(async () => {
+    root?.render(
+      createElement(
+        MemoryRouter,
+        {
+          initialEntries: [
+            { pathname: '/st3215-bus-calibration', state: { bus: mocks.bus } },
+          ],
+        },
+        createElement(St3215BusCalibrationPage),
+      ),
+    );
+  });
+
+  expect(mocks.sendSt3215Command).not.toHaveBeenCalled();
+});

--- a/software/station/clients/station-viewer/src/pages/St3215BusCalibrationPage.tsx
+++ b/software/station/clients/station-viewer/src/pages/St3215BusCalibrationPage.tsx
@@ -93,14 +93,6 @@ const St3215BusCalibrationPage: React.FC = () => {
     });
   };
 
-  // Send reset command when the calibration page opens
-  useEffect(() => {
-    const busSerial = selectedBus?.bus?.serialNumber;
-    if (!busSerial) return;
-    resetCalibration(busSerial);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedBus?.bus?.serialNumber]);
-
   useEffect(() => {
     if (isSavePending && isCalibrationFrozen) {
       navigate('/');


### PR DESCRIPTION
## Summary

- prevent the calibration page from resetting an existing calibration on open
- keep calibration reset behind explicit user confirmation
- add a regression test ensuring that opening the page does not send a reset command

Fixes #91