### PR TITLE
Add Portenta X8 first-boot station setup

### DIFF
--- a/device-support/arduino-portenta-x8/yocto/README.md
+++ b/device-support/arduino-portenta-x8/yocto/README.md
@@ -10,6 +10,7 @@ then adds the Arduino, Tailscale, and NormaCore layers on top.
 
 - [Image Profile](#image-profile-)
 - [Max Carrier Setup](#max-carrier-setup-)
+- [M4 PWM Firmware](#m4-pwm-firmware-)
 - [Cellular Modem Support](#cellular-modem-support-)
 - [Hardware Network Watchdog](#hardware-network-watchdog-)
 - [SD Card Automount](#sd-card-automount-)
@@ -44,6 +45,8 @@ The target image includes:
 - Default hostname `rover-alpha`; override with `X8_HOSTNAME` in
   `conf/local.conf`.
 - Max Carrier boot overlay selection and Portenta X8/H7 support packages.
+- NormaCore PWM output firmware for the STM32H7 M4 core, installed from a
+  required prebuilt ELF artifact at `/opt/x8-firmware/m4-user-sketch.elf`.
 - Wi-Fi, Bluetooth, ALSA audio, V4L2, CAN, I2C, GPIO, USB, PCI, PPP, QMI,
   MBIM, and serial-console tools.
 - Removable SD-card automounting at `/media/sdcard`.
@@ -99,6 +102,39 @@ Arduino documents this as Ethernet enabled for Portenta X8. See the
 [Portenta Max Carrier user manual](https://docs.arduino.cc/tutorials/portenta-max-carrier/user-manual/)
 for the carrier DIP switch table.
 
+## M4 PWM Firmware 🧩
+
+Build the NormaCore PWM output sketch for the STM32H7 M4 core outside Yocto:
+
+```sh
+mkdir -p target/arduino-portenta-x8/pwm-output-m4
+arduino-cli compile \
+  --fqbn arduino:mbed_portenta:portenta_x8 \
+  --output-dir target/arduino-portenta-x8/pwm-output-m4 \
+  software/drivers/pwm-output/firmware/pwm_output_m4
+```
+
+The Yocto recipe defaults to this artifact path:
+
+```bitbake
+X8_M4_USER_SKETCH_ELF ??= "${NORMACORE_REPO_ROOT}/target/arduino-portenta-x8/pwm-output-m4/pwm_output_m4.ino.elf"
+```
+
+The image build fails if that ELF is missing. Override `X8_M4_USER_SKETCH_ELF`
+only when using a different artifact path. The ELF is installed into the target
+image as:
+
+```text
+/opt/x8-firmware/m4-user-sketch.elf
+```
+
+`x8h7-init` flashes this file once on first boot, before loading the post-H7 IO
+kernel modules, and writes:
+
+```text
+/var/lib/x8h7-init/m4-user-sketch.done
+```
+
 ## Cellular Modem Support 📡
 
 The image includes basic cellular support for both the Max Carrier onboard
@@ -131,6 +167,37 @@ Leaving both APNs empty keeps the service installed but inactive at boot.
 The image includes ModemManager plus QMI/MBIM tools, but it does not include
 NetworkManager. Modem detection and inspection are available through
 ModemManager, while connection policy is handled by `x8-cellulard`.
+
+## Station Service 🛰️
+
+The image installs the prebuilt ARM64 Station binary from:
+
+```text
+target/aarch64-unknown-linux-gnu/release/station
+```
+
+If that binary is missing, the image build fails and asks to build it from the
+Station source folder:
+
+```sh
+cd software/station/bin/station
+make build-arm64
+```
+
+Station is installed at `/opt/station/station` and managed by a SysV supervisor
+that starts it with TCP/Web enabled, `--max-memory-usage=128M`, and
+`--normfs-persistence-mode=memory-only`. The default config and data paths are:
+
+```text
+/opt/station/station.yaml
+/opt/station/station_data
+```
+
+Private Station identity data can be provided by placing the seed at
+`bld-x8/conf/station.crypto_seed`. If that file exists, it is copied into the
+image as `/opt/station/station_data/.crypto_seed`. If it does not exist, the
+image does not install a seed and Station creates a new NormFS identity on first
+boot.
 
 ## Hardware Network Watchdog ⏱️
 
@@ -182,15 +249,22 @@ whole card device is mounted.
 
 ## eMMC Root Filesystem Size 💽
 
-Portenta X8 has a 16 GB onboard eMMC. The image uses a fixed 14336 MiB rootfs
-partition in the generated `.wic` so the flashed system has a large rootfs
-available immediately, without first-boot partition resizing.
+Portenta X8 has a 16 GB onboard eMMC. The generated `.wic` keeps the flashed
+rootfs partition compact by default:
 
-Arduino's stock `lmp-factory-image-portenta-x8.wic.gz` reference image uses a
-smaller root partition of about 2.9 GiB. NormaCore intentionally uses the larger
-fixed partition because this image is flashed directly to the X8 eMMC, while
-keeping enough margin for the capacity exposed by Arduino's mfgtool fastboot
-target.
+```bitbake
+X8_ROOTFS_FLASH_SIZE_MB ??= "3072"
+```
+
+This avoids decompressing and flashing a 14 GiB image mostly filled with zeroed
+ext4 free space. On first boot, `x8-grow-rootfs` expands the root partition and
+online ext4 filesystem to the rest of the eMMC, writes
+`/var/lib/x8-grow-rootfs.done`, and removes itself from SysV autostart.
+
+If the kernel cannot reread the mounted root partition table immediately after
+the partition is expanded, `resize2fs` may fail on that boot. In that case the
+service stays enabled and retries on the next boot, when the kernel sees the new
+partition size from startup.
 
 ## Start Here 📍
 

--- a/device-support/arduino-portenta-x8/yocto/meta-normacore-x8/conf/templates/normacore-x8/conf-notes.txt
+++ b/device-support/arduino-portenta-x8/yocto/meta-normacore-x8/conf/templates/normacore-x8/conf-notes.txt
@@ -19,6 +19,14 @@ Optional cellular settings:
     X8_CELLULARD_SARA_APN = ""
     X8_CELLULARD_INTERVAL_SEC = "30"
 
+Optional private Station identity:
+
+  conf/station.crypto_seed
+
+  If this file exists, it is copied into
+  /opt/station/station_data/.crypto_seed. If it does not exist, the image does
+  not install a seed and Station creates a new NormFS identity on first boot.
+
 The image build intentionally fails if either X8_ROOT_HASH or
 X8_ROOT_AUTHORIZED_KEYS_FILE is missing or empty.
 

--- a/device-support/arduino-portenta-x8/yocto/meta-normacore-x8/recipes-bsp/x8-m4-pwm-output-firmware/x8-m4-pwm-output-firmware.bb
+++ b/device-support/arduino-portenta-x8/yocto/meta-normacore-x8/recipes-bsp/x8-m4-pwm-output-firmware/x8-m4-pwm-output-firmware.bb
@@ -1,0 +1,32 @@
+SUMMARY = "NormaCore Portenta X8 M4 PWM output firmware"
+DESCRIPTION = "Installs a prebuilt NormaCore PWM output M4 firmware ELF for first-boot flashing."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+INHIBIT_PACKAGE_STRIP = "1"
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+INHIBIT_SYSROOT_STRIP = "1"
+INSANE_SKIP:${PN} += "arch"
+
+NORMACORE_REPO_ROOT ?= "${THISDIR}/../../../../../.."
+X8_M4_USER_SKETCH_ELF ??= "${NORMACORE_REPO_ROOT}/target/arduino-portenta-x8/pwm-output-m4/pwm_output_m4.ino.elf"
+
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+do_install[nostamp] = "1"
+
+do_install() {
+    if [ -z "${X8_M4_USER_SKETCH_ELF}" ]; then
+        bbfatal "Missing X8_M4_USER_SKETCH_ELF. Build the M4 firmware separately and set X8_M4_USER_SKETCH_ELF to the resulting pwm_output_m4.ino.elf path."
+    fi
+
+    if [ ! -f "${X8_M4_USER_SKETCH_ELF}" ]; then
+        bbfatal "X8_M4_USER_SKETCH_ELF does not exist: ${X8_M4_USER_SKETCH_ELF}. Build it with: arduino-cli compile --fqbn arduino:mbed_portenta:portenta_x8 --output-dir ${NORMACORE_REPO_ROOT}/target/arduino-portenta-x8/pwm-output-m4 ${NORMACORE_REPO_ROOT}/software/drivers/pwm-output/firmware/pwm_output_m4"
+    fi
+
+    install -d ${D}/opt/x8-firmware
+    install -m 0644 "${X8_M4_USER_SKETCH_ELF}" ${D}/opt/x8-firmware/m4-user-sketch.elf
+}
+
+FILES:${PN} += "/opt/x8-firmware/m4-user-sketch.elf"

--- a/device-support/arduino-portenta-x8/yocto/meta-normacore-x8/recipes-core/images/x8-normacore-emmc.wks.in
+++ b/device-support/arduino-portenta-x8/yocto/meta-normacore-x8/recipes-core/images/x8-normacore-emmc.wks.in
@@ -1,9 +1,9 @@
-# short-description: Portenta X8 eMMC image with a large rootfs partition
+# short-description: Portenta X8 eMMC image with first-boot rootfs expansion
 # long-description:
-# Keep Arduino/NXP's X8 single-rootfs boot layout, but make the root
-# partition large enough to use nearly all of the 16 GB Portenta X8 eMMC.
+# Keep Arduino/NXP's X8 single-rootfs boot layout, but keep the flashed image
+# compact. x8-grow-rootfs expands the root partition/filesystem on first boot.
 
 part u-boot --source rawcopy --sourceparams="file=imx-boot.tagged" --ondisk mmcblk --no-table --align ${IMX_BOOT_SEEK}
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 8192 --fixed-size 14336M
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 8192 --fixed-size ${X8_ROOTFS_FLASH_SIZE_MB}M
 
 bootloader --ptable msdos

--- a/device-support/arduino-portenta-x8/yocto/meta-normacore-x8/recipes-core/images/x8-normacore.bb
+++ b/device-support/arduino-portenta-x8/yocto/meta-normacore-x8/recipes-core/images/x8-normacore.bb
@@ -23,6 +23,7 @@ IMAGE_INSTALL = "\
     \
     m-x8h7 \
     linux-firmware-arduino-portenta-x8-stm32h7 \
+    x8-m4-pwm-output-firmware \
     x8h7-init \
     \
     m-bq24195 \
@@ -59,6 +60,7 @@ IMAGE_INSTALL = "\
     util-linux \
     e2fsprogs \
     dosfstools \
+    x8-grow-rootfs \
     x8-sdcard-automount \
     \
     v4l-utils \
@@ -78,6 +80,8 @@ IMAGE_INSTALL = "\
     chrony \
     chronyc \
     \
+    station \
+    \
     vim \
     tmux \
 "
@@ -85,6 +89,7 @@ IMAGE_INSTALL = "\
 IMAGE_FSTYPES += "wic.zst"
 WKS_FILE = "x8-normacore-emmc.wks.in"
 WKS_FILE:mx8mm-nxp-bsp = "x8-normacore-emmc.wks.in"
+X8_ROOTFS_FLASH_SIZE_MB ??= "3072"
 
 ROOTFS_POSTPROCESS_COMMAND += "x8_patch_uenv_for_max_carrier;"
 

--- a/device-support/arduino-portenta-x8/yocto/meta-normacore-x8/recipes-core/station/files/station-supervisor
+++ b/device-support/arduino-portenta-x8/yocto/meta-normacore-x8/recipes-core/station/files/station-supervisor
@@ -1,0 +1,97 @@
+#!/bin/sh
+
+CONFIG=/etc/default/station
+
+STATION_BINARY="/opt/station/station"
+STATION_WORKDIR="/opt/station"
+STATION_CONFIG="/opt/station/station.yaml"
+STATION_DATA_DIR="/opt/station/station_data"
+STATION_TCP_ADDR="0.0.0.0:8888"
+STATION_WEB_ADDR="0.0.0.0:8889"
+STATION_MAX_MEMORY_USAGE="128M"
+STATION_NORMFS_PERSISTENCE_MODE="memory-only"
+STATION_EXTRA_ARGS=""
+STATION_RESTART_DELAY_SEC="5"
+STATION_LOG="/var/log/station.log"
+
+STOPFILE=/run/station.stop
+CHILD_PIDFILE=/run/station.pid
+
+[ -f "$CONFIG" ] && . "$CONFIG"
+
+log() {
+    mkdir -p /var/log
+    echo "$(date '+%Y-%m-%d %H:%M:%S') station-supervisor: $*" >> "$STATION_LOG"
+}
+
+stop_child() {
+    if [ -f "$CHILD_PIDFILE" ]; then
+        child_pid="$(cat "$CHILD_PIDFILE" 2>/dev/null || true)"
+        if [ -n "$child_pid" ]; then
+            kill "$child_pid" 2>/dev/null || true
+        fi
+    fi
+}
+
+handle_stop() {
+    touch "$STOPFILE"
+    stop_child
+}
+
+trap handle_stop TERM INT
+
+mkdir -p /run "$STATION_WORKDIR" "$STATION_DATA_DIR" /var/log
+rm -f "$STOPFILE"
+
+if ! cd "$STATION_WORKDIR"; then
+    log "failed to enter station workdir: $STATION_WORKDIR"
+    exit 1
+fi
+
+while [ ! -f "$STOPFILE" ]; do
+    if [ ! -x "$STATION_BINARY" ]; then
+        log "station binary is not executable: $STATION_BINARY"
+        sleep "${STATION_RESTART_DELAY_SEC:-5}"
+        continue
+    fi
+
+    set -- \
+        --config "$STATION_CONFIG" \
+        --normfs-base-folder "$STATION_DATA_DIR" \
+        --max-memory-usage "$STATION_MAX_MEMORY_USAGE" \
+        --normfs-persistence-mode "$STATION_NORMFS_PERSISTENCE_MODE"
+
+    if [ -n "$STATION_TCP_ADDR" ]; then
+        set -- "$@" --tcp "$STATION_TCP_ADDR"
+    fi
+
+    if [ -n "$STATION_WEB_ADDR" ]; then
+        set -- "$@" --web "$STATION_WEB_ADDR"
+    fi
+
+    if [ -n "$STATION_EXTRA_ARGS" ]; then
+        # shellcheck disable=SC2086
+        set -- "$@" $STATION_EXTRA_ARGS
+    fi
+
+    log "starting station: $STATION_BINARY $*"
+    (
+        exec "$STATION_BINARY" "$@"
+    ) >> "$STATION_LOG" 2>&1 &
+
+    child_pid="$!"
+    echo "$child_pid" > "$CHILD_PIDFILE"
+    wait "$child_pid"
+    status="$?"
+    rm -f "$CHILD_PIDFILE"
+
+    if [ -f "$STOPFILE" ]; then
+        break
+    fi
+
+    log "station exited with status $status; restarting in ${STATION_RESTART_DELAY_SEC:-5}s"
+    sleep "${STATION_RESTART_DELAY_SEC:-5}"
+done
+
+rm -f "$CHILD_PIDFILE" "$STOPFILE"
+log "station supervisor stopped"

--- a/device-support/arduino-portenta-x8/yocto/meta-normacore-x8/recipes-core/station/files/station.init
+++ b/device-support/arduino-portenta-x8/yocto/meta-normacore-x8/recipes-core/station/files/station.init
@@ -1,0 +1,78 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:          station
+# Required-Start:    $remote_fs $network x8h7-init
+# Required-Stop:     $remote_fs $network
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: NormaCore Station supervisor
+### END INIT INFO
+
+CONFIG=/etc/default/station
+SUPERVISOR=/opt/station/station-supervisor
+PIDFILE=/run/station-supervisor.pid
+STOPFILE=/run/station.stop
+
+STATION_ENABLED="1"
+STATION_BINARY="/opt/station/station"
+
+[ -f "$CONFIG" ] && . "$CONFIG"
+
+case "$1" in
+    start)
+        if [ "$STATION_ENABLED" = "0" ] || [ "$STATION_ENABLED" = "false" ]; then
+            echo "station disabled in $CONFIG"
+            exit 0
+        fi
+
+        [ -x "$SUPERVISOR" ] || {
+            echo "station supervisor not found"
+            exit 1
+        }
+        [ -x "$STATION_BINARY" ] || {
+            echo "station binary not found: $STATION_BINARY"
+            exit 1
+        }
+
+        if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
+            echo "station already running"
+            exit 0
+        fi
+
+        mkdir -p /run
+        rm -f "$STOPFILE"
+        echo "Starting station"
+        start-stop-daemon -S -b -m -p "$PIDFILE" -x "$SUPERVISOR"
+        ;;
+
+    stop)
+        echo "Stopping station"
+        mkdir -p /run
+        touch "$STOPFILE"
+        start-stop-daemon -K -p "$PIDFILE" 2>/dev/null || true
+        rm -f "$PIDFILE"
+        ;;
+
+    restart)
+        "$0" stop
+        sleep 1
+        "$0" start
+        ;;
+
+    status)
+        if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
+            echo "station running"
+            exit 0
+        fi
+        echo "station not running"
+        exit 3
+        ;;
+
+    *)
+        echo "Usage: $0 {start|stop|restart|status}"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/device-support/arduino-portenta-x8/yocto/meta-normacore-x8/recipes-core/station/files/station.yaml
+++ b/device-support/arduino-portenta-x8/yocto/meta-normacore-x8/recipes-core/station/files/station.yaml
@@ -1,0 +1,28 @@
+drivers:
+  system-info: true
+  st3215:
+    enabled: false
+  vesc-trampa:
+    enabled: true
+    port-baud-rate: 115200
+  pwm-output:
+    enabled: true
+    device-path: /dev/x8h7_ui
+    outputs:
+      - id: steering
+  usb-video:
+    enabled: true
+    formats:
+      - format: "640x480@maxfps,jpeg"
+    frame-skip: 0
+  hikmicro-thermal:
+    enabled: true
+    frame-timeout: 5s
+    frame-skip: 0
+  airgradient-open-air-o-1pst:
+    enabled: true
+    read-timeout: 10s
+  victron-smartsolar-mppt:
+    enabled: true
+    read-timeout: 10s
+inference: []

--- a/device-support/arduino-portenta-x8/yocto/meta-normacore-x8/recipes-core/station/station.bb
+++ b/device-support/arduino-portenta-x8/yocto/meta-normacore-x8/recipes-core/station/station.bb
@@ -1,0 +1,73 @@
+SUMMARY = "NormaCore Station for Portenta X8"
+DESCRIPTION = "Installs a prebuilt NormaCore Station binary and SysV supervisor for Portenta X8."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = " \
+    file://station.init \
+    file://station-supervisor \
+    file://station.yaml \
+"
+
+inherit update-rc.d
+
+INITSCRIPT_NAME = "station"
+INITSCRIPT_PARAMS = "defaults 85 15"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+INHIBIT_PACKAGE_STRIP = "1"
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+INHIBIT_SYSROOT_STRIP = "1"
+INSANE_SKIP:${PN} += "already-stripped"
+
+NORMACORE_REPO_ROOT ?= "${THISDIR}/../../../../../.."
+X8_STATION_BINARY ??= "${NORMACORE_REPO_ROOT}/target/aarch64-unknown-linux-gnu/release/station"
+
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+do_install[nostamp] = "1"
+
+CONFFILES:${PN} += " \
+    /etc/default/station \
+    /opt/station/station.yaml \
+"
+
+FILES:${PN} += " \
+    /opt/station \
+    /etc/init.d/station \
+    /etc/default/station \
+"
+
+do_install() {
+    if [ ! -f "${X8_STATION_BINARY}" ]; then
+        bbfatal "X8_STATION_BINARY does not exist: ${X8_STATION_BINARY}. Build it with: cd ${NORMACORE_REPO_ROOT}/software/station/bin/station && make build-arm64"
+    fi
+
+    install -d ${D}/opt/station/station_data
+    install -m 0755 "${X8_STATION_BINARY}" ${D}/opt/station/station
+    install -m 0755 ${WORKDIR}/station-supervisor ${D}/opt/station/station-supervisor
+    install -m 0644 ${WORKDIR}/station.yaml ${D}/opt/station/station.yaml
+
+    if [ -f "${TOPDIR}/conf/station.crypto_seed" ]; then
+        install -m 0600 "${TOPDIR}/conf/station.crypto_seed" ${D}/opt/station/station_data/.crypto_seed
+    fi
+
+    install -d ${D}${sysconfdir}/init.d ${D}${sysconfdir}/default
+    install -m 0755 ${WORKDIR}/station.init ${D}${sysconfdir}/init.d/station
+
+    cat > ${D}${sysconfdir}/default/station <<EOF
+# NormaCore Station service configuration.
+STATION_ENABLED="1"
+STATION_BINARY="/opt/station/station"
+STATION_WORKDIR="/opt/station"
+STATION_CONFIG="/opt/station/station.yaml"
+STATION_DATA_DIR="/opt/station/station_data"
+STATION_TCP_ADDR="0.0.0.0:8888"
+STATION_WEB_ADDR="0.0.0.0:8889"
+STATION_MAX_MEMORY_USAGE="128M"
+STATION_NORMFS_PERSISTENCE_MODE="memory-only"
+STATION_RESTART_DELAY_SEC="5"
+STATION_LOG="/var/log/station.log"
+STATION_EXTRA_ARGS=""
+EOF
+}

--- a/device-support/arduino-portenta-x8/yocto/meta-normacore-x8/recipes-core/x8-grow-rootfs/files/x8-grow-rootfs
+++ b/device-support/arduino-portenta-x8/yocto/meta-normacore-x8/recipes-core/x8-grow-rootfs/files/x8-grow-rootfs
@@ -1,0 +1,153 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:          x8-grow-rootfs
+# Required-Start:    $local_fs
+# Required-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:
+# Short-Description: First-boot Portenta X8 rootfs expansion
+### END INIT INFO
+
+DONE=/var/lib/x8-grow-rootfs.done
+LOG=/var/log/x8-grow-rootfs.log
+PIDFILE=/run/x8-grow-rootfs.pid
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+
+log() {
+    mkdir -p /var/log
+    echo "$(date '+%Y-%m-%d %H:%M:%S') x8-grow-rootfs: $*" >> "$LOG"
+}
+
+disable_service() {
+    update-rc.d -f x8-grow-rootfs remove >/dev/null 2>&1 || true
+}
+
+root_devnum() {
+    awk '$5 == "/" { print $3; exit }' /proc/self/mountinfo
+}
+
+resolve_root_device() {
+    devnum="$(root_devnum)"
+    [ -n "$devnum" ] || return 1
+
+    sys_path="/sys/dev/block/$devnum"
+    [ -e "$sys_path" ] || return 1
+
+    part_sys="$(readlink -f "$sys_path")"
+    [ -n "$part_sys" ] && [ -f "$part_sys/partition" ] || return 1
+
+    part_name="$(basename "$part_sys")"
+    disk_sys="$(dirname "$part_sys")"
+    disk_name="$(basename "$disk_sys")"
+    part_no="$(cat "$part_sys/partition")"
+
+    [ -n "$part_name" ] && [ -n "$disk_name" ] && [ -n "$part_no" ] || return 1
+    [ -b "/dev/$part_name" ] && [ -b "/dev/$disk_name" ] || return 1
+
+    printf '%s %s %s %s %s\n' "/dev/$disk_name" "/dev/$part_name" "$part_no" "$disk_sys" "$part_sys"
+}
+
+grow_rootfs() {
+    if [ -f "$DONE" ]; then
+        disable_service
+        return 0
+    fi
+
+    root_device="$(resolve_root_device)" || {
+        log "cannot resolve root block device"
+        return 1
+    }
+    set -- $root_device
+
+    disk_dev="$1"
+    part_dev="$2"
+    part_no="$3"
+    disk_sys="$4"
+    part_sys="$5"
+
+    disk_size="$(cat "$disk_sys/size")"
+    part_start="$(cat "$part_sys/start")"
+    part_size="$(cat "$part_sys/size")"
+    target_size=$((disk_size - part_start))
+
+    if [ "$target_size" -le 0 ]; then
+        log "invalid target size: disk_size=$disk_size part_start=$part_start"
+        return 1
+    fi
+
+    if [ "$target_size" -gt "$part_size" ]; then
+        log "growing $part_dev on $disk_dev: start=$part_start size=$part_size target=$target_size"
+
+        if ! printf '%s,%s\n' "$part_start" "$target_size" |
+            sfdisk --no-reread --force -N "$part_no" "$disk_dev" >> "$LOG" 2>&1; then
+            log "sfdisk failed"
+            return 1
+        fi
+
+        blockdev --rereadpt "$disk_dev" >> "$LOG" 2>&1 || true
+        partx --update "$part_dev" >> "$LOG" 2>&1 || partx --update "$disk_dev" >> "$LOG" 2>&1 || true
+    else
+        log "$part_dev already uses available partition space"
+    fi
+
+    if ! resize2fs "$part_dev" >> "$LOG" 2>&1; then
+        log "resize2fs failed; will retry on next boot"
+        return 1
+    fi
+
+    mkdir -p "$(dirname "$DONE")"
+    echo "expanded: $(date '+%Y-%m-%dT%H:%M:%S%z')" > "$DONE"
+    disable_service
+    log "rootfs expansion complete"
+    return 0
+}
+
+case "$1" in
+    start)
+        mkdir -p /run
+        if [ -f "$DONE" ]; then
+            disable_service
+            exit 0
+        fi
+
+        if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
+            log "worker already running"
+            exit 0
+        fi
+
+        start-stop-daemon -S -b -m -p "$PIDFILE" -x "$0" -- run
+        ;;
+
+    run)
+        grow_rootfs
+        exit $?
+        ;;
+
+    stop)
+        if [ -f "$PIDFILE" ]; then
+            start-stop-daemon -K -p "$PIDFILE" 2>/dev/null || true
+            rm -f "$PIDFILE"
+        fi
+        ;;
+
+    restart)
+        "$0" start
+        ;;
+
+    status)
+        if [ -f "$DONE" ]; then
+            echo "x8-grow-rootfs complete"
+            exit 0
+        fi
+        echo "x8-grow-rootfs pending"
+        exit 3
+        ;;
+
+    *)
+        echo "Usage: $0 {start|stop|restart|status}"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/device-support/arduino-portenta-x8/yocto/meta-normacore-x8/recipes-core/x8-grow-rootfs/x8-grow-rootfs.bb
+++ b/device-support/arduino-portenta-x8/yocto/meta-normacore-x8/recipes-core/x8-grow-rootfs/x8-grow-rootfs.bb
@@ -1,0 +1,26 @@
+SUMMARY = "First-boot root filesystem expansion for Portenta X8"
+DESCRIPTION = "Expands the compact flashed root partition and ext4 filesystem to the full eMMC on first boot."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://x8-grow-rootfs"
+
+inherit update-rc.d
+
+INITSCRIPT_NAME = "x8-grow-rootfs"
+INITSCRIPT_PARAMS = "defaults 08 92"
+
+RDEPENDS:${PN} += "\
+    busybox \
+    e2fsprogs-resize2fs \
+    util-linux-blockdev \
+    util-linux-partx \
+    util-linux-sfdisk \
+"
+
+do_install() {
+    install -d ${D}${sysconfdir}/init.d
+    install -m 0755 ${WORKDIR}/x8-grow-rootfs ${D}${sysconfdir}/init.d/x8-grow-rootfs
+}
+
+FILES:${PN} += "${sysconfdir}/init.d/x8-grow-rootfs"

--- a/device-support/arduino-portenta-x8/yocto/meta-normacore-x8/recipes-core/x8h7-init/files/x8h7-init
+++ b/device-support/arduino-portenta-x8/yocto/meta-normacore-x8/recipes-core/x8h7-init/files/x8h7-init
@@ -10,6 +10,24 @@
 ### END INIT INFO
 
 DT_X8H7="/sys/firmware/devicetree/base/soc@0/bus@30800000/spba-bus@30800000/spi@30840000/x8h7@0"
+M4_FIRMWARE="/opt/x8-firmware/m4-user-sketch.elf"
+M4_DONE="/var/lib/x8h7-init/m4-user-sketch.done"
+
+program_m4_once() {
+    [ -f "$M4_FIRMWARE" ] || return 0
+    [ ! -f "$M4_DONE" ] || return 0
+
+    if [ ! -f /usr/arduino/extra/program-m4.sh ]; then
+        echo "Portenta X8: M4 firmware found but program-m4.sh is missing"
+        return 1
+    fi
+
+    echo "Portenta X8: programming STM32H7 M4 firmware"
+    /bin/sh /usr/arduino/extra/program-m4.sh || return 1
+
+    mkdir -p "$(dirname "$M4_DONE")"
+    echo "programmed: $(date '+%Y-%m-%dT%H:%M:%S%z')" > "$M4_DONE"
+}
 
 case "$1" in
     start)
@@ -20,6 +38,8 @@ case "$1" in
 
         echo "Portenta X8: programming/checking STM32H7 firmware"
         /bin/sh /usr/arduino/extra/program-h7.sh || exit 1
+
+        program_m4_once || exit 1
 
         echo "Portenta X8: loading post-H7 IO modules"
         /bin/sh /usr/arduino/extra/load_modules_post.sh || exit 1

--- a/device-support/arduino-portenta-x8/yocto/meta-normacore-x8/recipes-kernel/linux-firmware/linux-firmware-arduino-portenta-x8-stm32h7_%.bbappend
+++ b/device-support/arduino-portenta-x8/yocto/meta-normacore-x8/recipes-kernel/linux-firmware/linux-firmware-arduino-portenta-x8-stm32h7_%.bbappend
@@ -1,0 +1,12 @@
+RDEPENDS:${PN}:append = " openocd"
+
+do_install:append() {
+    helper="${D}/usr/arduino/extra/program-m4.sh"
+    if [ -f "$helper" ]; then
+        sed -i \
+            -e '2i set -e' \
+            -e 's#/bin/openocd#/usr/bin/openocd#g' \
+            -e 's#/tmp/arduino/m4-user-sketch.elf#/opt/x8-firmware/m4-user-sketch.elf#g' \
+            "$helper"
+    fi
+}


### PR DESCRIPTION
Adds Portenta X8 image support for first-boot station startup, M4 PWM firmware flashing, and rootfs growth for compact flash images.