### PR TITLE
victron-smartsolar-mppt: full device state in every envelope

### DIFF
--- a/protobufs/drivers/victron-smartsolar-mppt/victron_smartsolar_mppt.proto
+++ b/protobufs/drivers/victron-smartsolar-mppt/victron_smartsolar_mppt.proto
@@ -40,5 +40,7 @@ message RxEnvelope {
     // Raw VE.Direct HEX response frame on HEX_FRAME; empty otherwise.
     bytes hex_frame = 21;
 
+    repeated bytes hex_frames = 22;
+
     string error = 50;
 }

--- a/software/drivers/victron-smartsolar-mppt/src/hex.rs
+++ b/software/drivers/victron-smartsolar-mppt/src/hex.rs
@@ -1,4 +1,6 @@
 pub const CMD_GET: u8 = 7;
+pub const RSP_GET: u8 = 7;
+pub const RSP_ASYNC: u8 = 0xA;
 
 const HEX: &[u8; 16] = b"0123456789ABCDEF";
 
@@ -39,6 +41,21 @@ fn hex_val(c: u8) -> Option<u8> {
         b'a'..=b'f' => Some(c - b'a' + 10),
         _ => None,
     }
+}
+
+pub fn frame_header(frame: &[u8]) -> Option<(u8, u16, u8)> {
+    let body = frame.strip_prefix(b":")?;
+    if body.len() < 9 {
+        return None;
+    }
+    let response = hex_val(body[0])?;
+    let mut bytes = [0u8; 3];
+    for (i, slot) in bytes.iter_mut().enumerate() {
+        let hi = hex_val(body[1 + i * 2])?;
+        let lo = hex_val(body[2 + i * 2])?;
+        *slot = (hi << 4) | lo;
+    }
+    Some((response, u16::from_le_bytes([bytes[0], bytes[1]]), bytes[2]))
 }
 
 pub fn validate_frame(frame: &[u8]) -> bool {

--- a/software/drivers/victron-smartsolar-mppt/src/port.rs
+++ b/software/drivers/victron-smartsolar-mppt/src/port.rs
@@ -9,6 +9,7 @@ use normfs::{NormFS, QueueId};
 use prost::Message;
 use station_iface::StationEngine;
 use station_iface::iface_proto::drivers::QueueDataType;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, ReadHalf, WriteHalf};
@@ -106,6 +107,7 @@ impl<T: StationEngine> VictronPort<T> {
             VictronSignalType::VictronConnected,
             Some(&probe_block),
             None,
+            Vec::new(),
             String::new(),
         );
         self.publish(
@@ -114,13 +116,21 @@ impl<T: StationEngine> VictronPort<T> {
             VictronSignalType::VictronTextBlock,
             Some(&probe_block),
             None,
+            Vec::new(),
             String::new(),
         );
 
         let poller: JoinHandle<()> = tokio::spawn(run_hex_poller(write_half));
 
         let reason = self
-            .read_loop(&mut reader, &mut demux, &rx_queue_id, &device, leftover)
+            .read_loop(
+                &mut reader,
+                &mut demux,
+                &rx_queue_id,
+                &device,
+                leftover,
+                probe_block,
+            )
             .await;
 
         poller.abort();
@@ -134,6 +144,7 @@ impl<T: StationEngine> VictronPort<T> {
             VictronSignalType::VictronDisconnected,
             None,
             None,
+            Vec::new(),
             reason,
         );
         Ok(())
@@ -230,12 +241,15 @@ impl<T: StationEngine> VictronPort<T> {
         rx_queue_id: &QueueId,
         device: &Arc<VictronDevice>,
         leftover: Vec<u8>,
+        probe_block: Vec<u8>,
     ) -> String {
         let mut malformed_count: u64 = 0;
         let mut last_malformed_log: Option<Instant> = None;
         let mut last_valid = Instant::now();
         let mut fault_reported = false;
         let mut carry = leftover;
+        let mut last_text = Some(probe_block);
+        let mut regs: BTreeMap<u16, Bytes> = BTreeMap::new();
 
         loop {
             let bytes = if !carry.is_empty() {
@@ -262,24 +276,34 @@ impl<T: StationEngine> VictronPort<T> {
                     Some(DemuxEvent::TextBlock(block)) => {
                         last_valid = Instant::now();
                         fault_reported = false;
+                        last_text = Some(block);
                         self.publish(
                             rx_queue_id,
                             device,
                             VictronSignalType::VictronTextBlock,
-                            Some(&block),
+                            last_text.as_deref(),
                             None,
+                            regs.values().cloned().collect(),
                             String::new(),
                         );
                     }
                     Some(DemuxEvent::HexFrame(frame)) => {
                         last_valid = Instant::now();
                         fault_reported = false;
+                        let frame = Bytes::from(frame);
+                        if let Some((response, register, flags)) = hex::frame_header(&frame) {
+                            let answered = response == hex::RSP_GET || response == hex::RSP_ASYNC;
+                            if answered && flags == 0 {
+                                regs.insert(register, frame.clone());
+                            }
+                        }
                         self.publish(
                             rx_queue_id,
                             device,
                             VictronSignalType::VictronHexFrame,
-                            None,
+                            last_text.as_deref(),
                             Some(frame),
+                            regs.values().cloned().collect(),
                             String::new(),
                         );
                     }
@@ -297,6 +321,7 @@ impl<T: StationEngine> VictronPort<T> {
                     VictronSignalType::VictronError,
                     None,
                     None,
+                    Vec::new(),
                     format!("no valid VE.Direct frame for {:?}", last_valid.elapsed()),
                 );
                 fault_reported = true;
@@ -310,7 +335,8 @@ impl<T: StationEngine> VictronPort<T> {
         device: &VictronDevice,
         signal_type: VictronSignalType,
         data: Option<&[u8]>,
-        hex_frame: Option<Vec<u8>>,
+        hex_frame: Option<Bytes>,
+        hex_frames: Vec<Bytes>,
         error: String,
     ) {
         let envelope = RxEnvelope {
@@ -320,7 +346,8 @@ impl<T: StationEngine> VictronPort<T> {
             signal_type: signal_type as i32,
             device: Some(device.clone()),
             data: data.map(Bytes::copy_from_slice).unwrap_or_default(),
-            hex_frame: hex_frame.map(Bytes::from).unwrap_or_default(),
+            hex_frame: hex_frame.unwrap_or_default(),
+            hex_frames,
             error,
         };
 

--- a/software/station/clients/station-viewer/src/api/proto.d.ts
+++ b/software/station/clients/station-viewer/src/api/proto.d.ts
@@ -14371,6 +14371,9 @@ export namespace victron_smartsolar_mppt {
         /** RxEnvelope hexFrame */
         hexFrame?: (Uint8Array|null);
 
+        /** RxEnvelope hexFrames */
+        hexFrames?: (Uint8Array[]|null);
+
         /** RxEnvelope error */
         error?: (string|null);
     }
@@ -14404,6 +14407,9 @@ export namespace victron_smartsolar_mppt {
 
         /** RxEnvelope hexFrame. */
         public hexFrame: Uint8Array;
+
+        /** RxEnvelope hexFrames. */
+        public hexFrames: Uint8Array[];
 
         /** RxEnvelope error. */
         public error: string;

--- a/software/station/clients/station-viewer/src/api/proto.js
+++ b/software/station/clients/station-viewer/src/api/proto.js
@@ -41776,6 +41776,7 @@ export const victron_smartsolar_mppt = $root.victron_smartsolar_mppt = (() => {
          * @property {victron_smartsolar_mppt.IVictronDevice|null} [device] RxEnvelope device
          * @property {Uint8Array|null} [data] RxEnvelope data
          * @property {Uint8Array|null} [hexFrame] RxEnvelope hexFrame
+         * @property {Array.<Uint8Array>|null} [hexFrames] RxEnvelope hexFrames
          * @property {string|null} [error] RxEnvelope error
          */
 
@@ -41788,6 +41789,7 @@ export const victron_smartsolar_mppt = $root.victron_smartsolar_mppt = (() => {
          * @param {victron_smartsolar_mppt.IRxEnvelope=} [properties] Properties to set
          */
         function RxEnvelope(properties) {
+            this.hexFrames = [];
             if (properties)
                 for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
                     if (properties[keys[i]] != null && keys[i] !== "__proto__")
@@ -41851,6 +41853,14 @@ export const victron_smartsolar_mppt = $root.victron_smartsolar_mppt = (() => {
         RxEnvelope.prototype.hexFrame = $util.newBuffer([]);
 
         /**
+         * RxEnvelope hexFrames.
+         * @member {Array.<Uint8Array>} hexFrames
+         * @memberof victron_smartsolar_mppt.RxEnvelope
+         * @instance
+         */
+        RxEnvelope.prototype.hexFrames = $util.emptyArray;
+
+        /**
          * RxEnvelope error.
          * @member {string} error
          * @memberof victron_smartsolar_mppt.RxEnvelope
@@ -41896,6 +41906,9 @@ export const victron_smartsolar_mppt = $root.victron_smartsolar_mppt = (() => {
                 writer.uint32(/* id 20, wireType 2 =*/162).bytes(message.data);
             if (message.hexFrame != null && Object.hasOwnProperty.call(message, "hexFrame"))
                 writer.uint32(/* id 21, wireType 2 =*/170).bytes(message.hexFrame);
+            if (message.hexFrames != null && message.hexFrames.length)
+                for (let i = 0; i < message.hexFrames.length; ++i)
+                    writer.uint32(/* id 22, wireType 2 =*/178).bytes(message.hexFrames[i]);
             if (message.error != null && Object.hasOwnProperty.call(message, "error"))
                 writer.uint32(/* id 50, wireType 2 =*/402).string(message.error);
             return writer;
@@ -41964,6 +41977,12 @@ export const victron_smartsolar_mppt = $root.victron_smartsolar_mppt = (() => {
                     }
                 case 21: {
                         message.hexFrame = reader.bytes();
+                        break;
+                    }
+                case 22: {
+                        if (!(message.hexFrames && message.hexFrames.length))
+                            message.hexFrames = [];
+                        message.hexFrames.push(reader.bytes());
                         break;
                     }
                 case 50: {
@@ -42041,6 +42060,13 @@ export const victron_smartsolar_mppt = $root.victron_smartsolar_mppt = (() => {
             if (message.hexFrame != null && message.hasOwnProperty("hexFrame"))
                 if (!(message.hexFrame && typeof message.hexFrame.length === "number" || $util.isString(message.hexFrame)))
                     return "hexFrame: buffer expected";
+            if (message.hexFrames != null && message.hasOwnProperty("hexFrames")) {
+                if (!Array.isArray(message.hexFrames))
+                    return "hexFrames: array expected";
+                for (let i = 0; i < message.hexFrames.length; ++i)
+                    if (!(message.hexFrames[i] && typeof message.hexFrames[i].length === "number" || $util.isString(message.hexFrames[i])))
+                        return "hexFrames: buffer[] expected";
+            }
             if (message.error != null && message.hasOwnProperty("error"))
                 if (!$util.isString(message.error))
                     return "error: string expected";
@@ -42137,6 +42163,16 @@ export const victron_smartsolar_mppt = $root.victron_smartsolar_mppt = (() => {
                     $util.base64.decode(object.hexFrame, message.hexFrame = $util.newBuffer($util.base64.length(object.hexFrame)), 0);
                 else if (object.hexFrame.length >= 0)
                     message.hexFrame = object.hexFrame;
+            if (object.hexFrames) {
+                if (!Array.isArray(object.hexFrames))
+                    throw TypeError(".victron_smartsolar_mppt.RxEnvelope.hexFrames: array expected");
+                message.hexFrames = [];
+                for (let i = 0; i < object.hexFrames.length; ++i)
+                    if (typeof object.hexFrames[i] === "string")
+                        $util.base64.decode(object.hexFrames[i], message.hexFrames[i] = $util.newBuffer($util.base64.length(object.hexFrames[i])), 0);
+                    else if (object.hexFrames[i].length >= 0)
+                        message.hexFrames[i] = object.hexFrames[i];
+            }
             if (object.error != null)
                 message.error = String(object.error);
             return message;
@@ -42155,6 +42191,8 @@ export const victron_smartsolar_mppt = $root.victron_smartsolar_mppt = (() => {
             if (!options)
                 options = {};
             let object = {};
+            if (options.arrays || options.defaults)
+                object.hexFrames = [];
             if (options.defaults) {
                 if ($util.Long) {
                     let long = new $util.Long(0, 0, true);
@@ -42212,6 +42250,11 @@ export const victron_smartsolar_mppt = $root.victron_smartsolar_mppt = (() => {
                 object.data = options.bytes === String ? $util.base64.encode(message.data, 0, message.data.length) : options.bytes === Array ? Array.prototype.slice.call(message.data) : message.data;
             if (message.hexFrame != null && message.hasOwnProperty("hexFrame"))
                 object.hexFrame = options.bytes === String ? $util.base64.encode(message.hexFrame, 0, message.hexFrame.length) : options.bytes === Array ? Array.prototype.slice.call(message.hexFrame) : message.hexFrame;
+            if (message.hexFrames && message.hexFrames.length) {
+                object.hexFrames = [];
+                for (let j = 0; j < message.hexFrames.length; ++j)
+                    object.hexFrames[j] = options.bytes === String ? $util.base64.encode(message.hexFrames[j], 0, message.hexFrames[j].length) : options.bytes === Array ? Array.prototype.slice.call(message.hexFrames[j]) : message.hexFrames[j];
+            }
             if (message.error != null && message.hasOwnProperty("error"))
                 object.error = message.error;
             return object;

--- a/software/station/clients/station-viewer/src/devices/victron-smartsolar-mppt/values.ts
+++ b/software/station/clients/station-viewer/src/devices/victron-smartsolar-mppt/values.ts
@@ -245,9 +245,6 @@ export const EMPTY_STATE: VictronState = {
   hexRegs: new Map(),
 };
 
-// TEXT blocks and HEX frames arrive in separate envelopes, so the device state is
-// the accumulation of both: the newest TEXT block plus the newest value seen for
-// each register.
 export function applyEnvelope(
   state: VictronState,
   envelope: victron_smartsolar_mppt.IRxEnvelope,
@@ -255,6 +252,24 @@ export function applyEnvelope(
   const signal = envelope.signalType ?? 0;
   const textBytes = envelope.data instanceof Uint8Array ? envelope.data : null;
   const hexFrame = envelope.hexFrame instanceof Uint8Array ? envelope.hexFrame : null;
+  const snapshot = envelope.hexFrames;
+
+  if (snapshot && snapshot.length > 0) {
+    const hexRegs = new Map<number, Uint8Array>();
+    for (const frame of snapshot) {
+      const parsed = parseVeDirectHexFrame(frame);
+      if (parsed) {
+        hexRegs.set(parsed.register, parsed.value);
+      }
+    }
+    return {
+      textValues:
+        textBytes && textBytes.length > 0
+          ? parseVeDirectTextBlock(textBytes)
+          : state.textValues,
+      hexRegs,
+    };
+  }
 
   if (
     signal === victron_smartsolar_mppt.VictronSignalType.VICTRON_TEXT_BLOCK ||


### PR DESCRIPTION
Driver now keeps the last TEXT block + latest valid frame per register and publishes the full set in every envelope. One entry = complete card.

Closes #114 