### PR TITLE
ov5647: set the new usbvideo command field on frame envelopes

### DIFF
--- a/software/drivers/ov5647/src/state.rs
+++ b/software/drivers/ov5647/src/state.rs
@@ -72,6 +72,7 @@ impl<K: StationEngine> StateTracker<K> {
             formats: vec![],
             last_inference_queue_ptr: self.get_last_inference_id_bytes(),
             error: String::new(),
+            command: None,
         };
 
         let mut buf = BytesMut::new();


### PR DESCRIPTION
Fixes the arm64 build with `FEATURES=ov5647` broken by #117, which added `TxEnvelope command = 20` to `usbvideo.proto` and updated usbvideo's `state.rs` — but not ov5647's, which builds the same `usbvideo::RxEnvelope`.