### PR TITLE
feat(station-viewer): add fullscreen thermal mirror with relative temperatures

### DIFF
--- a/software/station/clients/station-viewer/src/api/frame-parser.ts
+++ b/software/station/clients/station-viewer/src/api/frame-parser.ts
@@ -493,6 +493,25 @@ export async function parseFrame(
           };
         } catch (error) {
           console.error(`Failed to read entry from queue ${entry.queue}:`, error);
+          // Keep a live thermal surface mounted through a temporary queue-read
+          // failure, including native fullscreen and its last image. Retain the
+          // OLD pointer/data identity so the view can mark it stale and the next
+          // observation will retry the failed pointer. History stays exact.
+          if (entry.type === drivers.QueueDataType.QDT_HIKMICRO_THERMAL && options.shouldPublishVideoFrames?.()) {
+            const previous = previousFrame?.hikmicroThermal?.find(camera => camera.queueId === entry.queue);
+            if (previous) {
+              return {
+                queue: entry.queue,
+                type: entry.type,
+                ptr: previous.ptr,
+                decoded: previous.data,
+                rawData: previous.rawData ?? null,
+                id: null,
+                reused: true,
+                isNormvla: false,
+              };
+            }
+          }
           return null;
         }
       })();

--- a/software/station/clients/station-viewer/src/components/DeviceStatusBadge.tsx
+++ b/software/station/clients/station-viewer/src/components/DeviceStatusBadge.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react';
+
+const TONES = {
+  success: 'border-accent-success text-accent-success',
+  warning: 'border-accent-warning text-accent-warning',
+  critical: 'border-accent-critical text-accent-critical',
+};
+
+interface DeviceStatusBadgeProps {
+  tone: keyof typeof TONES;
+  children: ReactNode;
+}
+
+function DeviceStatusBadge({ tone, children }: DeviceStatusBadgeProps) {
+  return <span className={`inline-flex shrink-0 items-center rounded border px-1.5 py-0.5 text-[10px] font-semibold leading-4 uppercase ${TONES[tone]}`}>{children}</span>;
+}
+
+export default DeviceStatusBadge;

--- a/software/station/clients/station-viewer/src/components/DeviceWidgetShell.tsx
+++ b/software/station/clients/station-viewer/src/components/DeviceWidgetShell.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import DeviceStatusBadge from '@/components/DeviceStatusBadge';
 
 interface DeviceWidgetShellProps {
   title: string;
@@ -21,9 +22,9 @@ function DeviceWidgetShell({
           <div className="truncate font-mono text-[11px] text-text-muted" title={subtitle}>{subtitle}</div>
         </div>
         {error && (
-          <span className="rounded border border-accent-critical px-1.5 py-0.5 text-[10px] font-semibold uppercase text-accent-critical">
+          <DeviceStatusBadge tone="critical">
             Error
-          </span>
+          </DeviceStatusBadge>
         )}
       </div>
       {children}

--- a/software/station/clients/station-viewer/src/devices/hikmicro-thermal/thermal-renderer.ts
+++ b/software/station/clients/station-viewer/src/devices/hikmicro-thermal/thermal-renderer.ts
@@ -1,0 +1,113 @@
+import type { hikmicro } from '@/api/proto.js';
+import type { ThermalPalette, ThermalRenderResult } from './thermal';
+import type { ThermalRenderRequest, ThermalRenderResponse } from './thermal-worker-protocol';
+
+/** One in flight + one replaceable pending frame, regardless of stream duration. */
+export class ThermalFrameRenderer {
+  private worker: Worker | null = null;
+  private pending: ThermalRenderRequest | null = null;
+  private busy = false;
+  private disposed = false;
+  private timeout: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(
+    private readonly onFrame: (result: ThermalRenderResult) => void,
+    private readonly onError: (message: string) => void,
+  ) {}
+
+  render(envelope: hikmicro.IRxEnvelope, frame: hikmicro.IThermalFrame, palette: ThermalPalette): void {
+    if (this.disposed) return;
+    // Send only the displayed frame and calibration, not the entire frames block
+    // or redundant USB descriptors/calibration chunks. Input buffers stay owned
+    // by the shared frame parser; structured clone must not detach them.
+    const calibration = envelope.deviceInfo?.calibration;
+    this.pending = {
+      payload: frame.payload ?? new Uint8Array(),
+      deviceInfo: calibration ? { calibration: {
+        ok: calibration.ok,
+        error: calibration.error,
+        container: calibration.container,
+        factoryBlobOffset: calibration.factoryBlobOffset,
+        factoryBlobLength: calibration.factoryBlobLength,
+      } } : null,
+      palette,
+    };
+    this.pump();
+  }
+
+  private clearTimeout(): void {
+    if (this.timeout !== null) clearTimeout(this.timeout);
+    this.timeout = null;
+  }
+
+  private stopWorker(): void {
+    this.clearTimeout();
+    if (this.worker) {
+      this.worker.onmessage = null;
+      this.worker.onerror = null;
+      this.worker.onmessageerror = null;
+      this.worker.terminate();
+      this.worker = null;
+    }
+    this.busy = false;
+  }
+
+  private pump(): void {
+    if (this.disposed || this.busy || !this.pending) return;
+    try {
+      if (!this.worker) {
+        const worker = new Worker(new URL('./thermal.worker.ts', import.meta.url), { type: 'module' });
+        this.worker = worker;
+        const fail = (message: string) => {
+          if (this.worker !== worker || this.disposed) return;
+          this.stopWorker();
+          this.onError(message);
+          this.pump();
+        };
+        worker.onmessage = ({ data }: MessageEvent<ThermalRenderResponse>) => {
+          if (this.worker !== worker || this.disposed) return;
+          this.clearTimeout();
+          this.busy = false;
+          if (data.result) this.onFrame(data.result);
+          else this.onError(data.error ?? 'Thermal decoding failed');
+          this.pump();
+        };
+        worker.onerror = event => {
+          event.preventDefault();
+          fail('Thermal decoder interrupted. Reconnecting…');
+        };
+        worker.onmessageerror = () => fail('Thermal decoder response could not be read');
+      }
+      const request = this.pending;
+      this.pending = null;
+      this.busy = true;
+      const worker = this.worker;
+      this.timeout = setTimeout(() => {
+        if (this.worker !== worker || this.disposed) return;
+        this.stopWorker();
+        this.onError('Thermal decoder timed out. Reconnecting…');
+        this.pump();
+      }, 10000);
+      // Protobuf byte views often share the entire 25-frame envelope buffer.
+      // Compact only at dispatch (not for skipped pending frames), then transfer
+      // these owned copies without detaching the parser's original buffers.
+      const payload = Uint8Array.from(request.payload);
+      const calibration = request.deviceInfo?.calibration;
+      const container = calibration?.container ? Uint8Array.from(calibration.container) : null;
+      const deviceInfo = calibration ? { calibration: { ...calibration, container } } : null;
+      const transfer: Transferable[] = [payload.buffer];
+      if (container) transfer.push(container.buffer);
+      worker.postMessage({ ...request, payload, deviceInfo }, transfer);
+    } catch (error) {
+      this.pending = null;
+      this.stopWorker();
+      this.onError(error instanceof Error ? error.message : 'Thermal decoder unavailable');
+    }
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.pending = null;
+    this.stopWorker();
+  }
+}

--- a/software/station/clients/station-viewer/src/devices/hikmicro-thermal/thermal-worker-protocol.ts
+++ b/software/station/clients/station-viewer/src/devices/hikmicro-thermal/thermal-worker-protocol.ts
@@ -1,0 +1,13 @@
+import type { hikmicro } from '@/api/proto.js';
+import type { ThermalPalette, ThermalRenderResult } from './thermal';
+
+export interface ThermalRenderRequest {
+  payload: Uint8Array;
+  deviceInfo: hikmicro.IDeviceInfo | null;
+  palette: ThermalPalette;
+}
+
+export interface ThermalRenderResponse {
+  result: ThermalRenderResult | null;
+  error: string | null;
+}

--- a/software/station/clients/station-viewer/src/devices/hikmicro-thermal/thermal.ts
+++ b/software/station/clients/station-viewer/src/devices/hikmicro-thermal/thermal.ts
@@ -9,6 +9,11 @@ const FACTORY_BLOB_BYTES = 0x3800;
 const RESP_INV_NUMERATOR = 70368744177664;
 const KELVIN_OFFSET_Q8 = 0x11126;
 const KELVIN_OFFSET_Q12 = 0x111266;
+// Fixed-size scratch storage: cache conversions within a frame, never across
+// runtime calibration states. Decoding is synchronous (and runs in a Worker).
+const TEMPERATURE_CACHE = new Float32Array(0x10000);
+
+export type ThermalPalette = 'arctic' | 'iron' | 'silver';
 
 export interface ThermalRenderResult {
   width: number;
@@ -497,7 +502,7 @@ function calibrationBlob(deviceInfo: hikmicro.IDeviceInfo | null | undefined): U
   const offset = calibration.factoryBlobOffset ?? 0;
   const length = calibration.factoryBlobLength ?? 0;
   if (length === FACTORY_BLOB_BYTES && offset >= 0 && offset + length <= container.length) {
-    return container.slice(offset, offset + length);
+    return container.subarray(offset, offset + length);
   }
 
   if (container.length === FACTORY_BLOB_BYTES) {
@@ -523,15 +528,21 @@ function runtimeBlock(payload: Uint8Array): Uint8Array {
   if (payload.length < Y16_BYTES + APPEND_BYTES) {
     throw new Error(`short HIKMICRO runtime block: ${payload.length} bytes`);
   }
-  return payload.slice(Y16_BYTES, Y16_BYTES + APPEND_BYTES);
+  return payload.subarray(Y16_BYTES, Y16_BYTES + APPEND_BYTES);
 }
 
 function temperatureMap(y16: Uint16Array, state: TemperatureState): Float32Array {
   const values = new Float32Array(y16.length);
+  TEMPERATURE_CACHE.fill(Number.NaN);
   for (let i = 0; i < y16.length; i += 1) {
-    const bb = blackbodyCQ12FromGray(state, y16[i]);
-    const obj = objectCQ6FromBbQ12(state, bb);
-    values[i] = obj / 64.0;
+    const gray = y16[i];
+    let temperature = TEMPERATURE_CACHE[gray];
+    if (Number.isNaN(temperature)) {
+      const bb = blackbodyCQ12FromGray(state, gray);
+      temperature = objectCQ6FromBbQ12(state, bb) / 64.0;
+      TEMPERATURE_CACHE[gray] = temperature;
+    }
+    values[i] = temperature;
   }
   return values;
 }
@@ -601,15 +612,38 @@ function palette(value: number, lo: number, hi: number): [number, number, number
   ];
 }
 
-function toRgba(values: Float32Array, lo: number, hi: number): Uint8ClampedArray {
+const ARCTIC_STOPS = [
+  [57, 70, 157], [45, 139, 212], [75, 207, 216], [174, 238, 208], [255, 236, 135],
+];
+
+function toRgba(values: Float32Array, lo: number, hi: number, paletteName: ThermalPalette): Uint8ClampedArray {
   const rgba = new Uint8ClampedArray(values.length * 4);
+  const span = hi > lo ? hi - lo : 1;
   for (let i = 0; i < values.length; i += 1) {
     const value = values[i];
-    const [r, g, b] = Number.isFinite(value) ? palette(value, lo, hi) : [0, 0, 0];
     const j = i * 4;
-    rgba[j] = r;
-    rgba[j + 1] = g;
-    rgba[j + 2] = b;
+    if (!Number.isFinite(value)) {
+      rgba[j] = rgba[j + 1] = rgba[j + 2] = 241;
+    } else if (paletteName === 'iron') {
+      const [r, g, b] = palette(value, lo, hi);
+      rgba[j] = r;
+      rgba[j + 1] = g;
+      rgba[j + 2] = b;
+    } else {
+      const t = Math.max(0, Math.min(1, (value - lo) / span));
+      if (paletteName === 'silver') {
+        const gray = Math.round(65 + t * 190);
+        rgba[j] = rgba[j + 1] = rgba[j + 2] = gray;
+      } else {
+        const position = t * (ARCTIC_STOPS.length - 1);
+        const index = Math.min(Math.floor(position), ARCTIC_STOPS.length - 2);
+        const fraction = position - index;
+        for (let channel = 0; channel < 3; channel++) {
+          rgba[j + channel] = Math.round(ARCTIC_STOPS[index][channel] +
+            (ARCTIC_STOPS[index + 1][channel] - ARCTIC_STOPS[index][channel]) * fraction);
+        }
+      }
+    }
     rgba[j + 3] = 255;
   }
   return rgba;
@@ -618,6 +652,7 @@ function toRgba(values: Float32Array, lo: number, hi: number): Uint8ClampedArray
 export function renderThermalFrame(
   envelope: hikmicro.IRxEnvelope,
   frame: hikmicro.IThermalFrame,
+  paletteName: ThermalPalette = 'iron',
 ): ThermalRenderResult {
   let error: string | null = null;
   const payload = frame.payload ?? new Uint8Array();
@@ -648,7 +683,7 @@ export function renderThermalFrame(
   return {
     width: SENSOR_WIDTH,
     height: SENSOR_HEIGHT,
-    rgba: toRgba(map, lo, hi),
+    rgba: toRgba(map, lo, hi, paletteName),
     minC: usedCalibration ? stats.min : null,
     maxC: usedCalibration ? stats.max : null,
     centerC: usedCalibration ? stats.center : null,
@@ -684,4 +719,13 @@ export function formatCelsius(value: number | null): string {
     return 'N/A';
   }
   return `${value.toFixed(1)} C`;
+}
+
+export function formatTemperatureDelta(value: number | null, reference: number | null): string {
+  if (value === null || reference === null || !Number.isFinite(value) || !Number.isFinite(reference)) {
+    return '—';
+  }
+  const delta = Math.round((value - reference) * 10) / 10;
+  const sign = delta > 0 ? '+' : delta < 0 ? '−' : '';
+  return `${sign}${Math.abs(delta).toFixed(1)} °C`;
 }

--- a/software/station/clients/station-viewer/src/devices/hikmicro-thermal/thermal.worker.ts
+++ b/software/station/clients/station-viewer/src/devices/hikmicro-thermal/thermal.worker.ts
@@ -1,0 +1,17 @@
+import { renderThermalFrame } from './thermal';
+import type { ThermalRenderRequest, ThermalRenderResponse } from './thermal-worker-protocol';
+
+// Keep the worker independent of protobuf runtime and React.
+const worker = self as unknown as {
+  onmessage: (event: MessageEvent<ThermalRenderRequest>) => void;
+  postMessage: (message: ThermalRenderResponse, transfer: Transferable[]) => void;
+};
+
+worker.onmessage = ({ data }) => {
+  try {
+    const result = renderThermalFrame({ deviceInfo: data.deviceInfo }, { payload: data.payload }, data.palette);
+    worker.postMessage({ result, error: null }, [result.rgba.buffer]);
+  } catch (error) {
+    worker.postMessage({ result: null, error: error instanceof Error ? error.message : 'Thermal decoding failed' }, []);
+  }
+};

--- a/software/station/clients/station-viewer/src/devices/hikmicro-thermal/ui/HikmicroThermalLiveView.tsx
+++ b/software/station/clients/station-viewer/src/devices/hikmicro-thermal/ui/HikmicroThermalLiveView.tsx
@@ -1,111 +1,119 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { FlipHorizontal2, Maximize2, Minimize2 } from 'lucide-react';
 import type { hikmicro } from '@/api/proto.js';
-import {
-  formatCelsius,
-  hikmicroDeviceLabel,
-  latestThermalFrame,
-  renderThermalFrame,
-} from '../thermal';
+import DeviceStatusBadge from '@/components/DeviceStatusBadge';
+import { useElementFullscreen } from '@/hooks';
+import { isElectron } from '@/utils/platform';
+import { formatTemperatureDelta, hikmicroDeviceLabel, latestThermalFrame, type ThermalPalette } from '../thermal';
+import { useThermalPreview } from './useThermalPreview';
+// oxlint-disable-next-line import/no-unassigned-import -- Load styles with this lazy device view.
+import './thermal-mirror.css';
 
-export interface HikmicroThermalLiveViewProps {
-  data: hikmicro.IRxEnvelope;
-}
+export interface HikmicroThermalLiveViewProps { data: hikmicro.IRxEnvelope; }
 
-function Metric({ label, value, tone = 'text-accent-data' }: {
-  label: string;
-  value: string;
-  tone?: string;
-}) {
-  return (
-    <div className="min-w-0 rounded border border-border-default bg-surface-primary px-2 py-1.5">
-      <div className="text-[10px] uppercase text-text-label">{label}</div>
-      <div className={`truncate font-mono text-sm font-semibold ${tone}`}>{value}</div>
-    </div>
-  );
+function Metric({ label, value, tone }: { label: string; value: string; tone?: string }) {
+  return <div className="thermal-mirror__metric" data-tone={tone}><dt>{label}</dt><dd>{value}</dd></div>;
 }
 
 function HikmicroThermalLiveView({ data }: HikmicroThermalLiveViewProps) {
+  const surfaceRef = useRef<HTMLElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const { isFullscreen, toggleFullscreen } = useElementFullscreen(surfaceRef);
+  const [mirrored, setMirrored] = useState(true);
+  const [palette, setPalette] = useState<ThermalPalette>('arctic');
   const frame = latestThermalFrame(data);
-  const rendered = useMemo(() => {
-    if (!frame) {
-      return null;
-    }
-    return renderThermalFrame(data, frame);
-  }, [data, frame]);
+  const { stats, stale, error } = useThermalPreview(data, frame, palette, canvasRef);
+  const label = hikmicroDeviceLabel(data, 'HIKMICRO');
+  const available = Boolean(stats && !stale && !error);
+  const reference = available ? stats!.avgC : null;
+  const delta = (value: number | null | undefined) => formatTemperatureDelta(available ? value ?? null : null, reference);
+  const status = error ? 'RECOVERING' : stale ? 'SIGNAL DELAYED' : stats ? 'LIVE' : 'CONNECTING';
+  const fullscreenLabel = isFullscreen ? 'Exit thermal fullscreen' : 'Fullscreen thermal camera';
 
   useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas || !rendered) {
-      return;
-    }
-    canvas.width = rendered.width;
-    canvas.height = rendered.height;
-    const ctx = canvas.getContext('2d');
-    if (!ctx) {
-      return;
-    }
-    const imageData = ctx.createImageData(rendered.width, rendered.height);
-    imageData.data.set(rendered.rgba);
-    ctx.putImageData(imageData, 0, 0);
-  }, [rendered]);
+    try {
+      const saved = JSON.parse(localStorage.getItem(`thermal-mirror:${label}`) ?? 'null');
+      if (saved?.palette === 'arctic' || saved?.palette === 'silver' || saved?.palette === 'iron') setPalette(saved.palette);
+      if (typeof saved?.mirrored === 'boolean') setMirrored(saved.mirrored);
+    } catch { /* Optional preferences; outdoor defaults still work. */ }
+  }, [label]);
 
-  const label = hikmicroDeviceLabel(data, 'HIKMICRO Thermal');
-  const thermalWidth = rendered?.width ?? 256;
-  const thermalHeight = rendered?.height ?? 192;
+  const changePalette = (next: ThermalPalette) => {
+    setPalette(next);
+    try { localStorage.setItem(`thermal-mirror:${label}`, JSON.stringify({ palette: next, mirrored })); } catch { /* Optional preference. */ }
+  };
+  const changeMirror = () => {
+    setMirrored(!mirrored);
+    try { localStorage.setItem(`thermal-mirror:${label}`, JSON.stringify({ palette, mirrored: !mirrored })); } catch { /* Optional preference. */ }
+  };
+  const controls = <div className="thermal-mirror__controls">
+    <button type="button" onClick={changeMirror} aria-pressed={mirrored} aria-label="Mirror thermal image" title="Mirror thermal image"><FlipHorizontal2 aria-hidden="true" /></button>
+    <button type="button" onClick={() => void toggleFullscreen()} aria-label={fullscreenLabel} title={fullscreenLabel}>
+      {isFullscreen ? <Minimize2 aria-hidden="true" /> : <Maximize2 aria-hidden="true" />}
+    </button>
+  </div>;
 
   return (
-    <section className="w-fit max-w-full overflow-hidden rounded-md border border-border-default bg-surface-secondary shadow-sm">
-      <div className="flex min-w-0 flex-wrap items-center justify-between gap-2 border-b border-border-default px-3 py-2">
-        <div className="min-w-0">
-          <div className="truncate text-sm font-semibold text-text-primary" title={label}>
-            {label}
-          </div>
-          <div className="truncate font-mono text-[11px] text-text-muted">
-            {thermalWidth}x{thermalHeight}
-            {' / '}
-            {data.deviceInfo?.streamFormat?.framesPerSecond?.toFixed(1) ?? '25.0'} FPS
-          </div>
-        </div>
-        <div className={`rounded border px-2 py-1 text-xs font-semibold ${
-          rendered?.usedCalibration
-            ? 'border-accent-success text-accent-success'
-            : 'border-accent-warning text-accent-warning'
-        }`}>
-          {rendered?.usedCalibration ? 'CALIBRATED' : 'RAW'}
-        </div>
-      </div>
-
-      <div className="space-y-3 p-3">
-        <div className="relative overflow-hidden rounded bg-black">
-          {rendered ? (
-            <canvas
-              ref={canvasRef}
-              className="block select-none [image-rendering:pixelated]"
-              aria-label="HIKMICRO thermal frame"
-            />
-          ) : (
-            <div className="flex h-full items-center justify-center p-4 text-sm text-text-secondary">
-              Waiting for HIKMICRO frame data...
+    <section ref={surfaceRef} aria-label="Thermal mirror" className="thermal-mirror" data-fullscreen={isFullscreen}>
+      <header className="thermal-mirror__header">
+        {isFullscreen && <img className="thermal-mirror__brand" src={isElectron() ? './logo_with_text.svg' : '/logo_with_text.svg'} alt="NormaCore" width={2248} height={1137} />}
+        {isFullscreen ? <div className="thermal-mirror__identity">
+          <div className="thermal-mirror__eyebrow">HIKMICRO <span>/</span> INTERACTIVE</div>
+          <h2>Thermal mirror<span className="thermal-mirror__delta">Δ</span></h2>
+        </div> : <>
+          <div className="min-w-0">
+            <div className="truncate text-sm font-semibold text-text-primary" title={label}>{label}</div>
+            <div className="truncate font-mono text-[11px] text-text-muted">
+              {stats?.width ?? 256}x{stats?.height ?? 192}
+              {' / '}{data.deviceInfo?.streamFormat?.framesPerSecond?.toFixed(1) ?? '25.0'} FPS
             </div>
-          )}
-        </div>
-
-        <div className="grid grid-cols-2 gap-2">
-          <Metric label="Center" value={formatCelsius(rendered?.centerC ?? null)} tone="text-accent-warning" />
-          <Metric label="Average" value={formatCelsius(rendered?.avgC ?? null)} />
-          <Metric label="Min" value={formatCelsius(rendered?.minC ?? null)} tone="text-accent-info" />
-          <Metric label="Max" value={formatCelsius(rendered?.maxC ?? null)} tone="text-accent-critical" />
-        </div>
-
-        {rendered?.error && (
-          <div className="rounded border border-accent-warning bg-surface-primary p-2 text-xs text-accent-warning">
-            {rendered.error}
           </div>
-        )}
+          <DeviceStatusBadge tone={stats?.usedCalibration ? 'success' : 'warning'}>
+            {stats?.usedCalibration ? 'CALIBRATED' : 'RAW'}
+          </DeviceStatusBadge>
+        </>}
+        {isFullscreen && controls}
+      </header>
+      <div className="thermal-mirror__body">
+        <div className="thermal-mirror__view">
+          <div className="thermal-mirror__image" data-ready={Boolean(stats)}>
+            <canvas ref={canvasRef} width={256} height={192} className="thermal-mirror__canvas" data-mirrored={mirrored} aria-label="HIKMICRO thermal frame" />
+            {!isFullscreen && controls}
+            {isFullscreen && available && <span className="thermal-mirror__crosshair" aria-hidden="true" />}
+            {!available && <div className="thermal-mirror__notice" data-stale={Boolean(stats)} role="status">
+              <strong>{stats ? 'Signal delayed · showing last frame' : 'Connecting to thermal camera'}</strong>
+              <span>{error || stats ? 'The image will resume automatically.' : 'The first frame can take a little while.'}</span>
+            </div>}
+          </div>
+        </div>
+        <aside className="thermal-mirror__readings">
+          <div className="thermal-mirror__relative">{isFullscreen && <span className="thermal-mirror__eyebrow">TEMPERATURE DIFFERENCE</span>}<p>Δ relative to the frame average</p></div>
+          <dl className="thermal-mirror__metrics">
+            <Metric label="Center Δ" value={delta(stats?.centerC)} tone="warning" />
+            {!isFullscreen && <Metric label="Average Δ" value={delta(stats?.avgC)} />}
+            <Metric label={isFullscreen ? 'Coolest Δ' : 'Min Δ'} value={delta(stats?.minC)} tone="info" />
+            <Metric label={isFullscreen ? 'Warmest Δ' : 'Max Δ'} value={delta(stats?.maxC)} tone="critical" />
+          </dl>
+          {isFullscreen && <><div className="thermal-mirror__scale" data-palette={palette}>
+            <div className="thermal-mirror__scale-bar" aria-hidden="true" />
+            <div className="thermal-mirror__scale-labels"><span>Cooler</span><span>Warmer</span></div>
+          </div>
+          <fieldset className="thermal-mirror__palettes">
+            <legend>Palette</legend>
+            {(['arctic', 'silver', 'iron'] as const).map(name => <button type="button" key={name} aria-pressed={palette === name} onClick={() => changePalette(name)}>
+              <span className="thermal-mirror__swatch" data-palette={name} aria-hidden="true" />
+              {name === 'arctic' ? 'Arctic' : name === 'silver' ? 'Silver' : 'Iron'}
+            </button>)}
+          </fieldset></>}
+          {(isFullscreen || (stats && !stats.usedCalibration)) && <p className="thermal-mirror__note">{stats && !stats.usedCalibration ? 'Relative readings unavailable. Showing heat contrast.' : 'Explore heat differences. Not a body temperature measurement.'}</p>}
+        </aside>
       </div>
+      {isFullscreen && <footer className="thermal-mirror__footer">
+        <span className="thermal-mirror__status" data-live={available}><i aria-hidden="true" />{status}</span>
+        <span className="thermal-mirror__device" title={label}>{label}</span>
+        <span className="thermal-mirror__resolution">256 × 192</span>
+      </footer>}
     </section>
   );
 }
-
 export default HikmicroThermalLiveView;

--- a/software/station/clients/station-viewer/src/devices/hikmicro-thermal/ui/thermal-mirror.css
+++ b/software/station/clients/station-viewer/src/devices/hikmicro-thermal/ui/thermal-mirror.css
@@ -1,0 +1,146 @@
+/* The compact card follows the station; the fullscreen outdoor mirror stays light. */
+.thermal-mirror {
+  --thermal-ink: var(--color-text-primary);
+  --thermal-muted: var(--color-text-muted);
+  --thermal-accent: var(--color-accent-data);
+  --thermal-line: var(--color-border-default);
+  color: var(--thermal-ink);
+  background: var(--color-surface-secondary);
+  width: 282px;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--thermal-line);
+  border-radius: 6px;
+  box-shadow: 0 1px 3px #0000001a, 0 1px 2px #0000001a;
+}
+.thermal-mirror:fullscreen {
+  --thermal-ink: #12323d;
+  --thermal-muted: #48616a;
+  --thermal-accent: #006c78;
+  --thermal-line: #c7dade;
+  color-scheme: light;
+  color: var(--thermal-ink);
+  background: #fff;
+  box-shadow: none;
+}
+.thermal-mirror__header { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 12px; }
+.thermal-mirror__identity { min-width: 0; }
+.thermal-mirror__eyebrow { font: 650 9px ui-monospace, monospace; letter-spacing: .08em; color: var(--thermal-muted); }
+.thermal-mirror__eyebrow span { padding: 0 5px; color: var(--thermal-accent); }
+.thermal-mirror h2 { margin: 3px 0 0; font-size: 20px; font-weight: 650; letter-spacing: -.05em; line-height: 1.15; }
+.thermal-mirror__delta { margin-left: 8px; color: var(--thermal-accent); font-weight: 400; }
+.thermal-mirror__controls { display: flex; gap: 8px; flex-shrink: 0; }
+.thermal-mirror button { cursor: pointer; color: var(--thermal-ink); border: 1px solid var(--thermal-line); background: #fff; border-radius: 8px; transition: background 120ms ease, border-color 120ms ease; }
+.thermal-mirror button:hover { background: #eef9f9; border-color: var(--thermal-accent); }
+.thermal-mirror button:focus-visible { outline: 3px solid #008b9b; outline-offset: 3px; }
+.thermal-mirror button[aria-pressed="true"] { background: #e0f6f4; border-color: var(--thermal-accent); color: #005c66; }
+.thermal-mirror__controls button { width: 44px; height: 44px; display: grid; place-items: center; }
+.thermal-mirror__controls svg { width: 19px; height: 19px; }
+.thermal-mirror__body { min-height: 0; }
+.thermal-mirror__view { display: flex; align-items: center; justify-content: center; padding: 0 12px; min-height: 0; }
+.thermal-mirror__image { width: 100%; aspect-ratio: 4 / 3; position: relative; overflow: hidden; border-radius: 6px; background: #edf5f6; }
+.thermal-mirror__canvas { display: block; width: 100%; height: 100%; object-fit: contain; image-rendering: pixelated; }
+.thermal-mirror__canvas[data-mirrored="true"] { transform: scaleX(-1); }
+.thermal-mirror__image[data-ready="false"] .thermal-mirror__canvas { visibility: hidden; }
+.thermal-mirror__crosshair { position: absolute; left: 50%; top: 50%; width: 22px; height: 22px; transform: translate(-50%, -50%); border: 1px solid #fff; border-radius: 50%; box-shadow: 0 0 0 1px #12323d; pointer-events: none; }
+.thermal-mirror__crosshair::after { content: ''; position: absolute; inset: 8px; border-radius: 50%; background: #fff; box-shadow: 0 0 0 1px #12323d; }
+.thermal-mirror__notice { position: absolute; inset: 0; display: flex; flex-direction: column; justify-content: center; align-items: center; gap: 8px; padding: 24px; text-align: center; background: #f1f8f8ed; }
+.thermal-mirror__notice strong { font-size: 16px; font-weight: 600; }
+.thermal-mirror__notice span { font-size: 12px; color: var(--thermal-muted); }
+.thermal-mirror__notice[data-stale="true"] { top: auto; padding: 10px; gap: 2px; }
+.thermal-mirror__notice[data-stale="true"] strong { font-size: 12px; }
+.thermal-mirror__notice[data-stale="true"] span { font-size: 10px; }
+.thermal-mirror__readings { padding: 12px; }
+.thermal-mirror__relative p { margin: 4px 0 0; font-size: 12px; color: var(--thermal-muted); }
+.thermal-mirror__metrics { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); margin: 14px 0; }
+.thermal-mirror__metric + .thermal-mirror__metric { border-left: 1px solid var(--thermal-line); padding-left: 8px; }
+.thermal-mirror__metric dt { color: var(--thermal-muted); font-size: 10px; text-transform: uppercase; letter-spacing: .06em; }
+.thermal-mirror__metric dd { margin: 5px 0 0; font-family: ui-monospace, monospace; font-size: 18px; font-weight: 650; letter-spacing: -.065em; white-space: nowrap; }
+.thermal-mirror__scale-bar { height: 8px; border-radius: 2px; }
+.thermal-mirror [data-palette="arctic"] { --thermal-palette: linear-gradient(90deg, #39469d, #2d8bd4, #4bcfd8, #aeeed0, #ffec87); }
+.thermal-mirror [data-palette="silver"] { --thermal-palette: linear-gradient(90deg, #414141, #fff); }
+.thermal-mirror [data-palette="iron"] { --thermal-palette: linear-gradient(90deg, #590000, #ff140a, #ffb80a, #ffff3d); }
+.thermal-mirror__scale-bar, .thermal-mirror__swatch { background: var(--thermal-palette); }
+.thermal-mirror__scale-labels { display: flex; justify-content: space-between; margin-top: 5px; font-size: 10px; color: var(--thermal-muted); }
+.thermal-mirror__palettes { display: flex; gap: 6px; margin: 18px 0 0; padding: 0; border: 0; }
+.thermal-mirror__palettes legend { position: absolute; width: 1px; height: 1px; overflow: hidden; clip-path: inset(50%); }
+.thermal-mirror__palettes button { display: flex; flex: 1; align-items: center; justify-content: center; gap: 6px; min-height: 44px; padding: 8px; font-size: 12px; font-weight: 600; }
+.thermal-mirror__swatch { width: 14px; height: 14px; flex-shrink: 0; border-radius: 50%; border: 1px solid #b4c6cc; }
+.thermal-mirror__note { margin: 12px 0 0; color: var(--thermal-muted); font-size: 11px; line-height: 1.5; }
+.thermal-mirror__footer { display: flex; gap: 12px; align-items: center; padding: 10px 12px; border-top: 1px solid var(--thermal-line); background: #f4f9f9; font: 10px ui-monospace, monospace; color: var(--thermal-muted); }
+.thermal-mirror__status { display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; color: #825408; font-weight: 700; letter-spacing: .04em; }
+.thermal-mirror__status[data-live="true"] { color: var(--thermal-accent); }
+.thermal-mirror__status i { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+.thermal-mirror__device { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; margin-left: auto; }
+.thermal-mirror__resolution { display: none; white-space: nowrap; }
+.thermal-mirror:not(:fullscreen) .thermal-mirror__header { flex-wrap: wrap; align-items: flex-start; padding: 8px 12px; border-bottom: 1px solid var(--thermal-line); }
+.thermal-mirror:not(:fullscreen) .thermal-mirror__view { padding: 12px 12px 0; }
+.thermal-mirror:not(:fullscreen) .thermal-mirror__image { border-radius: 4px; }
+.thermal-mirror:not(:fullscreen) .thermal-mirror__controls { position: absolute; top: 8px; right: 8px; z-index: 1; gap: 4px; }
+.thermal-mirror:not(:fullscreen) button { background: var(--color-surface-primary); border-radius: 4px; }
+.thermal-mirror:not(:fullscreen) button[aria-pressed="true"] { color: var(--color-accent-data); border-color: var(--color-accent-data); }
+.thermal-mirror:not(:fullscreen) .thermal-mirror__readings { padding: 12px; }
+.thermal-mirror:not(:fullscreen) .thermal-mirror__relative p { margin: 0 0 8px; font-size: 10px; }
+.thermal-mirror:not(:fullscreen) .thermal-mirror__metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; margin: 0; }
+.thermal-mirror:not(:fullscreen) .thermal-mirror__metric { min-width: 0; padding: 6px 8px; border: 1px solid var(--thermal-line); border-radius: 4px; background: var(--color-surface-primary); }
+.thermal-mirror:not(:fullscreen) .thermal-mirror__metric dt { color: var(--color-text-label); font-size: 10px; letter-spacing: normal; }
+.thermal-mirror:not(:fullscreen) .thermal-mirror__metric dd { overflow: hidden; text-overflow: ellipsis; margin: 0; font-size: 14px; font-weight: 600; line-height: 20px; letter-spacing: normal; color: var(--color-accent-data); }
+.thermal-mirror:not(:fullscreen) [data-tone="warning"] dd { color: var(--color-accent-warning); }
+.thermal-mirror:not(:fullscreen) [data-tone="info"] dd { color: var(--color-accent-info); }
+.thermal-mirror:not(:fullscreen) [data-tone="critical"] dd { color: var(--color-accent-critical); }
+.thermal-mirror:not(:fullscreen) .thermal-mirror__notice { background: var(--color-surface-secondary); }
+.thermal-mirror:fullscreen { width: 100%; height: 100dvh; max-width: none; border: 0; border-radius: 0; display: flex; flex-direction: column; }
+.thermal-mirror::backdrop { background: #fff; }
+.thermal-mirror:fullscreen .thermal-mirror__header { padding: 20px 28px; gap: 24px; flex-shrink: 0; }
+.thermal-mirror__brand { display: block; width: 120px; height: auto; flex-shrink: 0; filter: brightness(0); }
+.thermal-mirror:fullscreen .thermal-mirror__identity { flex: 1; }
+.thermal-mirror:fullscreen h2 { font-size: 30px; }
+.thermal-mirror:fullscreen .thermal-mirror__resolution { display: inline; }
+.thermal-mirror:fullscreen .thermal-mirror__body { flex: 1; display: grid; grid-template-columns: minmax(0, 1fr) 280px; }
+.thermal-mirror:fullscreen .thermal-mirror__view { padding: 0 24px 24px; container-type: size; }
+.thermal-mirror:fullscreen .thermal-mirror__image { width: min(100cqw, calc(100cqh * 4 / 3)); max-height: 100%; }
+.thermal-mirror:fullscreen .thermal-mirror__readings { border-left: 1px solid var(--thermal-line); padding: 28px 24px; overflow: auto; }
+.thermal-mirror:fullscreen .thermal-mirror__metrics { grid-template-columns: 1fr; gap: 28px; margin: 28px 0; }
+.thermal-mirror:fullscreen .thermal-mirror__metric + .thermal-mirror__metric { border-left: 0; padding-left: 0; }
+.thermal-mirror:fullscreen .thermal-mirror__metric dd { font-size: 40px; }
+.thermal-mirror:fullscreen .thermal-mirror__metric dt { font-size: 12px; }
+.thermal-mirror:fullscreen .thermal-mirror__footer { flex-shrink: 0; }
+@media (max-width: 480px) {
+  .thermal-mirror__header { padding: 16px; gap: 8px; }
+  .thermal-mirror__eyebrow { font-size: 9px; }
+  .thermal-mirror__readings { padding: 16px; }
+  .thermal-mirror__metric + .thermal-mirror__metric { padding-left: 8px; }
+  .thermal-mirror__metric dd { font-size: 18px; }
+  .thermal-mirror__resolution { display: none; }
+  .thermal-mirror__footer { padding: 12px 16px; }
+  .thermal-mirror:fullscreen .thermal-mirror__header { gap: 12px; }
+  .thermal-mirror:fullscreen .thermal-mirror__brand { width: 80px; }
+  .thermal-mirror:fullscreen .thermal-mirror__identity .thermal-mirror__eyebrow { display: none; }
+  .thermal-mirror:fullscreen h2 { font-size: 18px; }
+}
+@media (orientation: portrait) {
+  .thermal-mirror:fullscreen .thermal-mirror__header { padding: 16px; }
+  .thermal-mirror:fullscreen .thermal-mirror__body { display: flex; flex-direction: column; }
+  .thermal-mirror:fullscreen .thermal-mirror__view { flex: 1; padding: 0 16px; }
+  .thermal-mirror:fullscreen .thermal-mirror__readings { border-left: 0; padding: 16px; flex-shrink: 0; }
+  .thermal-mirror:fullscreen .thermal-mirror__metrics { grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; margin: 14px 0; }
+  .thermal-mirror:fullscreen .thermal-mirror__metric dd { font-size: clamp(18px, 5vw, 32px); }
+  .thermal-mirror:fullscreen .thermal-mirror__metric dt { font-size: 10px; }
+}
+@media (max-height: 540px) and (orientation: landscape) {
+  .thermal-mirror:fullscreen .thermal-mirror__header { padding: 8px 16px; }
+  .thermal-mirror:fullscreen .thermal-mirror__brand { width: 88px; }
+  .thermal-mirror:fullscreen .thermal-mirror__header h2 { font-size: 22px; }
+  .thermal-mirror:fullscreen .thermal-mirror__body { grid-template-columns: minmax(0, 1fr) 240px; }
+  .thermal-mirror:fullscreen .thermal-mirror__readings { padding: 8px 16px; }
+  .thermal-mirror:fullscreen .thermal-mirror__metrics { gap: 8px; margin: 10px 0; }
+  .thermal-mirror:fullscreen .thermal-mirror__metric { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+  .thermal-mirror:fullscreen .thermal-mirror__metric dt { font-size: 10px; }
+  .thermal-mirror:fullscreen .thermal-mirror__metric dd { font-size: 24px; line-height: 1.2; margin-top: 0; }
+  .thermal-mirror:fullscreen .thermal-mirror__palettes { margin-top: 8px; }
+  .thermal-mirror:fullscreen .thermal-mirror__palettes button { font-size: 11px; }
+  .thermal-mirror:fullscreen .thermal-mirror__note { margin-top: 6px; font-size: 10px; }
+  .thermal-mirror:fullscreen .thermal-mirror__footer { padding: 6px 16px; }
+}
+@media (prefers-reduced-motion: reduce) { .thermal-mirror button { transition: none; } }

--- a/software/station/clients/station-viewer/src/devices/hikmicro-thermal/ui/useThermalPreview.ts
+++ b/software/station/clients/station-viewer/src/devices/hikmicro-thermal/ui/useThermalPreview.ts
@@ -1,0 +1,81 @@
+import { useEffect, useRef, useState, type RefObject } from 'react';
+import type { hikmicro } from '@/api/proto.js';
+import { ThermalFrameRenderer } from '../thermal-renderer';
+import type { ThermalPalette, ThermalRenderResult } from '../thermal';
+
+type ThermalStats = Omit<ThermalRenderResult, 'rgba'>;
+
+export function useThermalPreview(data: hikmicro.IRxEnvelope, frame: hikmicro.IThermalFrame | null, palette: ThermalPalette, canvasRef: RefObject<HTMLCanvasElement | null>) {
+  const rendererRef = useRef<ThermalFrameRenderer | null>(null);
+  const latestRef = useRef({ data, frame, palette });
+  const lastInputAtRef = useRef(performance.now());
+  const [stats, setStats] = useState<ThermalStats | null>(null);
+  const [stale, setStale] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (latestRef.current.frame !== frame) lastInputAtRef.current = performance.now();
+    latestRef.current = { data, frame, palette };
+    if (frame) rendererRef.current?.render(data, frame, palette);
+  }, [data, frame, palette]);
+
+  useEffect(() => {
+    let animation: number | null = null;
+    let pending: ThermalRenderResult | null = null;
+    let lastStatsAt = -Infinity;
+    const stop = () => {
+      rendererRef.current?.dispose();
+      rendererRef.current = null;
+      if (animation !== null) cancelAnimationFrame(animation);
+      animation = null;
+      pending = null;
+    };
+    const syncVisibility = () => {
+      stop();
+      if (document.visibilityState === 'hidden') return;
+      lastStatsAt = -Infinity;
+      rendererRef.current = new ThermalFrameRenderer(result => {
+        pending = result;
+        if (animation !== null) return;
+        animation = requestAnimationFrame(() => {
+          animation = null;
+          const rendered = pending;
+          pending = null;
+          const canvas = canvasRef.current;
+          if (!canvas || !rendered) return;
+          if (canvas.width !== rendered.width) canvas.width = rendered.width;
+          if (canvas.height !== rendered.height) canvas.height = rendered.height;
+          const ctx = canvas.getContext('2d', { alpha: false });
+          if (!ctx) { setError('Canvas unavailable'); return; }
+          // Transferred pixels are already owned by this thread: no extra pixel
+          // copy and no canvas backing-store reset on every frame.
+          ctx.putImageData(new ImageData(rendered.rgba as Uint8ClampedArray<ArrayBuffer>, rendered.width, rendered.height), 0, 0);
+          setError(null);
+          const now = performance.now();
+          setStale(now - lastInputAtRef.current > 5000);
+          if (now - lastStatsAt >= 250) {
+            const { rgba: _rgba, ...nextStats } = rendered;
+            setStats(nextStats);
+            lastStatsAt = now;
+          }
+        });
+      }, message => {
+        if (animation !== null) cancelAnimationFrame(animation);
+        animation = null;
+        pending = null;
+        setError(message);
+      });
+      const latest = latestRef.current;
+      if (latest.frame) rendererRef.current.render(latest.data, latest.frame, latest.palette);
+    };
+    syncVisibility();
+    document.addEventListener('visibilitychange', syncVisibility);
+    const freshnessTimer = setInterval(() => setStale(performance.now() - lastInputAtRef.current > 5000), 1000);
+    return () => {
+      stop();
+      clearInterval(freshnessTimer);
+      document.removeEventListener('visibilitychange', syncVisibility);
+    };
+  }, [canvasRef]);
+  return { stats, stale, error };
+}


### PR DESCRIPTION
# Info

Add an outdoor thermal mirror mode for HIKMICRO cameras. Keep the compact widget’s existing layout, with buttons for fullscreen and mirroring. Fullscreen uses a light interface with NormaCore branding and three selectable palettes.

Temperature readings now show deltas relative to the current frame average. Status badges share consistent sizing across device widgets.

Move thermal rendering into a Worker with one active frame and one replaceable pending frame. Reduce buffer copying, recover from decoder timeouts, and pause rendering in hidden tabs. Live read failures preserve the last frame with a stale indicator; history reads remain exact.
