### PR TITLE
trampa vesc: add duration-aware command sequences

### DIFF
--- a/protobufs/drivers/vesc-trampa/vesc_trampa.proto
+++ b/protobufs/drivers/vesc-trampa/vesc_trampa.proto
@@ -37,20 +37,21 @@ message TxEnvelope {
 
     bytes command_id = 4;
 
-    VescTrampaBoardCommand     board_command = 10;
-    VescTrampaMotorModeCommand motor_mode    = 11;
+    VescTrampaMotorModeCommand      motor_mode     = 11;
+    repeated VescTrampaBoardCommand board_commands = 12;
 }
 
 message Command {
     bytes target_board_uuid = 1;
 
-    VescTrampaBoardCommand     board_command = 10;
-    VescTrampaMotorModeCommand motor_mode    = 11;
+    VescTrampaMotorModeCommand      motor_mode     = 11;
+    repeated VescTrampaBoardCommand board_commands = 12;
 }
 
 message VescTrampaBoardCommand {
-    bytes payload = 1;
-    bool  response_expected = 2;
+    bytes  payload           = 1;
+    bool   response_expected = 2;
+    uint32 duration_ms       = 3;
 }
 
 enum VescTrampaMotorMode {

--- a/software/drivers/vesc-trampa/command.go
+++ b/software/drivers/vesc-trampa/command.go
@@ -12,6 +12,11 @@ const (
 	commandSetCurrent uint8 = 6
 )
 
+type CurrentStep struct {
+	CurrentMA  int32
+	DurationMS uint32
+}
+
 func setCurrentPayload(currentMA int32) []byte {
 	return int32Payload(commandSetCurrent, currentMA)
 }
@@ -21,20 +26,6 @@ func int32Payload(commandID uint8, value int32) []byte {
 	payload[0] = commandID
 	binary.BigEndian.PutUint32(payload[1:], uint32(value))
 	return payload
-}
-
-func boardPayloadCommand(targetBoardUUID []byte, payload []byte) *vescpb.Command {
-	return &vescpb.Command{
-		TargetBoardUuid: targetBoardUUID,
-		BoardCommand: &vescpb.VescTrampaBoardCommand{
-			Payload:          payload,
-			ResponseExpected: false,
-		},
-	}
-}
-
-func setCurrentCommand(targetBoardUUID []byte, currentMA int32) *vescpb.Command {
-	return boardPayloadCommand(targetBoardUUID, setCurrentPayload(currentMA))
 }
 
 func motorModeCommand(targetBoardUUID []byte, mode vescpb.VescTrampaMotorMode) *vescpb.Command {
@@ -47,10 +38,47 @@ func motorModeCommand(targetBoardUUID []byte, mode vescpb.VescTrampaMotorMode) *
 }
 
 func SetCurrentStationCommand(commandID []byte, targetBoardUUID []byte, currentMA int32) *commandspb.DriverCommand {
+	return SetCurrentSequenceStationCommand(commandID, targetBoardUUID, []CurrentStep{
+		{CurrentMA: currentMA},
+	})
+}
+
+func SetCurrentForDurationStationCommand(
+	commandID []byte,
+	targetBoardUUID []byte,
+	currentMA int32,
+	durationMS uint32,
+	finalCurrentMA int32,
+) *commandspb.DriverCommand {
+	return SetCurrentSequenceStationCommand(commandID, targetBoardUUID, []CurrentStep{
+		{CurrentMA: currentMA, DurationMS: durationMS},
+		{CurrentMA: finalCurrentMA},
+	})
+}
+
+func SetCurrentSequenceStationCommand(
+	commandID []byte,
+	targetBoardUUID []byte,
+	steps []CurrentStep,
+) *commandspb.DriverCommand {
+	commands := make([]*vescpb.VescTrampaBoardCommand, 0, len(steps))
+	for _, step := range steps {
+		commands = append(commands, &vescpb.VescTrampaBoardCommand{
+			Payload:          setCurrentPayload(step.CurrentMA),
+			ResponseExpected: false,
+			DurationMs:       step.DurationMS,
+		})
+	}
+
+	command := &vescpb.Command{
+		TargetBoardUuid: targetBoardUUID,
+		BoardCommands:   commands,
+	}
+
 	return &commandspb.DriverCommand{
 		CommandId: commandID,
 		Type:      driverspb.StationCommandType_STC_VESC_TRAMPA_COMMAND,
-		Body:      setCurrentCommand(targetBoardUUID, currentMA).Marshal(),
+		Body:      command.Marshal(),
 	}
 }
 

--- a/software/drivers/vesc-trampa/command_test.go
+++ b/software/drivers/vesc-trampa/command_test.go
@@ -15,13 +15,57 @@ func TestSetCurrentStationCommand(t *testing.T) {
 	uuid := []byte{0xaa, 0xbb, 0xcc}
 
 	command := SetCurrentStationCommand(commandID, uuid, -1250)
-	payload := stationBoardCommandPayload(t, command, commandID, uuid)
-
-	if payload[0] != commandSetCurrent {
-		t.Fatalf("payload command = %d", payload[0])
+	body := stationCommandBody(t, command, commandID, uuid)
+	boardCommands := stationBoardCommands(t, body, 1)
+	assertCurrentPayload(t, boardCommands[0].GetPayload(), -1250)
+	if boardCommands[0].GetDurationMs() != 0 {
+		t.Fatalf("duration_ms = %d", boardCommands[0].GetDurationMs())
 	}
-	if got := int32(binary.BigEndian.Uint32(payload[1:])); got != -1250 {
-		t.Fatalf("current payload = %d", got)
+}
+
+func TestSetCurrentForDurationStationCommand(t *testing.T) {
+	commandID := []byte{0x03, 0x04}
+	uuid := []byte{0xdd, 0xee, 0xff}
+
+	command := SetCurrentForDurationStationCommand(commandID, uuid, 10_000, 1_500, 0)
+	body := stationCommandBody(t, command, commandID, uuid)
+	boardCommands := stationBoardCommands(t, body, 2)
+	assertCurrentPayload(t, boardCommands[0].GetPayload(), 10_000)
+	if boardCommands[0].GetDurationMs() != 1_500 {
+		t.Fatalf("duration_ms = %d", boardCommands[0].GetDurationMs())
+	}
+	assertCurrentPayload(t, boardCommands[1].GetPayload(), 0)
+	if boardCommands[1].GetDurationMs() != 0 {
+		t.Fatalf("final duration_ms = %d", boardCommands[1].GetDurationMs())
+	}
+}
+
+func TestSetCurrentSequenceStationCommand(t *testing.T) {
+	commandID := []byte{0x07, 0x08}
+	uuid := []byte{0x10, 0x20, 0x30}
+
+	command := SetCurrentSequenceStationCommand(commandID, uuid, []CurrentStep{
+		{CurrentMA: -19_000, DurationMS: 250},
+		{CurrentMA: -8_000, DurationMS: 1_250},
+		{CurrentMA: 0},
+	})
+	body := stationCommandBody(t, command, commandID, uuid)
+	if body.GetMotorMode() != nil {
+		t.Fatal("sequence command should not carry motor mode")
+	}
+
+	boardCommands := stationBoardCommands(t, body, 3)
+	assertCurrentPayload(t, boardCommands[0].GetPayload(), -19_000)
+	if boardCommands[0].GetDurationMs() != 250 {
+		t.Fatalf("first duration_ms = %d", boardCommands[0].GetDurationMs())
+	}
+	assertCurrentPayload(t, boardCommands[1].GetPayload(), -8_000)
+	if boardCommands[1].GetDurationMs() != 1_250 {
+		t.Fatalf("second duration_ms = %d", boardCommands[1].GetDurationMs())
+	}
+	assertCurrentPayload(t, boardCommands[2].GetPayload(), 0)
+	if boardCommands[2].GetDurationMs() != 0 {
+		t.Fatalf("third duration_ms = %d", boardCommands[2].GetDurationMs())
 	}
 }
 
@@ -54,8 +98,8 @@ func TestSetMotorModeStationCommand(t *testing.T) {
 		t.Fatalf("target uuid = %x", body.GetTargetBoardUuid())
 	}
 
-	if body.GetBoardCommand() != nil {
-		t.Fatal("motor-mode command should not carry a raw board command")
+	if len(body.GetBoardCommands()) != 0 {
+		t.Fatal("motor-mode command should not carry board commands")
 	}
 
 	motorMode := body.GetMotorMode()
@@ -67,12 +111,12 @@ func TestSetMotorModeStationCommand(t *testing.T) {
 	}
 }
 
-func stationBoardCommandPayload(
+func stationCommandBody(
 	t *testing.T,
 	command *commandspb.DriverCommand,
 	commandID []byte,
 	uuid []byte,
-) []byte {
+) *vescpb.CommandReader {
 	t.Helper()
 
 	reader := commandspb.NewDriverCommandReader()
@@ -93,21 +137,38 @@ func stationBoardCommandPayload(
 	if !bytes.Equal(body.GetTargetBoardUuid(), uuid) {
 		t.Fatalf("target uuid = %x", body.GetTargetBoardUuid())
 	}
+	return body
+}
+
+func stationBoardCommands(t *testing.T, body *vescpb.CommandReader, count int) []*vescpb.VescTrampaBoardCommandReader {
+	t.Helper()
+
 	if body.GetMotorMode() != nil {
-		t.Fatal("raw board command should not carry motor mode")
+		t.Fatal("board command should not carry motor mode")
 	}
 
-	boardCommand := body.GetBoardCommand()
-	if boardCommand == nil {
-		t.Fatal("missing board command")
+	boardCommands := body.GetBoardCommands()
+	if len(boardCommands) != count {
+		t.Fatalf("board command count = %d, want %d", len(boardCommands), count)
 	}
-	if boardCommand.GetResponseExpected() {
-		t.Fatal("board command should not expect a response")
+	for index, boardCommand := range boardCommands {
+		if boardCommand.GetResponseExpected() {
+			t.Fatalf("board command %d should not expect a response", index)
+		}
 	}
+	return boardCommands
+}
 
-	payload := boardCommand.GetPayload()
+func assertCurrentPayload(t *testing.T, payload []byte, expectedMA int32) {
+	t.Helper()
+
 	if len(payload) != 5 {
 		t.Fatalf("payload len = %d", len(payload))
 	}
-	return payload
+	if payload[0] != commandSetCurrent {
+		t.Fatalf("payload command = %d", payload[0])
+	}
+	if got := int32(binary.BigEndian.Uint32(payload[1:])); got != expectedMA {
+		t.Fatalf("current payload = %d", got)
+	}
 }

--- a/software/drivers/vesc-trampa/src/driver.rs
+++ b/software/drivers/vesc-trampa/src/driver.rs
@@ -99,7 +99,7 @@ impl VescTrampaDriver {
                                 app_start_id: systime::get_app_start_id(),
                                 target_board_uuid: command.target_board_uuid,
                                 command_id: cmd.command_id.clone(),
-                                board_command: command.board_command,
+                                board_commands: command.board_commands,
                                 motor_mode: command.motor_mode,
                             };
 

--- a/software/drivers/vesc-trampa/src/port.rs
+++ b/software/drivers/vesc-trampa/src/port.rs
@@ -4,16 +4,17 @@ use crate::protocol::{
 };
 use crate::state::VescTrampaCommunicator;
 use crate::vesc_trampa_proto::{
-    RxEnvelope, TxEnvelope, VescTrampaBoard, VescTrampaBoardPacket, VescTrampaMotorMode,
-    VescTrampaSignalType,
+    RxEnvelope, TxEnvelope, VescTrampaBoard, VescTrampaBoardCommand, VescTrampaBoardPacket,
+    VescTrampaMotorMode, VescTrampaSignalType,
 };
 use bytes::Bytes;
 use log::{debug, error, info, warn};
 use prost::Message;
+use std::collections::VecDeque;
 use std::fmt;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 use tokio::time::MissedTickBehavior;
 use tokio_serial::{SerialPortBuilderExt, SerialPortInfo, SerialStream};
@@ -21,6 +22,20 @@ use tokio_serial::{SerialPortBuilderExt, SerialPortInfo, SerialStream};
 pub const VESC_TRAMPA_COMMAND_TIMEOUT_MS: u64 = 100;
 pub const VESC_TRAMPA_TICK_INTERVAL_MS: u64 = 20;
 pub const VESC_TRAMPA_HOLD_HANDBRAKE_CURRENT_A: f32 = 10.0;
+const VESC_TRAMPA_SET_CURRENT_COMMAND_ID: u8 = 6;
+
+#[derive(Debug, Clone)]
+struct ActiveBoardCommand {
+    payload: Bytes,
+    stop_at: Instant,
+    next_steps: VecDeque<TimedBoardCommandStep>,
+}
+
+#[derive(Debug, Clone)]
+struct TimedBoardCommandStep {
+    payload: Bytes,
+    duration: Duration,
+}
 
 #[derive(Debug)]
 pub struct VescTrampaProbeError {
@@ -142,6 +157,7 @@ impl VescTrampaPort {
             tokio::time::interval(Duration::from_millis(VESC_TRAMPA_TICK_INTERVAL_MS));
         tick_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
         let mut hold_mode_active = false;
+        let mut active_board_command: Option<ActiveBoardCommand> = None;
 
         loop {
             tokio::select! {
@@ -149,20 +165,12 @@ impl VescTrampaPort {
                     command_waiting.store(false, Ordering::SeqCst);
                     self.log_command_received(&command);
 
-                    if hold_mode_active && !Self::is_motor_mode_hold_command(&command) {
-                        info!(
-                            "Canceling VESC Trampa hold mode on {} before processing command_id={:02X?}",
-                            self.board_info.port_name, command.command_id
-                        );
-                        hold_mode_active = false;
-                    }
-
                     if let Err(error) = self.send_command_received_signal(&command) {
                         error!("Failed to send VESC Trampa command received signal: {}", error);
                         break;
                     }
 
-                    match self.process_command(&mut port, &command, &mut hold_mode_active).await {
+                    match self.process_command(&mut port, &command, &mut hold_mode_active, &mut active_board_command).await {
                         Ok(processed) => {
                             let signal_type = if processed {
                                 VescTrampaSignalType::VescTrampaCommandSuccess
@@ -199,6 +207,11 @@ impl VescTrampaPort {
                             warn!("VESC Trampa port {} disconnected while holding: {}", port_name, error);
                             break;
                         }
+                    }
+
+                    if let Err(error) = self.tick_active_board_command(&mut port, &mut active_board_command).await {
+                        warn!("VESC Trampa port {} disconnected while writing timed board command: {}", port_name, error);
+                        break;
                     }
 
                     if let Err(error) = self.read_values(&mut port).await {
@@ -255,6 +268,7 @@ impl VescTrampaPort {
         port: &mut SerialStream,
         command: &TxEnvelope,
         hold_mode_active: &mut bool,
+        active_board_command: &mut Option<ActiveBoardCommand>,
     ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
         let command_variant_count = Self::command_variant_count(command);
         if command_variant_count != 1 {
@@ -275,6 +289,7 @@ impl VescTrampaPort {
                     return Ok(false);
                 }
                 VescTrampaMotorMode::Hold => {
+                    active_board_command.take();
                     info!(
                         "Processing VESC Trampa motor mode HOLD command on {} with handbrake_current_a={:.3}",
                         self.board_info.port_name, VESC_TRAMPA_HOLD_HANDBRAKE_CURRENT_A
@@ -287,28 +302,41 @@ impl VescTrampaPort {
             }
         }
 
-        let Some(board_command) = command.board_command.as_ref() else {
+        if let Err(reason) = Self::validate_board_commands(&command.board_commands) {
             warn!(
-                "Rejected VESC Trampa command for {}: missing board_command",
-                self.board_info.port_name
-            );
-            return Ok(false);
-        };
-
-        if board_command.payload.is_empty() {
-            warn!(
-                "Rejected VESC Trampa command for {}: empty payload",
-                self.board_info.port_name
+                "Rejected VESC Trampa board command for {}: {}",
+                self.board_info.port_name, reason
             );
             return Ok(false);
         }
 
-        let request_packet = CommPacket::new(board_command.payload.clone())?;
-        request_packet
-            .async_write(port, VESC_TRAMPA_COMMAND_TIMEOUT_MS)
-            .await?;
+        if *hold_mode_active {
+            info!(
+                "Canceling VESC Trampa hold mode on {} before processing command_id={:02X?}",
+                self.board_info.port_name, command.command_id
+            );
+            *hold_mode_active = false;
+        }
 
-        if board_command.response_expected {
+        self.process_board_commands(port, &command.board_commands, active_board_command)
+            .await
+    }
+
+    async fn process_board_commands(
+        &self,
+        port: &mut SerialStream,
+        board_commands: &[VescTrampaBoardCommand],
+        active_board_command: &mut Option<ActiveBoardCommand>,
+    ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+        let response_expected = board_commands.len() == 1 && board_commands[0].response_expected;
+        active_board_command.take();
+
+        if response_expected {
+            let request_packet = CommPacket::new(board_commands[0].payload.clone())?;
+            request_packet
+                .async_write(port, VESC_TRAMPA_COMMAND_TIMEOUT_MS)
+                .await?;
+
             let response_packet =
                 CommPacket::async_read(port, VESC_TRAMPA_COMMAND_TIMEOUT_MS).await?;
             if response_packet.command_id() != request_packet.command_id() {
@@ -323,9 +351,118 @@ impl VescTrampaPort {
                 .into());
             }
             self.send_board_packet_signal(&response_packet)?;
+            return Ok(true);
         }
 
+        let steps = board_commands
+            .iter()
+            .map(|command| TimedBoardCommandStep {
+                payload: command.payload.clone(),
+                duration: Duration::from_millis(u64::from(command.duration_ms)),
+            })
+            .collect();
+        self.advance_board_command_steps(port, active_board_command, steps)
+            .await?;
         Ok(true)
+    }
+
+    async fn tick_active_board_command(
+        &self,
+        port: &mut SerialStream,
+        active_board_command: &mut Option<ActiveBoardCommand>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let Some(command) = active_board_command.as_mut() else {
+            return Ok(());
+        };
+
+        if Instant::now() < command.stop_at {
+            self.write_board_payload(port, command.payload.clone())
+                .await?;
+            return Ok(());
+        }
+
+        let next_steps = std::mem::take(&mut command.next_steps);
+        *active_board_command = None;
+        self.advance_board_command_steps(port, active_board_command, next_steps)
+            .await
+    }
+
+    async fn advance_board_command_steps(
+        &self,
+        port: &mut SerialStream,
+        active_board_command: &mut Option<ActiveBoardCommand>,
+        mut steps: VecDeque<TimedBoardCommandStep>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        while let Some(step) = steps.pop_front() {
+            let payload = step.payload.clone();
+            self.write_board_payload(port, payload.clone()).await?;
+            if step.duration.is_zero() {
+                continue;
+            }
+
+            *active_board_command = Some(ActiveBoardCommand {
+                payload,
+                stop_at: Instant::now()
+                    .checked_add(step.duration)
+                    .ok_or_else(|| Self::duration_overflow_error("board command step"))?,
+                next_steps: steps,
+            });
+            return Ok(());
+        }
+
+        Ok(())
+    }
+
+    fn validate_board_commands(commands: &[VescTrampaBoardCommand]) -> Result<(), &'static str> {
+        if commands.is_empty() {
+            return Err("empty board_commands");
+        }
+
+        let response_commands = commands
+            .iter()
+            .filter(|command| command.response_expected)
+            .count();
+        if response_commands > 0 && (commands.len() != 1 || commands[0].duration_ms > 0) {
+            return Err("timed or multi-step board commands cannot expect responses");
+        }
+
+        for command in commands {
+            Self::validate_board_command_payload(command)?;
+            if command.duration_ms == 0
+                && Self::set_current_payload_ma(&command.payload).is_some_and(|ma| ma != 0)
+            {
+                return Err("non-zero current requires duration_ms");
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_board_command_payload(
+        command: &VescTrampaBoardCommand,
+    ) -> Result<(), &'static str> {
+        if command.payload.is_empty() {
+            return Err("empty payload");
+        }
+        Ok(())
+    }
+
+    fn duration_overflow_error(command_type: &'static str) -> std::io::Error {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("VESC Trampa {command_type} duration is too large"),
+        )
+    }
+
+    async fn write_board_payload(
+        &self,
+        port: &mut SerialStream,
+        payload: Bytes,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let packet = CommPacket::new(payload)?;
+        packet
+            .async_write(port, VESC_TRAMPA_COMMAND_TIMEOUT_MS)
+            .await?;
+        Ok(())
     }
 
     async fn write_set_handbrake(
@@ -333,11 +470,8 @@ impl VescTrampaPort {
         port: &mut SerialStream,
         current_a: f32,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let packet = CommPacket::new(Self::set_handbrake_payload(current_a))?;
-        packet
-            .async_write(port, VESC_TRAMPA_COMMAND_TIMEOUT_MS)
-            .await?;
-        Ok(())
+        self.write_board_payload(port, Self::set_handbrake_payload(current_a))
+            .await
     }
 
     fn set_handbrake_payload(current_a: f32) -> Bytes {
@@ -347,13 +481,16 @@ impl VescTrampaPort {
         Bytes::from(payload)
     }
 
-    fn command_variant_count(command: &TxEnvelope) -> usize {
-        (command.board_command.is_some() as usize) + (command.motor_mode.is_some() as usize)
+    fn set_current_payload_ma(payload: &[u8]) -> Option<i32> {
+        if payload.first().copied() != Some(VESC_TRAMPA_SET_CURRENT_COMMAND_ID) || payload.len() < 5
+        {
+            return None;
+        }
+        Some(i32::from_be_bytes(payload[1..5].try_into().ok()?))
     }
 
-    fn is_motor_mode_hold_command(command: &TxEnvelope) -> bool {
-        command.board_command.is_none()
-            && Self::motor_mode(command) == Some(VescTrampaMotorMode::Hold)
+    fn command_variant_count(command: &TxEnvelope) -> usize {
+        (!command.board_commands.is_empty() as usize) + (command.motor_mode.is_some() as usize)
     }
 
     fn motor_mode(command: &TxEnvelope) -> Option<VescTrampaMotorMode> {
@@ -366,15 +503,26 @@ impl VescTrampaPort {
         let now_ns = systime::get_monotonic_stamp_ns();
         let latency_ns = now_ns.saturating_sub(command.monotonic_stamp_ns);
         let latency_ms = latency_ns as f64 / 1_000_000.0;
-        let payload_len = command
-            .board_command
-            .as_ref()
+        let board_commands = command.board_commands.len();
+        let board_payload_total_len = command
+            .board_commands
+            .iter()
             .map(|command| command.payload.len())
-            .unwrap_or_default();
+            .sum::<usize>();
         let motor_mode = Self::motor_mode(command);
+        let board_duration_ms = command
+            .board_commands
+            .iter()
+            .map(|command| u64::from(command.duration_ms))
+            .sum::<u64>();
+        let board_response_expected = command
+            .board_commands
+            .iter()
+            .filter(|command| command.response_expected)
+            .count();
 
         debug!(
-            "Received VESC Trampa command for port {} uuid={} (latency: {:.2}ms): TxEnvelope {{ monotonic_stamp_ns: {}, local_stamp_ns: {}, app_start_id: {}, command_id: {:02X?}, payload_len: {}, response_expected: {}, motor_mode: {:?} }}",
+            "Received VESC Trampa command for port {} uuid={} (latency: {:.2}ms): TxEnvelope {{ monotonic_stamp_ns: {}, local_stamp_ns: {}, app_start_id: {}, command_id: {:02X?}, board_commands: {}, board_payload_total_len: {}, board_response_expected: {}, board_duration_ms: {}, motor_mode: {:?} }}",
             self.board_info.port_name,
             format_bytes(self.board_info.uuid.as_ref()),
             latency_ms,
@@ -382,12 +530,10 @@ impl VescTrampaPort {
             command.local_stamp_ns,
             command.app_start_id,
             command.command_id,
-            payload_len,
-            command
-                .board_command
-                .as_ref()
-                .map(|command| command.response_expected)
-                .unwrap_or_default(),
+            board_commands,
+            board_payload_total_len,
+            board_response_expected,
+            board_duration_ms,
             motor_mode,
         );
     }
@@ -574,4 +720,102 @@ fn format_bytes(value: &[u8]) -> String {
         write!(&mut formatted, "{byte:02x}").expect("writing to String cannot fail");
     }
     formatted
+}
+
+#[cfg(test)]
+mod tests {
+    use super::VescTrampaPort;
+    use crate::vesc_trampa_proto::{TxEnvelope, VescTrampaBoardCommand};
+    use bytes::Bytes;
+
+    #[test]
+    fn parses_set_current_payload_current_ma() {
+        let payload = [6, 0xff, 0xff, 0xfb, 0x1e];
+
+        assert_eq!(
+            VescTrampaPort::set_current_payload_ma(&payload),
+            Some(-1250)
+        );
+    }
+
+    #[test]
+    fn ignores_non_current_payload_for_current_guard() {
+        let payload = [10, 0, 0, 0, 0];
+
+        assert_eq!(VescTrampaPort::set_current_payload_ma(&payload), None);
+    }
+
+    #[test]
+    fn sequence_command_counts_as_one_variant() {
+        let envelope = TxEnvelope {
+            board_commands: vec![VescTrampaBoardCommand {
+                payload: Bytes::from_static(&[6, 0, 0, 0, 0]),
+                duration_ms: 100,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        assert_eq!(VescTrampaPort::command_variant_count(&envelope), 1);
+    }
+
+    #[test]
+    fn repeated_board_commands_count_as_one_variant() {
+        let envelope = TxEnvelope {
+            board_commands: vec![
+                VescTrampaBoardCommand {
+                    payload: Bytes::from_static(&[6, 0, 0, 0, 0]),
+                    duration_ms: 100,
+                    ..Default::default()
+                },
+                VescTrampaBoardCommand {
+                    payload: Bytes::from_static(&[6, 0, 0, 0, 0]),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        assert_eq!(VescTrampaPort::command_variant_count(&envelope), 1);
+    }
+
+    #[test]
+    fn validates_board_command_sequence_shape() {
+        let commands = vec![
+            VescTrampaBoardCommand {
+                payload: Bytes::from_static(&[6, 0, 0, 0, 1]),
+                duration_ms: 100,
+                ..Default::default()
+            },
+            VescTrampaBoardCommand {
+                payload: Bytes::from_static(&[6, 0, 0, 0, 0]),
+                ..Default::default()
+            },
+        ];
+
+        assert!(VescTrampaPort::validate_board_commands(&commands).is_ok());
+    }
+
+    #[test]
+    fn rejects_non_zero_current_without_duration() {
+        let commands = vec![VescTrampaBoardCommand {
+            payload: Bytes::from_static(&[6, 0, 0, 0, 1]),
+            ..Default::default()
+        }];
+
+        assert_eq!(
+            VescTrampaPort::validate_board_commands(&commands),
+            Err("non-zero current requires duration_ms")
+        );
+    }
+
+    #[test]
+    fn accepts_zero_current_without_duration() {
+        let commands = vec![VescTrampaBoardCommand {
+            payload: Bytes::from_static(&[6, 0, 0, 0, 0]),
+            ..Default::default()
+        }];
+
+        assert!(VescTrampaPort::validate_board_commands(&commands).is_ok());
+    }
 }

--- a/software/drivers/vesc-trampa/src/state.rs
+++ b/software/drivers/vesc-trampa/src/state.rs
@@ -81,9 +81,7 @@ impl VescTrampaCommunicator {
             Ok(vesc_trampa_proto::VescTrampaSignalType::VescTrampaBoardPacket) => {
                 self.update_values(board, envelope, ptr);
             }
-            Ok(vesc_trampa_proto::VescTrampaSignalType::VescTrampaCommand) => {
-                self.update_mode_for_command_received(board, envelope);
-            }
+            Ok(vesc_trampa_proto::VescTrampaSignalType::VescTrampaCommand) => {}
             Ok(vesc_trampa_proto::VescTrampaSignalType::VescTrampaCommandSuccess) => {
                 self.update_mode_for_command_success(board, envelope);
             }
@@ -172,19 +170,6 @@ impl VescTrampaCommunicator {
         }
     }
 
-    fn update_mode_for_command_received(
-        &self,
-        board: &vesc_trampa_proto::VescTrampaBoard,
-        envelope: &vesc_trampa_proto::RxEnvelope,
-    ) {
-        let Some(command) = envelope.command.as_ref() else {
-            return;
-        };
-        if !Self::is_motor_mode_hold_command(command) {
-            self.set_motor_mode(board, vesc_trampa_proto::VescTrampaMotorMode::Unspecified);
-        }
-    }
-
     fn update_mode_for_command_success(
         &self,
         board: &vesc_trampa_proto::VescTrampaBoard,
@@ -193,7 +178,7 @@ impl VescTrampaCommunicator {
         let Some(command) = envelope.command.as_ref() else {
             return;
         };
-        if command.board_command.is_some() {
+        if !command.board_commands.is_empty() {
             self.set_motor_mode(board, vesc_trampa_proto::VescTrampaMotorMode::Unspecified);
             return;
         }
@@ -222,17 +207,6 @@ impl VescTrampaCommunicator {
         {
             board_state.motor_mode = mode as i32;
         }
-    }
-
-    fn is_motor_mode_hold_command(command: &vesc_trampa_proto::TxEnvelope) -> bool {
-        if command.board_command.is_some() {
-            return false;
-        }
-        let Some(motor_mode) = command.motor_mode.as_ref() else {
-            return false;
-        };
-        vesc_trampa_proto::VescTrampaMotorMode::try_from(motor_mode.mode)
-            == Ok(vesc_trampa_proto::VescTrampaMotorMode::Hold)
     }
 
     fn same_board(

--- a/software/station/clients/station-viewer/src/api/proto.d.ts
+++ b/software/station/clients/station-viewer/src/api/proto.d.ts
@@ -3983,11 +3983,11 @@ export namespace vesc_trampa {
         /** TxEnvelope commandId */
         commandId?: (Uint8Array|null);
 
-        /** TxEnvelope boardCommand */
-        boardCommand?: (vesc_trampa.IVescTrampaBoardCommand|null);
-
         /** TxEnvelope motorMode */
         motorMode?: (vesc_trampa.IVescTrampaMotorModeCommand|null);
+
+        /** TxEnvelope boardCommands */
+        boardCommands?: (vesc_trampa.IVescTrampaBoardCommand[]|null);
     }
 
     /** Represents a TxEnvelope. */
@@ -4014,11 +4014,11 @@ export namespace vesc_trampa {
         /** TxEnvelope commandId. */
         public commandId: Uint8Array;
 
-        /** TxEnvelope boardCommand. */
-        public boardCommand?: (vesc_trampa.IVescTrampaBoardCommand|null);
-
         /** TxEnvelope motorMode. */
         public motorMode?: (vesc_trampa.IVescTrampaMotorModeCommand|null);
+
+        /** TxEnvelope boardCommands. */
+        public boardCommands: vesc_trampa.IVescTrampaBoardCommand[];
 
         /**
          * Creates a new TxEnvelope instance using the specified properties.
@@ -4104,11 +4104,11 @@ export namespace vesc_trampa {
         /** Command targetBoardUuid */
         targetBoardUuid?: (Uint8Array|null);
 
-        /** Command boardCommand */
-        boardCommand?: (vesc_trampa.IVescTrampaBoardCommand|null);
-
         /** Command motorMode */
         motorMode?: (vesc_trampa.IVescTrampaMotorModeCommand|null);
+
+        /** Command boardCommands */
+        boardCommands?: (vesc_trampa.IVescTrampaBoardCommand[]|null);
     }
 
     /** Represents a Command. */
@@ -4123,11 +4123,11 @@ export namespace vesc_trampa {
         /** Command targetBoardUuid. */
         public targetBoardUuid: Uint8Array;
 
-        /** Command boardCommand. */
-        public boardCommand?: (vesc_trampa.IVescTrampaBoardCommand|null);
-
         /** Command motorMode. */
         public motorMode?: (vesc_trampa.IVescTrampaMotorModeCommand|null);
+
+        /** Command boardCommands. */
+        public boardCommands: vesc_trampa.IVescTrampaBoardCommand[];
 
         /**
          * Creates a new Command instance using the specified properties.
@@ -4215,6 +4215,9 @@ export namespace vesc_trampa {
 
         /** VescTrampaBoardCommand responseExpected */
         responseExpected?: (boolean|null);
+
+        /** VescTrampaBoardCommand durationMs */
+        durationMs?: (number|null);
     }
 
     /** Represents a VescTrampaBoardCommand. */
@@ -4231,6 +4234,9 @@ export namespace vesc_trampa {
 
         /** VescTrampaBoardCommand responseExpected. */
         public responseExpected: boolean;
+
+        /** VescTrampaBoardCommand durationMs. */
+        public durationMs: number;
 
         /**
          * Creates a new VescTrampaBoardCommand instance using the specified properties.

--- a/software/station/clients/station-viewer/src/api/proto.js
+++ b/software/station/clients/station-viewer/src/api/proto.js
@@ -11523,8 +11523,8 @@ export const vesc_trampa = $root.vesc_trampa = (() => {
          * @property {Long|null} [appStartId] TxEnvelope appStartId
          * @property {Uint8Array|null} [targetBoardUuid] TxEnvelope targetBoardUuid
          * @property {Uint8Array|null} [commandId] TxEnvelope commandId
-         * @property {vesc_trampa.IVescTrampaBoardCommand|null} [boardCommand] TxEnvelope boardCommand
          * @property {vesc_trampa.IVescTrampaMotorModeCommand|null} [motorMode] TxEnvelope motorMode
+         * @property {Array.<vesc_trampa.IVescTrampaBoardCommand>|null} [boardCommands] TxEnvelope boardCommands
          */
 
         /**
@@ -11536,6 +11536,7 @@ export const vesc_trampa = $root.vesc_trampa = (() => {
          * @param {vesc_trampa.ITxEnvelope=} [properties] Properties to set
          */
         function TxEnvelope(properties) {
+            this.boardCommands = [];
             if (properties)
                 for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
                     if (properties[keys[i]] != null && keys[i] !== "__proto__")
@@ -11583,20 +11584,20 @@ export const vesc_trampa = $root.vesc_trampa = (() => {
         TxEnvelope.prototype.commandId = $util.newBuffer([]);
 
         /**
-         * TxEnvelope boardCommand.
-         * @member {vesc_trampa.IVescTrampaBoardCommand|null|undefined} boardCommand
-         * @memberof vesc_trampa.TxEnvelope
-         * @instance
-         */
-        TxEnvelope.prototype.boardCommand = null;
-
-        /**
          * TxEnvelope motorMode.
          * @member {vesc_trampa.IVescTrampaMotorModeCommand|null|undefined} motorMode
          * @memberof vesc_trampa.TxEnvelope
          * @instance
          */
         TxEnvelope.prototype.motorMode = null;
+
+        /**
+         * TxEnvelope boardCommands.
+         * @member {Array.<vesc_trampa.IVescTrampaBoardCommand>} boardCommands
+         * @memberof vesc_trampa.TxEnvelope
+         * @instance
+         */
+        TxEnvelope.prototype.boardCommands = $util.emptyArray;
 
         /**
          * Creates a new TxEnvelope instance using the specified properties.
@@ -11632,10 +11633,11 @@ export const vesc_trampa = $root.vesc_trampa = (() => {
                 writer.uint32(/* id 4, wireType 2 =*/34).bytes(message.commandId);
             if (message.appStartId != null && Object.hasOwnProperty.call(message, "appStartId"))
                 writer.uint32(/* id 5, wireType 0 =*/40).uint64(message.appStartId);
-            if (message.boardCommand != null && Object.hasOwnProperty.call(message, "boardCommand"))
-                $root.vesc_trampa.VescTrampaBoardCommand.encode(message.boardCommand, writer.uint32(/* id 10, wireType 2 =*/82).fork()).ldelim();
             if (message.motorMode != null && Object.hasOwnProperty.call(message, "motorMode"))
                 $root.vesc_trampa.VescTrampaMotorModeCommand.encode(message.motorMode, writer.uint32(/* id 11, wireType 2 =*/90).fork()).ldelim();
+            if (message.boardCommands != null && message.boardCommands.length)
+                for (let i = 0; i < message.boardCommands.length; ++i)
+                    $root.vesc_trampa.VescTrampaBoardCommand.encode(message.boardCommands[i], writer.uint32(/* id 12, wireType 2 =*/98).fork()).ldelim();
             return writer;
         };
 
@@ -11696,12 +11698,14 @@ export const vesc_trampa = $root.vesc_trampa = (() => {
                         message.commandId = reader.bytes();
                         break;
                     }
-                case 10: {
-                        message.boardCommand = $root.vesc_trampa.VescTrampaBoardCommand.decode(reader, reader.uint32(), undefined, long + 1);
-                        break;
-                    }
                 case 11: {
                         message.motorMode = $root.vesc_trampa.VescTrampaMotorModeCommand.decode(reader, reader.uint32(), undefined, long + 1);
+                        break;
+                    }
+                case 12: {
+                        if (!(message.boardCommands && message.boardCommands.length))
+                            message.boardCommands = [];
+                        message.boardCommands.push($root.vesc_trampa.VescTrampaBoardCommand.decode(reader, reader.uint32(), undefined, long + 1));
                         break;
                     }
                 default:
@@ -11758,15 +11762,19 @@ export const vesc_trampa = $root.vesc_trampa = (() => {
             if (message.commandId != null && message.hasOwnProperty("commandId"))
                 if (!(message.commandId && typeof message.commandId.length === "number" || $util.isString(message.commandId)))
                     return "commandId: buffer expected";
-            if (message.boardCommand != null && message.hasOwnProperty("boardCommand")) {
-                let error = $root.vesc_trampa.VescTrampaBoardCommand.verify(message.boardCommand, long + 1);
-                if (error)
-                    return "boardCommand." + error;
-            }
             if (message.motorMode != null && message.hasOwnProperty("motorMode")) {
                 let error = $root.vesc_trampa.VescTrampaMotorModeCommand.verify(message.motorMode, long + 1);
                 if (error)
                     return "motorMode." + error;
+            }
+            if (message.boardCommands != null && message.hasOwnProperty("boardCommands")) {
+                if (!Array.isArray(message.boardCommands))
+                    return "boardCommands: array expected";
+                for (let i = 0; i < message.boardCommands.length; ++i) {
+                    let error = $root.vesc_trampa.VescTrampaBoardCommand.verify(message.boardCommands[i], long + 1);
+                    if (error)
+                        return "boardCommands." + error;
+                }
             }
             return null;
         };
@@ -11824,15 +11832,20 @@ export const vesc_trampa = $root.vesc_trampa = (() => {
                     $util.base64.decode(object.commandId, message.commandId = $util.newBuffer($util.base64.length(object.commandId)), 0);
                 else if (object.commandId.length >= 0)
                     message.commandId = object.commandId;
-            if (object.boardCommand != null) {
-                if (typeof object.boardCommand !== "object")
-                    throw TypeError(".vesc_trampa.TxEnvelope.boardCommand: object expected");
-                message.boardCommand = $root.vesc_trampa.VescTrampaBoardCommand.fromObject(object.boardCommand, long + 1);
-            }
             if (object.motorMode != null) {
                 if (typeof object.motorMode !== "object")
                     throw TypeError(".vesc_trampa.TxEnvelope.motorMode: object expected");
                 message.motorMode = $root.vesc_trampa.VescTrampaMotorModeCommand.fromObject(object.motorMode, long + 1);
+            }
+            if (object.boardCommands) {
+                if (!Array.isArray(object.boardCommands))
+                    throw TypeError(".vesc_trampa.TxEnvelope.boardCommands: array expected");
+                message.boardCommands = [];
+                for (let i = 0; i < object.boardCommands.length; ++i) {
+                    if (typeof object.boardCommands[i] !== "object")
+                        throw TypeError(".vesc_trampa.TxEnvelope.boardCommands: object expected");
+                    message.boardCommands[i] = $root.vesc_trampa.VescTrampaBoardCommand.fromObject(object.boardCommands[i], long + 1);
+                }
             }
             return message;
         };
@@ -11850,6 +11863,8 @@ export const vesc_trampa = $root.vesc_trampa = (() => {
             if (!options)
                 options = {};
             let object = {};
+            if (options.arrays || options.defaults)
+                object.boardCommands = [];
             if (options.defaults) {
                 if ($util.Long) {
                     let long = new $util.Long(0, 0, true);
@@ -11880,7 +11895,6 @@ export const vesc_trampa = $root.vesc_trampa = (() => {
                     object.appStartId = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
                 } else
                     object.appStartId = options.longs === String ? "0" : 0;
-                object.boardCommand = null;
                 object.motorMode = null;
             }
             if (message.monotonicStampNs != null && message.hasOwnProperty("monotonicStampNs"))
@@ -11902,10 +11916,13 @@ export const vesc_trampa = $root.vesc_trampa = (() => {
                     object.appStartId = options.longs === String ? String(message.appStartId) : message.appStartId;
                 else
                     object.appStartId = options.longs === String ? $util.Long.prototype.toString.call(message.appStartId) : options.longs === Number ? new $util.LongBits(message.appStartId.low >>> 0, message.appStartId.high >>> 0).toNumber(true) : message.appStartId;
-            if (message.boardCommand != null && message.hasOwnProperty("boardCommand"))
-                object.boardCommand = $root.vesc_trampa.VescTrampaBoardCommand.toObject(message.boardCommand, options);
             if (message.motorMode != null && message.hasOwnProperty("motorMode"))
                 object.motorMode = $root.vesc_trampa.VescTrampaMotorModeCommand.toObject(message.motorMode, options);
+            if (message.boardCommands && message.boardCommands.length) {
+                object.boardCommands = [];
+                for (let j = 0; j < message.boardCommands.length; ++j)
+                    object.boardCommands[j] = $root.vesc_trampa.VescTrampaBoardCommand.toObject(message.boardCommands[j], options);
+            }
             return object;
         };
 
@@ -11945,8 +11962,8 @@ export const vesc_trampa = $root.vesc_trampa = (() => {
          * @memberof vesc_trampa
          * @interface ICommand
          * @property {Uint8Array|null} [targetBoardUuid] Command targetBoardUuid
-         * @property {vesc_trampa.IVescTrampaBoardCommand|null} [boardCommand] Command boardCommand
          * @property {vesc_trampa.IVescTrampaMotorModeCommand|null} [motorMode] Command motorMode
+         * @property {Array.<vesc_trampa.IVescTrampaBoardCommand>|null} [boardCommands] Command boardCommands
          */
 
         /**
@@ -11958,6 +11975,7 @@ export const vesc_trampa = $root.vesc_trampa = (() => {
          * @param {vesc_trampa.ICommand=} [properties] Properties to set
          */
         function Command(properties) {
+            this.boardCommands = [];
             if (properties)
                 for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
                     if (properties[keys[i]] != null && keys[i] !== "__proto__")
@@ -11973,20 +11991,20 @@ export const vesc_trampa = $root.vesc_trampa = (() => {
         Command.prototype.targetBoardUuid = $util.newBuffer([]);
 
         /**
-         * Command boardCommand.
-         * @member {vesc_trampa.IVescTrampaBoardCommand|null|undefined} boardCommand
-         * @memberof vesc_trampa.Command
-         * @instance
-         */
-        Command.prototype.boardCommand = null;
-
-        /**
          * Command motorMode.
          * @member {vesc_trampa.IVescTrampaMotorModeCommand|null|undefined} motorMode
          * @memberof vesc_trampa.Command
          * @instance
          */
         Command.prototype.motorMode = null;
+
+        /**
+         * Command boardCommands.
+         * @member {Array.<vesc_trampa.IVescTrampaBoardCommand>} boardCommands
+         * @memberof vesc_trampa.Command
+         * @instance
+         */
+        Command.prototype.boardCommands = $util.emptyArray;
 
         /**
          * Creates a new Command instance using the specified properties.
@@ -12014,10 +12032,11 @@ export const vesc_trampa = $root.vesc_trampa = (() => {
                 writer = $Writer.create();
             if (message.targetBoardUuid != null && Object.hasOwnProperty.call(message, "targetBoardUuid"))
                 writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.targetBoardUuid);
-            if (message.boardCommand != null && Object.hasOwnProperty.call(message, "boardCommand"))
-                $root.vesc_trampa.VescTrampaBoardCommand.encode(message.boardCommand, writer.uint32(/* id 10, wireType 2 =*/82).fork()).ldelim();
             if (message.motorMode != null && Object.hasOwnProperty.call(message, "motorMode"))
                 $root.vesc_trampa.VescTrampaMotorModeCommand.encode(message.motorMode, writer.uint32(/* id 11, wireType 2 =*/90).fork()).ldelim();
+            if (message.boardCommands != null && message.boardCommands.length)
+                for (let i = 0; i < message.boardCommands.length; ++i)
+                    $root.vesc_trampa.VescTrampaBoardCommand.encode(message.boardCommands[i], writer.uint32(/* id 12, wireType 2 =*/98).fork()).ldelim();
             return writer;
         };
 
@@ -12062,12 +12081,14 @@ export const vesc_trampa = $root.vesc_trampa = (() => {
                         message.targetBoardUuid = reader.bytes();
                         break;
                     }
-                case 10: {
-                        message.boardCommand = $root.vesc_trampa.VescTrampaBoardCommand.decode(reader, reader.uint32(), undefined, long + 1);
-                        break;
-                    }
                 case 11: {
                         message.motorMode = $root.vesc_trampa.VescTrampaMotorModeCommand.decode(reader, reader.uint32(), undefined, long + 1);
+                        break;
+                    }
+                case 12: {
+                        if (!(message.boardCommands && message.boardCommands.length))
+                            message.boardCommands = [];
+                        message.boardCommands.push($root.vesc_trampa.VescTrampaBoardCommand.decode(reader, reader.uint32(), undefined, long + 1));
                         break;
                     }
                 default:
@@ -12112,15 +12133,19 @@ export const vesc_trampa = $root.vesc_trampa = (() => {
             if (message.targetBoardUuid != null && message.hasOwnProperty("targetBoardUuid"))
                 if (!(message.targetBoardUuid && typeof message.targetBoardUuid.length === "number" || $util.isString(message.targetBoardUuid)))
                     return "targetBoardUuid: buffer expected";
-            if (message.boardCommand != null && message.hasOwnProperty("boardCommand")) {
-                let error = $root.vesc_trampa.VescTrampaBoardCommand.verify(message.boardCommand, long + 1);
-                if (error)
-                    return "boardCommand." + error;
-            }
             if (message.motorMode != null && message.hasOwnProperty("motorMode")) {
                 let error = $root.vesc_trampa.VescTrampaMotorModeCommand.verify(message.motorMode, long + 1);
                 if (error)
                     return "motorMode." + error;
+            }
+            if (message.boardCommands != null && message.hasOwnProperty("boardCommands")) {
+                if (!Array.isArray(message.boardCommands))
+                    return "boardCommands: array expected";
+                for (let i = 0; i < message.boardCommands.length; ++i) {
+                    let error = $root.vesc_trampa.VescTrampaBoardCommand.verify(message.boardCommands[i], long + 1);
+                    if (error)
+                        return "boardCommands." + error;
+                }
             }
             return null;
         };
@@ -12146,15 +12171,20 @@ export const vesc_trampa = $root.vesc_trampa = (() => {
                     $util.base64.decode(object.targetBoardUuid, message.targetBoardUuid = $util.newBuffer($util.base64.length(object.targetBoardUuid)), 0);
                 else if (object.targetBoardUuid.length >= 0)
                     message.targetBoardUuid = object.targetBoardUuid;
-            if (object.boardCommand != null) {
-                if (typeof object.boardCommand !== "object")
-                    throw TypeError(".vesc_trampa.Command.boardCommand: object expected");
-                message.boardCommand = $root.vesc_trampa.VescTrampaBoardCommand.fromObject(object.boardCommand, long + 1);
-            }
             if (object.motorMode != null) {
                 if (typeof object.motorMode !== "object")
                     throw TypeError(".vesc_trampa.Command.motorMode: object expected");
                 message.motorMode = $root.vesc_trampa.VescTrampaMotorModeCommand.fromObject(object.motorMode, long + 1);
+            }
+            if (object.boardCommands) {
+                if (!Array.isArray(object.boardCommands))
+                    throw TypeError(".vesc_trampa.Command.boardCommands: array expected");
+                message.boardCommands = [];
+                for (let i = 0; i < object.boardCommands.length; ++i) {
+                    if (typeof object.boardCommands[i] !== "object")
+                        throw TypeError(".vesc_trampa.Command.boardCommands: object expected");
+                    message.boardCommands[i] = $root.vesc_trampa.VescTrampaBoardCommand.fromObject(object.boardCommands[i], long + 1);
+                }
             }
             return message;
         };
@@ -12172,6 +12202,8 @@ export const vesc_trampa = $root.vesc_trampa = (() => {
             if (!options)
                 options = {};
             let object = {};
+            if (options.arrays || options.defaults)
+                object.boardCommands = [];
             if (options.defaults) {
                 if (options.bytes === String)
                     object.targetBoardUuid = "";
@@ -12180,15 +12212,17 @@ export const vesc_trampa = $root.vesc_trampa = (() => {
                     if (options.bytes !== Array)
                         object.targetBoardUuid = $util.newBuffer(object.targetBoardUuid);
                 }
-                object.boardCommand = null;
                 object.motorMode = null;
             }
             if (message.targetBoardUuid != null && message.hasOwnProperty("targetBoardUuid"))
                 object.targetBoardUuid = options.bytes === String ? $util.base64.encode(message.targetBoardUuid, 0, message.targetBoardUuid.length) : options.bytes === Array ? Array.prototype.slice.call(message.targetBoardUuid) : message.targetBoardUuid;
-            if (message.boardCommand != null && message.hasOwnProperty("boardCommand"))
-                object.boardCommand = $root.vesc_trampa.VescTrampaBoardCommand.toObject(message.boardCommand, options);
             if (message.motorMode != null && message.hasOwnProperty("motorMode"))
                 object.motorMode = $root.vesc_trampa.VescTrampaMotorModeCommand.toObject(message.motorMode, options);
+            if (message.boardCommands && message.boardCommands.length) {
+                object.boardCommands = [];
+                for (let j = 0; j < message.boardCommands.length; ++j)
+                    object.boardCommands[j] = $root.vesc_trampa.VescTrampaBoardCommand.toObject(message.boardCommands[j], options);
+            }
             return object;
         };
 
@@ -12229,6 +12263,7 @@ export const vesc_trampa = $root.vesc_trampa = (() => {
          * @interface IVescTrampaBoardCommand
          * @property {Uint8Array|null} [payload] VescTrampaBoardCommand payload
          * @property {boolean|null} [responseExpected] VescTrampaBoardCommand responseExpected
+         * @property {number|null} [durationMs] VescTrampaBoardCommand durationMs
          */
 
         /**
@@ -12263,6 +12298,14 @@ export const vesc_trampa = $root.vesc_trampa = (() => {
         VescTrampaBoardCommand.prototype.responseExpected = false;
 
         /**
+         * VescTrampaBoardCommand durationMs.
+         * @member {number} durationMs
+         * @memberof vesc_trampa.VescTrampaBoardCommand
+         * @instance
+         */
+        VescTrampaBoardCommand.prototype.durationMs = 0;
+
+        /**
          * Creates a new VescTrampaBoardCommand instance using the specified properties.
          * @function create
          * @memberof vesc_trampa.VescTrampaBoardCommand
@@ -12290,6 +12333,8 @@ export const vesc_trampa = $root.vesc_trampa = (() => {
                 writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.payload);
             if (message.responseExpected != null && Object.hasOwnProperty.call(message, "responseExpected"))
                 writer.uint32(/* id 2, wireType 0 =*/16).bool(message.responseExpected);
+            if (message.durationMs != null && Object.hasOwnProperty.call(message, "durationMs"))
+                writer.uint32(/* id 3, wireType 0 =*/24).uint32(message.durationMs);
             return writer;
         };
 
@@ -12338,6 +12383,10 @@ export const vesc_trampa = $root.vesc_trampa = (() => {
                         message.responseExpected = reader.bool();
                         break;
                     }
+                case 3: {
+                        message.durationMs = reader.uint32();
+                        break;
+                    }
                 default:
                     reader.skipType(tag & 7, long);
                     break;
@@ -12383,6 +12432,9 @@ export const vesc_trampa = $root.vesc_trampa = (() => {
             if (message.responseExpected != null && message.hasOwnProperty("responseExpected"))
                 if (typeof message.responseExpected !== "boolean")
                     return "responseExpected: boolean expected";
+            if (message.durationMs != null && message.hasOwnProperty("durationMs"))
+                if (!$util.isInteger(message.durationMs))
+                    return "durationMs: integer expected";
             return null;
         };
 
@@ -12409,6 +12461,8 @@ export const vesc_trampa = $root.vesc_trampa = (() => {
                     message.payload = object.payload;
             if (object.responseExpected != null)
                 message.responseExpected = Boolean(object.responseExpected);
+            if (object.durationMs != null)
+                message.durationMs = object.durationMs >>> 0;
             return message;
         };
 
@@ -12434,11 +12488,14 @@ export const vesc_trampa = $root.vesc_trampa = (() => {
                         object.payload = $util.newBuffer(object.payload);
                 }
                 object.responseExpected = false;
+                object.durationMs = 0;
             }
             if (message.payload != null && message.hasOwnProperty("payload"))
                 object.payload = options.bytes === String ? $util.base64.encode(message.payload, 0, message.payload.length) : options.bytes === Array ? Array.prototype.slice.call(message.payload) : message.payload;
             if (message.responseExpected != null && message.hasOwnProperty("responseExpected"))
                 object.responseExpected = message.responseExpected;
+            if (message.durationMs != null && message.hasOwnProperty("durationMs"))
+                object.durationMs = message.durationMs;
             return object;
         };
 

--- a/software/station/clients/station-viewer/src/components/history/ExpandedView.tsx
+++ b/software/station/clients/station-viewer/src/components/history/ExpandedView.tsx
@@ -299,12 +299,14 @@ export default function ExpandedView({ data, type, rawData, queueId, entryId }: 
           <div className="text-xs text-text-label">
             UUID: {data.targetBoardUuid ? Array.from(data.targetBoardUuid).map((byte) => byte.toString(16).padStart(2, '0')).join('') : 'N/A'}
           </div>
-          {data.boardCommand && (
+          {(data.boardCommands?.length ?? 0) > 0 && (
             <div className="bg-surface-primary p-2 rounded text-xs">
-              <div className="text-accent-data mb-1">Board Command:</div>
-              <div className="text-text-secondary">
-                Payload: {data.boardCommand.payload?.length ?? 0} bytes, Response: {data.boardCommand.responseExpected ? 'yes' : 'no'}
-              </div>
+              <div className="text-accent-data mb-1">Board Commands:</div>
+              {data.boardCommands?.map((command, index) => (
+                <div key={`${index}-${command.durationMs ?? 0}`} className="text-text-secondary">
+                  #{index + 1}: Payload {command.payload?.length ?? 0} bytes, Duration {command.durationMs ?? 0}ms, Response {command.responseExpected ? 'yes' : 'no'}
+                </div>
+              ))}
             </div>
           )}
         </div>

--- a/software/station/clients/station-viewer/src/components/history/HistoryElement.tsx
+++ b/software/station/clients/station-viewer/src/components/history/HistoryElement.tsx
@@ -399,12 +399,12 @@ function HistoryElement({ element, index, dataQueueType, dataQueueId }: HistoryE
                   UUID: {formatBytes(vescTrampaTxData.targetBoardUuid, 12)}
                 </span>
               )}
-              {vescTrampaTxData.boardCommand && (
+              {(vescTrampaTxData.boardCommands?.length ?? 0) > 0 && (
                 <span className="text-accent-data">
-                  Payload: {vescTrampaTxData.boardCommand.payload?.length ?? 0}b
+                  Commands: {vescTrampaTxData.boardCommands?.length ?? 0}
                 </span>
               )}
-              {vescTrampaTxData.boardCommand?.responseExpected && (
+              {vescTrampaTxData.boardCommands?.some((command) => command.responseExpected) && (
                 <span className="text-accent-success">
                   Response
                 </span>

--- a/software/station/clients/station-viewer/src/devices/vesc-pwm-output-control/useRoverControlSession.ts
+++ b/software/station/clients/station-viewer/src/devices/vesc-pwm-output-control/useRoverControlSession.ts
@@ -8,7 +8,6 @@ import {
 import {
   PWM_OUTPUT_DEFAULT_CHANNEL,
   PWM_OUTPUT_DEFAULT_PERIOD_US,
-  PWM_OUTPUT_DEFAULT_REPEAT,
   PWM_OUTPUT_DEFAULT_STEERING_MAX_PULSE_US,
   PWM_OUTPUT_DEFAULT_STEERING_MIN_PULSE_US,
   PWM_OUTPUT_STEERING_CENTER_DEG,
@@ -31,6 +30,9 @@ import {
 } from './control-input';
 
 const CONTROL_SEND_INTERVAL_MS = 50;
+const CONTROL_COMMAND_HOLD_MS = 2_500;
+const DRIVE_COMMAND_DURATION_MS = CONTROL_COMMAND_HOLD_MS;
+const STEERING_COMMAND_REPEAT = Math.ceil((CONTROL_COMMAND_HOLD_MS * 1000) / PWM_OUTPUT_DEFAULT_PERIOD_US);
 const JOYSTICK_DEAD_ZONE = 0.12;
 
 interface KeyboardState {
@@ -175,7 +177,11 @@ export function useRoverControlSession({
           ? setVescTrampaCurrent(
             driveUuid,
             pending.target.currentA,
-            ROVER_MAX_DRIVE_CURRENT_A,
+            {
+              maxAbsCurrentA: ROVER_MAX_DRIVE_CURRENT_A,
+              durationMs: pending.target.currentA === 0 ? 0 : DRIVE_COMMAND_DURATION_MS,
+              finalCurrentA: 0,
+            },
           ).then(() => {
             lastDriveCurrentRef.current = pending.target.currentA;
           }).catch((commandError) => {
@@ -189,7 +195,7 @@ export function useRoverControlSession({
             PWM_OUTPUT_DEFAULT_CHANNEL,
             pending.target.steeringDeg,
             PWM_OUTPUT_DEFAULT_PERIOD_US,
-            PWM_OUTPUT_DEFAULT_REPEAT,
+            STEERING_COMMAND_REPEAT,
             PWM_OUTPUT_DEFAULT_STEERING_MIN_PULSE_US,
             PWM_OUTPUT_DEFAULT_STEERING_MAX_PULSE_US,
           ).then(() => {

--- a/software/station/clients/station-viewer/src/devices/vesc-trampa/commands.ts
+++ b/software/station/clients/station-viewer/src/devices/vesc-trampa/commands.ts
@@ -8,6 +8,12 @@ export const VESC_TRAMPA_CURRENT_STEP_A = 0.1;
 
 const COMMAND_SET_CURRENT = 6;
 
+export interface SetVescTrampaCurrentOptions {
+  maxAbsCurrentA?: number;
+  durationMs?: number;
+  finalCurrentA?: number;
+}
+
 function int32Payload(commandId: number, value: number): Uint8Array {
   const payload = new Uint8Array(5);
   payload[0] = commandId;
@@ -32,15 +38,32 @@ export function clampVescTrampaCurrent(
 export async function setVescTrampaCurrent(
   boardUuid: Uint8Array,
   currentA: number,
-  maxAbsCurrentA = VESC_TRAMPA_CURRENT_MAX_A,
+  optionsOrMaxAbsCurrentA: number | SetVescTrampaCurrentOptions = VESC_TRAMPA_CURRENT_MAX_A,
 ): Promise<void> {
+  const options = typeof optionsOrMaxAbsCurrentA === 'number'
+    ? { maxAbsCurrentA: optionsOrMaxAbsCurrentA }
+    : optionsOrMaxAbsCurrentA;
+  const maxAbsCurrentA = options.maxAbsCurrentA ?? VESC_TRAMPA_CURRENT_MAX_A;
   const clampedCurrentA = clampVescTrampaCurrent(currentA, maxAbsCurrentA);
+  const clampedFinalCurrentA = clampVescTrampaCurrent(options.finalCurrentA ?? 0, maxAbsCurrentA);
+  const durationMs = Number.isFinite(options.durationMs)
+    ? Math.max(0, Math.floor(options.durationMs ?? 0))
+    : 0;
+
   await commandManager.sendVescTrampaCommand({
     targetBoardUuid: boardUuid,
-    boardCommand: {
-      payload: int32Payload(COMMAND_SET_CURRENT, Math.round(clampedCurrentA * 1000)),
-      responseExpected: false,
-    },
+    boardCommands: [
+      {
+        payload: int32Payload(COMMAND_SET_CURRENT, Math.round(clampedCurrentA * 1000)),
+        responseExpected: false,
+        durationMs,
+      },
+      ...(durationMs > 0 ? [{
+        payload: int32Payload(COMMAND_SET_CURRENT, Math.round(clampedFinalCurrentA * 1000)),
+        responseExpected: false,
+        durationMs: 0,
+      }] : []),
+    ],
   });
 }
 

--- a/software/station/clients/station-viewer/src/devices/vesc-trampa/ui/VescTrampaCard.tsx
+++ b/software/station/clients/station-viewer/src/devices/vesc-trampa/ui/VescTrampaCard.tsx
@@ -21,6 +21,7 @@ import {
 import { formatVescTrampaUuid, longToNumber, shortVescTrampaUuid } from '../utils';
 
 const CURRENT_HOLD_SEND_INTERVAL_MS = 50;
+const CURRENT_COMMAND_DURATION_MS = 2_500;
 
 interface MetricCellProps {
   label: string;
@@ -105,7 +106,10 @@ const VescTrampaCard = ({ boardState, boardIndex }: VescTrampaCardProps) => {
   const sendCurrent = async (currentA: number) => {
     if (!canSendCommand) return;
     try {
-      await setVescTrampaCurrent(boardUuid, currentA);
+      await setVescTrampaCurrent(boardUuid, currentA, {
+        durationMs: currentA === 0 ? 0 : CURRENT_COMMAND_DURATION_MS,
+        finalCurrentA: 0,
+      });
     } catch (error) {
       console.error('Failed to set VESC Trampa current:', error);
     }

--- a/target/gen_python/protobuf/drivers/vesc_trampa/vesc_trampa.py
+++ b/target/gen_python/protobuf/drivers/vesc_trampa/vesc_trampa.py
@@ -196,8 +196,8 @@ class TxEnvelope:
     app_start_id: int = 0
     target_board_uuid: typing.Optional[bytes] = None
     command_id: typing.Optional[bytes] = None
-    board_command: typing.Optional[VescTrampaBoardCommand] = None
     motor_mode: typing.Optional[VescTrampaMotorModeCommand] = None
+    board_commands: list[VescTrampaBoardCommand | None] | None = None
 
     def calc_protobuf_size(self) -> int:
         res = 0
@@ -215,14 +215,19 @@ class TxEnvelope:
             bytes_len = len(self.command_id)
             bytes_len_size = ((bytes_len | 1).bit_length() + 6) // 7
             res += 1 + bytes_len_size + bytes_len
-        if self.board_command is not None:
-            size = self.board_command.calc_protobuf_size()
-            if size > 0:
-                res += 1 + (((size | 1).bit_length() + 6) // 7) + size
         if self.motor_mode is not None:
             size = self.motor_mode.calc_protobuf_size()
             if size > 0:
                 res += 1 + (((size | 1).bit_length() + 6) // 7) + size
+        if self.board_commands is not None:
+            for v in self.board_commands:
+                res += 1
+                if v is not None:
+                    size = v.calc_protobuf_size()
+                    res += (((size | 1).bit_length() + 6) // 7) + size
+                else:
+                    res += 1
+        
         return res
 
     def encode(self) -> bytes:
@@ -245,16 +250,20 @@ class TxEnvelope:
             target.append_bytes(b'\x1a', self.target_board_uuid)
         if self.command_id is not None and len(self.command_id) > 0:
             target.append_bytes(b'"', self.command_id)
-        if self.board_command is not None:
-            size = self.board_command.calc_protobuf_size()
-            if size > 0:
-                target.append_bytes_size_with_tag(b'R', size)
-                self.board_command.encode_to(target)
         if self.motor_mode is not None:
             size = self.motor_mode.calc_protobuf_size()
             if size > 0:
                 target.append_bytes_size_with_tag(b'Z', size)
                 self.motor_mode.encode_to(target)
+        if self.board_commands is not None:
+            for v in self.board_commands:
+                if v is not None:
+                    size = v.calc_protobuf_size()
+                    target.append_bytes_size_with_tag(b'b', size)
+                    v.encode_to(target)
+                else:
+                    target.append_bytes_size_with_tag(b'b', 0)
+        
 
 
 class TxEnvelopeReader:
@@ -264,8 +273,8 @@ class TxEnvelopeReader:
         self._app_start_id: int = 0
         self._target_board_uuid: typing.Optional[memoryview] = None
         self._command_id: typing.Optional[memoryview] = None
-        self._board_command_buf: typing.Optional[memoryview] = None
         self._motor_mode_buf: typing.Optional[memoryview] = None
+        self._board_commands_bufs: list[memoryview] | None = None
 
         if not src:
             return
@@ -295,14 +304,17 @@ class TxEnvelopeReader:
                     result = self._buf.read_bytes_view(offset)
                     offset += result.size
                     self._command_id = result.value
-                case 10:
-                    result = self._buf.read_bytes_view(offset)
-                    offset += result.size
-                    self._board_command_buf = result.value
                 case 11:
                     result = self._buf.read_bytes_view(offset)
                     offset += result.size
                     self._motor_mode_buf = result.value
+                case 12:
+                    result = self._buf.read_bytes_view(offset)
+                    offset += result.size
+                    if self._board_commands_bufs is None:
+                        self._board_commands_bufs = []
+                    self._board_commands_bufs.append(result.value)
+            
                 case _:
                     offset = self._buf.skip_data(offset, tag.wire)
 
@@ -321,23 +333,27 @@ class TxEnvelopeReader:
     def get_command_id(self) -> memoryview:
         return self._command_id if self._command_id is not None else memoryview(b'')
 
-    def get_board_command(self) -> VescTrampaBoardCommandReader:
-        if self._board_command_buf is not None:
-            return VescTrampaBoardCommandReader(self._board_command_buf)
-        return VescTrampaBoardCommandReader(b'')
-
     def get_motor_mode(self) -> VescTrampaMotorModeCommandReader:
         if self._motor_mode_buf is not None:
             return VescTrampaMotorModeCommandReader(self._motor_mode_buf)
         return VescTrampaMotorModeCommandReader(b'')
+
+    def get_board_commands(self) -> list[VescTrampaBoardCommandReader]:
+        if self._board_commands_bufs is not None:
+            result: list[VescTrampaBoardCommandReader] = []
+            for buf in self._board_commands_bufs:
+                result.append(VescTrampaBoardCommandReader(buf))
+            return result
+        return []
+    
 
 
 @dataclasses.dataclass
 class Command:
     # fields
     target_board_uuid: typing.Optional[bytes] = None
-    board_command: typing.Optional[VescTrampaBoardCommand] = None
     motor_mode: typing.Optional[VescTrampaMotorModeCommand] = None
+    board_commands: list[VescTrampaBoardCommand | None] | None = None
 
     def calc_protobuf_size(self) -> int:
         res = 0
@@ -345,14 +361,19 @@ class Command:
             bytes_len = len(self.target_board_uuid)
             bytes_len_size = ((bytes_len | 1).bit_length() + 6) // 7
             res += 1 + bytes_len_size + bytes_len
-        if self.board_command is not None:
-            size = self.board_command.calc_protobuf_size()
-            if size > 0:
-                res += 1 + (((size | 1).bit_length() + 6) // 7) + size
         if self.motor_mode is not None:
             size = self.motor_mode.calc_protobuf_size()
             if size > 0:
                 res += 1 + (((size | 1).bit_length() + 6) // 7) + size
+        if self.board_commands is not None:
+            for v in self.board_commands:
+                res += 1
+                if v is not None:
+                    size = v.calc_protobuf_size()
+                    res += (((size | 1).bit_length() + 6) // 7) + size
+                else:
+                    res += 1
+        
         return res
 
     def encode(self) -> bytes:
@@ -367,23 +388,27 @@ class Command:
     def encode_to(self, target: typing.Union[gremlin.Writer, gremlin.StreamingWriter]):
         if self.target_board_uuid is not None and len(self.target_board_uuid) > 0:
             target.append_bytes(b'\n', self.target_board_uuid)
-        if self.board_command is not None:
-            size = self.board_command.calc_protobuf_size()
-            if size > 0:
-                target.append_bytes_size_with_tag(b'R', size)
-                self.board_command.encode_to(target)
         if self.motor_mode is not None:
             size = self.motor_mode.calc_protobuf_size()
             if size > 0:
                 target.append_bytes_size_with_tag(b'Z', size)
                 self.motor_mode.encode_to(target)
+        if self.board_commands is not None:
+            for v in self.board_commands:
+                if v is not None:
+                    size = v.calc_protobuf_size()
+                    target.append_bytes_size_with_tag(b'b', size)
+                    v.encode_to(target)
+                else:
+                    target.append_bytes_size_with_tag(b'b', 0)
+        
 
 
 class CommandReader:
     def __init__(self, src: memoryview):
         self._target_board_uuid: typing.Optional[memoryview] = None
-        self._board_command_buf: typing.Optional[memoryview] = None
         self._motor_mode_buf: typing.Optional[memoryview] = None
+        self._board_commands_bufs: list[memoryview] | None = None
 
         if not src:
             return
@@ -397,29 +422,36 @@ class CommandReader:
                     result = self._buf.read_bytes_view(offset)
                     offset += result.size
                     self._target_board_uuid = result.value
-                case 10:
-                    result = self._buf.read_bytes_view(offset)
-                    offset += result.size
-                    self._board_command_buf = result.value
                 case 11:
                     result = self._buf.read_bytes_view(offset)
                     offset += result.size
                     self._motor_mode_buf = result.value
+                case 12:
+                    result = self._buf.read_bytes_view(offset)
+                    offset += result.size
+                    if self._board_commands_bufs is None:
+                        self._board_commands_bufs = []
+                    self._board_commands_bufs.append(result.value)
+            
                 case _:
                     offset = self._buf.skip_data(offset, tag.wire)
 
     def get_target_board_uuid(self) -> memoryview:
         return self._target_board_uuid if self._target_board_uuid is not None else memoryview(b'')
 
-    def get_board_command(self) -> VescTrampaBoardCommandReader:
-        if self._board_command_buf is not None:
-            return VescTrampaBoardCommandReader(self._board_command_buf)
-        return VescTrampaBoardCommandReader(b'')
-
     def get_motor_mode(self) -> VescTrampaMotorModeCommandReader:
         if self._motor_mode_buf is not None:
             return VescTrampaMotorModeCommandReader(self._motor_mode_buf)
         return VescTrampaMotorModeCommandReader(b'')
+
+    def get_board_commands(self) -> list[VescTrampaBoardCommandReader]:
+        if self._board_commands_bufs is not None:
+            result: list[VescTrampaBoardCommandReader] = []
+            for buf in self._board_commands_bufs:
+                result.append(VescTrampaBoardCommandReader(buf))
+            return result
+        return []
+    
 
 
 @dataclasses.dataclass
@@ -427,6 +459,7 @@ class VescTrampaBoardCommand:
     # fields
     payload: typing.Optional[bytes] = None
     response_expected: bool = False
+    duration_ms: int = 0
 
     def calc_protobuf_size(self) -> int:
         res = 0
@@ -436,6 +469,8 @@ class VescTrampaBoardCommand:
             res += 1 + bytes_len_size + bytes_len
         if self.response_expected:
             res += 2
+        if self.duration_ms != 0:
+            res += 1 + gremlin.sizes.size_varint(self.duration_ms)
         return res
 
     def encode(self) -> bytes:
@@ -452,12 +487,15 @@ class VescTrampaBoardCommand:
             target.append_bytes(b'\n', self.payload)
         if self.response_expected:
             target.append_bool(b'\x10', self.response_expected)
+        if self.duration_ms != 0:
+            target.append_uint32(b'\x18', self.duration_ms)
 
 
 class VescTrampaBoardCommandReader:
     def __init__(self, src: memoryview):
         self._payload: typing.Optional[memoryview] = None
         self._response_expected: bool = False
+        self._duration_ms: int = 0
 
         if not src:
             return
@@ -475,6 +513,10 @@ class VescTrampaBoardCommandReader:
                     result = self._buf.read_bool(offset)
                     offset += result.size
                     self._response_expected = result.value
+                case 3:
+                    result = self._buf.read_uint32(offset)
+                    offset += result.size
+                    self._duration_ms = result.value
                 case _:
                     offset = self._buf.skip_data(offset, tag.wire)
 
@@ -483,6 +525,9 @@ class VescTrampaBoardCommandReader:
 
     def get_response_expected(self) -> bool:
         return self._response_expected
+
+    def get_duration_ms(self) -> int:
+        return self._duration_ms
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
Fixes #125.

Adds duration-aware VESC command sequences and updates Station viewer command encoding so short current bursts can run on the station side without extra LTE round trips.

Tests:
- cargo test -p vesc-trampa