### PR TITLE
victron: stop driver before normfs closes on shutdown

### DIFF
--- a/software/drivers/victron-smartsolar-mppt/src/driver.rs
+++ b/software/drivers/victron-smartsolar-mppt/src/driver.rs
@@ -6,7 +6,7 @@ use station_iface::StationEngine;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::RwLock;
+use tokio::sync::{RwLock, watch};
 use tokio::task::JoinHandle;
 use tokio::time::interval;
 use tokio_serial::{SerialPortInfo, SerialPortType, available_ports};
@@ -52,7 +52,17 @@ pub(crate) struct PortParams {
 }
 
 pub struct VictronSmartSolarMpptDriver {
-    _worker: JoinHandle<()>,
+    shutdown: watch::Sender<bool>,
+    worker: JoinHandle<()>,
+}
+
+impl VictronSmartSolarMpptDriver {
+    pub async fn stop(self) {
+        let _ = self.shutdown.send(true);
+        if let Err(err) = self.worker.await {
+            warn!("Victron SmartSolar MPPT scan task failed during shutdown: {err}");
+        }
+    }
 }
 
 impl VictronSmartSolarMpptDriver {
@@ -73,9 +83,15 @@ impl VictronSmartSolarMpptDriver {
             "Victron SmartSolar MPPT scanning USB serial ports ({} match rule(s))",
             DEFAULT_USB_MATCHES.len()
         );
-        let worker = tokio::spawn(run_scan_loop(normfs.clone(), station_engine, config));
+        let (shutdown, shutdown_rx) = watch::channel(false);
+        let worker = tokio::spawn(run_scan_loop(
+            normfs.clone(),
+            station_engine,
+            config,
+            shutdown_rx,
+        ));
 
-        Ok(Self { _worker: worker })
+        Ok(Self { shutdown, worker })
     }
 }
 
@@ -101,15 +117,15 @@ pub async fn start_victron_smartsolar_mppt_driver<T: StationEngine>(
     normfs: Arc<NormFS>,
     station_engine: Arc<T>,
     config: VictronSmartSolarMpptDriverConfig,
-) -> Result<Arc<VictronSmartSolarMpptDriver>, Box<dyn std::error::Error>> {
-    let driver = VictronSmartSolarMpptDriver::new(normfs, station_engine, config).await?;
-    Ok(Arc::new(driver))
+) -> Result<VictronSmartSolarMpptDriver, Box<dyn std::error::Error>> {
+    VictronSmartSolarMpptDriver::new(normfs, station_engine, config).await
 }
 
 async fn run_scan_loop<T: StationEngine>(
     normfs: Arc<NormFS>,
     station_engine: Arc<T>,
     config: VictronSmartSolarMpptDriverConfig,
+    mut shutdown: watch::Receiver<bool>,
 ) {
     let base_params = PortParams {
         read_timeout: config.read_timeout,
@@ -120,9 +136,19 @@ async fn run_scan_loop<T: StationEngine>(
     let managed: Arc<RwLock<HashSet<String>>> = Arc::new(RwLock::new(HashSet::new()));
     let rejected: Arc<RwLock<HashMap<String, Instant>>> = Arc::new(RwLock::new(HashMap::new()));
     let mut scan = interval(Duration::from_secs(1));
+    let mut port_tasks: Vec<JoinHandle<()>> = Vec::new();
 
     loop {
-        scan.tick().await;
+        tokio::select! {
+            _ = scan.tick() => {}
+            _ = shutdown.changed() => break,
+        }
+
+        if *shutdown.borrow() {
+            break;
+        }
+
+        port_tasks.retain(|task| !task.is_finished());
 
         let ports = match available_ports() {
             Ok(ports) => ports,
@@ -167,8 +193,9 @@ async fn run_scan_loop<T: StationEngine>(
             let station_engine = station_engine.clone();
             let managed = managed.clone();
             let rejected = rejected.clone();
-            tokio::spawn(async move {
-                let port = VictronPort::new(normfs, station_engine, device, params);
+            let port_shutdown = shutdown.clone();
+            port_tasks.push(tokio::spawn(async move {
+                let port = VictronPort::new(normfs, station_engine, device, params, port_shutdown);
                 match port.open().await {
                     Ok(()) => {
                         info!(
@@ -205,7 +232,14 @@ async fn run_scan_loop<T: StationEngine>(
                     }
                 }
                 managed.write().await.remove(&port_name);
-            });
+            }));
+        }
+    }
+
+    info!("Victron SmartSolar MPPT scan loop stopping, waiting for {} port task(s)", port_tasks.len());
+    for task in port_tasks {
+        if let Err(err) = task.await {
+            warn!("Victron SmartSolar MPPT port task failed during shutdown: {err}");
         }
     }
 }

--- a/software/drivers/victron-smartsolar-mppt/src/port.rs
+++ b/software/drivers/victron-smartsolar-mppt/src/port.rs
@@ -13,6 +13,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, ReadHalf, WriteHalf};
+use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tokio::time::{MissedTickBehavior, interval, sleep, timeout};
 use tokio_serial::{SerialPortBuilderExt, SerialStream};
@@ -60,6 +61,7 @@ pub struct VictronPort<T: StationEngine> {
     station_engine: Arc<T>,
     device: VictronDevice,
     params: PortParams,
+    shutdown: watch::Receiver<bool>,
 }
 
 impl<T: StationEngine> VictronPort<T> {
@@ -68,12 +70,14 @@ impl<T: StationEngine> VictronPort<T> {
         station_engine: Arc<T>,
         device: VictronDevice,
         params: PortParams,
+        shutdown: watch::Receiver<bool>,
     ) -> Self {
         Self {
             normfs,
             station_engine,
             device,
             params,
+            shutdown,
         }
     }
 
@@ -120,7 +124,8 @@ impl<T: StationEngine> VictronPort<T> {
             String::new(),
         );
 
-        let poller: JoinHandle<()> = tokio::spawn(run_hex_poller(write_half));
+        let poller: JoinHandle<()> =
+            tokio::spawn(run_hex_poller(write_half, self.shutdown.clone()));
 
         let reason = self
             .read_loop(
@@ -243,6 +248,7 @@ impl<T: StationEngine> VictronPort<T> {
         leftover: Vec<u8>,
         probe_block: Vec<u8>,
     ) -> String {
+        let mut shutdown = self.shutdown.clone();
         let mut malformed_count: u64 = 0;
         let mut last_malformed_log: Option<Instant> = None;
         let mut last_valid = Instant::now();
@@ -252,10 +258,19 @@ impl<T: StationEngine> VictronPort<T> {
         let mut regs: BTreeMap<u16, Bytes> = BTreeMap::new();
 
         loop {
+            if *shutdown.borrow() {
+                return "station shutting down".to_string();
+            }
+
             let bytes = if !carry.is_empty() {
                 std::mem::take(&mut carry)
             } else {
-                match timeout(self.params.read_timeout, reader.fill_buf()).await {
+                let read = tokio::select! {
+                    _ = shutdown.changed() => return "station shutting down".to_string(),
+                    result = timeout(self.params.read_timeout, reader.fill_buf()) => result,
+                };
+
+                match read {
                     Err(_) => {
                         return format!("no data received within {:?}", self.params.read_timeout);
                     }
@@ -390,12 +405,16 @@ fn enrich_device(device: &mut VictronDevice, block: &[u8], product_id: u16) {
         .unwrap_or_default();
 }
 
-async fn run_hex_poller(mut writer: Writer) {
+async fn run_hex_poller(mut writer: Writer, mut shutdown: watch::Receiver<bool>) {
     let mut poll = interval(HEX_POLL_INTERVAL);
     poll.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
     loop {
-        poll.tick().await;
+        tokio::select! {
+            _ = poll.tick() => {}
+            _ = shutdown.changed() => return,
+        }
+
         if send_group(&mut writer, registers::CURRENT_GROUP).await.is_err() {
             return;
         }

--- a/software/station/bin/station/src/main.rs
+++ b/software/station/bin/station/src/main.rs
@@ -127,6 +127,9 @@ struct Station {
 
     #[cfg(feature = "ov5647")]
     ov5647_handle: Mutex<Option<ov5647::Ov5647Handle>>,
+
+    victron_smartsolar_mppt_handle:
+        Mutex<Option<victron_smartsolar_mppt::VictronSmartSolarMpptDriver>>,
 }
 
 struct Engine {
@@ -183,6 +186,7 @@ impl Station {
             usbvideo_instances: parking_lot::Mutex::new(Vec::new()),
             #[cfg(target_os = "linux")]
             hikmicro_thermal_handle: Mutex::new(None),
+            victron_smartsolar_mppt_handle: Mutex::new(None),
             #[cfg(feature = "ov5647")]
             ov5647_handle: Mutex::new(None),
         })
@@ -484,14 +488,19 @@ impl Station {
                     read_timeout: victron_config.read_timeout,
                 };
 
-                if let Err(e) = victron_smartsolar_mppt::start_victron_smartsolar_mppt_driver(
+                match victron_smartsolar_mppt::start_victron_smartsolar_mppt_driver(
                     self.normfs.clone(),
                     self.engine.clone(),
                     config,
                 )
                 .await
                 {
-                    log::error!("Failed to start Victron SmartSolar MPPT driver: {}", e);
+                    Ok(handle) => {
+                        *self.victron_smartsolar_mppt_handle.lock() = Some(handle);
+                    }
+                    Err(e) => {
+                        log::error!("Failed to start Victron SmartSolar MPPT driver: {}", e);
+                    }
                 }
             } else {
                 log::info!("Victron SmartSolar MPPT driver disabled by configuration");
@@ -746,6 +755,13 @@ impl Station {
             log::info!("OV5647 driver stopped");
         }
 
+        let victron_handle = self.victron_smartsolar_mppt_handle.lock().take();
+        if let Some(handle) = victron_handle {
+            log::info!("Stopping Victron SmartSolar MPPT driver...");
+            handle.stop().await;
+            log::info!("Victron SmartSolar MPPT driver stopped");
+        }
+
         log::info!("Closing NormFS (writing WAL)...");
 
         self.normfs.close().await?;
@@ -763,6 +779,24 @@ impl Station {
             vec![],
         );
         Ok(())
+    }
+}
+
+async fn wait_for_shutdown_signal() -> Result<(), std::io::Error> {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+
+        let mut terminate = signal(SignalKind::terminate())?;
+        tokio::select! {
+            result = tokio::signal::ctrl_c() => result,
+            _ = terminate.recv() => Ok(()),
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        tokio::signal::ctrl_c().await
     }
 }
 
@@ -835,6 +869,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // This MUST run on the main thread, so we use select! instead of spawn
     #[cfg(target_os = "macos")]
     {
+        let shutdown_signal = wait_for_shutdown_signal();
+        tokio::pin!(shutdown_signal);
         let mut interval = tokio::time::interval(tokio::time::Duration::from_millis(100));
         loop {
             tokio::select! {
@@ -842,7 +878,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     // Runs on main thread - tick the run loop
                     usbvideo::process_main_run_loop();
                 }
-                _ = tokio::signal::ctrl_c() => {
+                _ = &mut shutdown_signal => {
                     log::info!("\nShutting down...");
                     break;
                 }
@@ -852,7 +888,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     #[cfg(not(target_os = "macos"))]
     {
-        tokio::signal::ctrl_c().await?;
+        wait_for_shutdown_signal().await?;
         log::info!("\nShutting down...");
     }
 


### PR DESCRIPTION
Closes #118

The Victron driver kept publishing after NormFS closed, flooding "WAL writer not found". 
The station now retains the driver handle and stops it before closing NormFS. stop() aborts the scan loop and every port task, so a port stuck in a silent probe cannot block shutdown. 
A normal stop no longer writes a final disconnected envelope; the next start records the reconnect