### PR TITLE
fix(thermal): reduce frame batching latency and decouple live acquisition

### DIFF
--- a/software/drivers/hikmicro-thermal/src/linux.rs
+++ b/software/drivers/hikmicro-thermal/src/linux.rs
@@ -24,7 +24,8 @@ const XU_UNIT_ID: u8 = 10;
 const XU_INTERFACE: u8 = 0;
 const XU_W_INDEX: u16 = (XU_UNIT_ID as u16) << 8;
 const USB_TIMEOUT_MS: u32 = 1_000;
-const FRAMES_PER_RX_ENVELOPE: usize = 25;
+// Publish each captured frame immediately for the live thermal mirror.
+const FRAMES_PER_RX_ENVELOPE: usize = 1;
 const SHORT_FRAME_LOG_INTERVAL: Duration = Duration::from_secs(5);
 
 /// `frame_skip` is the number of frames dropped after each kept frame,

--- a/software/station/clients/station-viewer/src/api/frame-parser.ts
+++ b/software/station/clients/station-viewer/src/api/frame-parser.ts
@@ -57,6 +57,7 @@ type DecodedEntry = st3215.IInferenceState | st3215.ITxEnvelope | usbvideo.IRxEn
 
 interface ParseFrameOptions {
   retainRawData?: boolean;
+  thermalDiscoveryOnly?: boolean;
   shouldPublishVideoFrames?: () => boolean;
   shouldLoadVideoFrame?: (
     queueId: string,
@@ -295,6 +296,13 @@ export async function parseFrame(
       if (!entry.queue || !entry.ptr) {
         console.warn("Entry missing queue or ptr:", entry);
         return Promise.resolve(null);
+      }
+
+      // Live thermal viewers own their reads; a slow camera must not stall
+      // unrelated sensors. History still follows the exact recorded pointer.
+      if (options.thermalDiscoveryOnly && entry.type === drivers.QueueDataType.QDT_HIKMICRO_THERMAL) {
+        return Promise.resolve({ queue: entry.queue, type: entry.type, ptr: entry.ptr,
+          decoded: {}, rawData: null, id: null, reused: true, isNormvla: false });
       }
 
       // Check if we can reuse from previous frame

--- a/software/station/clients/station-viewer/src/api/websocket.test.ts
+++ b/software/station/clients/station-viewer/src/api/websocket.test.ts
@@ -158,22 +158,17 @@ describe('WebSocketManager state', () => {
     vi.unstubAllGlobals();
   });
 
-  it('recovers an evicted live thermal entry from the actual tail and preserves its identity', async () => {
+  it('publishes thermal discovery without waiting for an unresponsive camera queue', async () => {
     vi.useFakeTimers();
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    vi.spyOn(console, 'error').mockImplementation(() => undefined);
     const { default: manager } = await import('@/api/websocket');
     const socket = getSocket();
     const queue = 'hikmicro-thermal/EA2976465';
-    const entry = { queue, ptr: Uint8Array.of(9), type: drivers.QueueDataType.QDT_HIKMICRO_THERMAL };
-    queueFrame(socket, 40, [entry]);
-    socket.queueReadResponse(queue, { entryId: 9, data: new Uint8Array(), result: normfs.ReadResponse.Result.RR_NOT_FOUND });
-    socket.queueReadResponse(queue, { entryId: 10, data: hikmicro.RxEnvelope.encode({ frames: { sequence: 123 } }).finish(), onlyLatestAvailable: true });
-    const next = waitForNextLiveSnapshot(manager);
+    queueFrame(socket, 40, [{ queue, ptr: Uint8Array.of(9), type: drivers.QueueDataType.QDT_HIKMICRO_THERMAL }]);
+    // No thermal response: unrelated live state must still publish.
     socket.open();
-    const frame = (await next).frame;
-    expect(frame?.hikmicroThermal?.[0]?.ptr).toEqual(Uint8Array.of(10));
-    expect(frame?.hikmicroThermal?.[0]?.data.frames?.sequence).toBe(123);
+    await vi.advanceTimersByTimeAsync(10);
+    expect(manager.getLiveSnapshot().frame?.hikmicroThermal?.[0]?.queueId).toBe(queue);
     socket.disconnect();
   });
 

--- a/software/station/clients/station-viewer/src/api/websocket.ts
+++ b/software/station/clients/station-viewer/src/api/websocket.ts
@@ -123,6 +123,7 @@ class WebSocketManager extends EventTarget {
         }
         const frame = await parseFrame(inferenceRx, entry.id, this.normFs, previousFrame, {
           retainRawData: false,
+          thermalDiscoveryOnly: true,
           shouldLoadVideoFrame: shouldLoadLiveCameraFrame,
           shouldPublishVideoFrames: () =>
             this.isLiveMode() && acquisitionGeneration === this.acquisitionGeneration,

--- a/software/station/clients/station-viewer/src/devices/hikmicro-thermal/README.md
+++ b/software/station/clients/station-viewer/src/devices/hikmicro-thermal/README.md
@@ -19,3 +19,21 @@ The overlay canvas has a fixed backing scale relative to the small sensor image,
 not the screen resolution. Disabling hides the overlay immediately and stops
 contour generation on subsequent requests. Hidden tabs dispose the thermal Worker
 and scheduled drawing through the existing preview lifecycle.
+
+## Low-latency acquisition
+
+Live discovery only lists thermal queues. Each mounted viewer independently reads
+its current tail, at most once per 40 ms with one outstanding request. Older
+stations with multi-frame batches are polled at the batch cadence (up to 1 s). Duplicate
+entries are not decoded or published again. Hidden tabs and history mode suspend
+reads; unmount disposes the loop. An outstanding NormFS request may finish (or hit
+its existing timeout), but its response cannot publish after suspension/disposal.
+History continues to read the exact recorded entry. No frame backlog is replayed.
+
+The station driver publishes one frame per envelope. Rebuild and restart the
+station to enable this behavior; no new configuration is needed. Old binaries
+still produce 25-frame batches and roughly one displayed frame per second.
+Single-frame entries also change recording granularity and repeat calibration
+metadata more frequently. Raw image traffic alone is about 2.5 MB/s at 25 FPS.
+
+The FPS label describes the configured sensor rate, not measured display FPS.

--- a/software/station/clients/station-viewer/src/devices/hikmicro-thermal/live-stream.test.ts
+++ b/software/station/clients/station-viewer/src/devices/hikmicro-thermal/live-stream.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, expect, it, vi } from 'vitest';
+import { hikmicro } from '@/api/proto.js';
+import type { StreamEntry } from '@/api/normfs';
+import { ThermalLiveStream } from './live-stream';
+
+afterEach(() => vi.useRealTimers());
+
+function entry(id: number): StreamEntry {
+  return { id: Uint8Array.of(id), data: hikmicro.RxEnvelope.encode({ frames: { sequence: id } }).finish() };
+}
+
+it('keeps reads bounded and discards a response from before hide/resume or disposal', async () => {
+  vi.useFakeTimers();
+  const pending: ((entry: StreamEntry) => void)[] = [];
+  const client = { readLastEntry: vi.fn(() => new Promise<StreamEntry>(resolve => pending.push(resolve))) };
+  const received: number[] = [];
+  const stream = new ThermalLiveStream(client, 'thermal/camera', data => received.push(data.frames!.sequence!));
+  stream.setEnabled(true);
+  await vi.advanceTimersByTimeAsync(1000);
+  expect(client.readLastEntry).toHaveBeenCalledTimes(1);
+  stream.setEnabled(false);
+  stream.setEnabled(true);
+  pending.shift()!(entry(1));
+  await vi.advanceTimersByTimeAsync(40);
+  expect(received).toEqual([]);
+  expect(client.readLastEntry).toHaveBeenCalledTimes(2);
+  pending.shift()!(entry(2));
+  await vi.advanceTimersByTimeAsync(40);
+  expect(received).toEqual([2]);
+  stream.dispose();
+  pending.shift()!(entry(3));
+  await vi.advanceTimersByTimeAsync(1000);
+  expect(received).toEqual([2]);
+  expect(client.readLastEntry).toHaveBeenCalledTimes(3);
+});
+
+it('does not republish duplicate tails and recovers from a failed read at the latest entry', async () => {
+  vi.useFakeTimers();
+  const client = { readLastEntry: vi.fn()
+    .mockResolvedValueOnce(entry(1)).mockResolvedValueOnce(entry(1))
+    .mockRejectedValueOnce(new Error('Entry not found')).mockResolvedValue(entry(8)) };
+  const received: number[] = [];
+  const stream = new ThermalLiveStream(client, 'thermal/camera', data => received.push(data.frames!.sequence!));
+  stream.setEnabled(true);
+  await vi.advanceTimersByTimeAsync(400);
+  expect(received).toEqual([1, 8]);
+  stream.dispose();
+});
+
+it('paces reads for older stations that still publish one-second batches', async () => {
+  vi.useFakeTimers();
+  const block = { id: Uint8Array.of(1), data: hikmicro.RxEnvelope.encode({
+    frames: { frames: Array.from({ length: 25 }, () => ({ payload: Uint8Array.of(1) })) },
+  }).finish() };
+  const client = { readLastEntry: vi.fn().mockResolvedValue(block) };
+  const stream = new ThermalLiveStream(client, 'thermal/camera', () => {});
+  stream.setEnabled(true);
+  await vi.advanceTimersByTimeAsync(999);
+  expect(client.readLastEntry).toHaveBeenCalledTimes(1);
+  await vi.advanceTimersByTimeAsync(1001);
+  expect(client.readLastEntry).toHaveBeenCalledTimes(3);
+  stream.dispose();
+});

--- a/software/station/clients/station-viewer/src/devices/hikmicro-thermal/live-stream.ts
+++ b/software/station/clients/station-viewer/src/devices/hikmicro-thermal/live-stream.ts
@@ -1,0 +1,70 @@
+import { hikmicro } from '@/api/proto.js';
+import type { NormFsClient } from '@/api/normfs';
+
+/** Poll the current tail, never a backlog. At most one read is outstanding. */
+export class ThermalLiveStream {
+  private enabled = false;
+  private disposed = false;
+  private busy = false;
+  private generation = 0;
+  private intervalMs = 40;
+  private lastId: string | null = null;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(
+    private readonly client: Pick<NormFsClient, 'readLastEntry'>,
+    private readonly queueId: string,
+    private readonly onFrame: (data: hikmicro.IRxEnvelope) => void,
+  ) {}
+
+  setEnabled(enabled: boolean): void {
+    if (this.disposed || enabled === this.enabled) return;
+    this.enabled = enabled;
+    this.generation++;
+    this.lastId = null;
+    if (this.timer !== null) clearTimeout(this.timer);
+    this.timer = null;
+    if (enabled) void this.poll();
+  }
+
+  private async poll(): Promise<void> {
+    if (!this.enabled || this.disposed || this.busy) return;
+    this.busy = true;
+    const generation = this.generation;
+    const started = performance.now();
+    let retryMs = this.intervalMs;
+    try {
+      const entry = await this.client.readLastEntry(this.queueId);
+      if (!this.enabled || this.disposed || generation !== this.generation) return;
+      const id = Array.from(entry.id).join(',');
+      if (id !== this.lastId) {
+        const data = hikmicro.RxEnvelope.decode(entry.data);
+        // Older stations still batch 25 frames: do not repeatedly download
+        // the same 2.5 MB block at 25 Hz while waiting for their next batch.
+        const count = data.frames?.frames?.length ?? 1;
+        const fps = data.deviceInfo?.streamFormat?.framesPerSecond || 25;
+        this.intervalMs = Math.max(40, Math.min(1000, count * 1000 / fps));
+        retryMs = this.intervalMs;
+        this.lastId = id;
+        this.onFrame(data);
+      }
+    } catch {
+      // Keep the last image through disconnects, missing entries and timeouts.
+      // The view marks it stale; bounded retries resume at the current tail.
+      retryMs = 250;
+    } finally {
+      this.busy = false;
+      if (this.enabled && !this.disposed) {
+        this.timer = setTimeout(() => {
+          this.timer = null;
+          void this.poll();
+        }, Math.max(0, retryMs - (performance.now() - started)));
+      }
+    }
+  }
+
+  dispose(): void {
+    this.setEnabled(false);
+    this.disposed = true;
+  }
+}

--- a/software/station/clients/station-viewer/src/devices/hikmicro-thermal/module.ts
+++ b/software/station/clients/station-viewer/src/devices/hikmicro-thermal/module.ts
@@ -1,11 +1,14 @@
-import { live } from '@/devices/live';
+import { customLive } from '@/devices/live';
+import type { HikmicroThermalLiveViewProps } from './ui/HikmicroThermalLiveView';
 
-export default live({
+export default customLive<HikmicroThermalLiveViewProps>({
   id: 'hikmicro-thermal',
   label: 'HIKMICRO Thermal',
   order: 26,
   slot: 'summary',
-  field: 'hikmicroThermal',
-  when: (data) => Boolean(data.frames?.frames?.length),
+  select: frame => (frame.hikmicroThermal ?? []).map(entry => ({
+    key: entry.queueId,
+    props: { data: entry.data, queueId: entry.queueId },
+  })),
   loadView: () => import('./ui/HikmicroThermalLiveView'),
 });

--- a/software/station/clients/station-viewer/src/devices/hikmicro-thermal/ui/HikmicroThermalLiveView.tsx
+++ b/software/station/clients/station-viewer/src/devices/hikmicro-thermal/ui/HikmicroThermalLiveView.tsx
@@ -5,18 +5,21 @@ import DeviceStatusBadge from '@/components/DeviceStatusBadge';
 import { useElementFullscreen, useTheme } from '@/hooks';
 import { isElectron } from '@/utils/platform';
 import { formatTemperatureDelta, hikmicroDeviceLabel, latestThermalFrame, type ThermalPalette } from '../thermal';
+import { useThermalLiveStream } from './useThermalLiveStream';
 import { useThermalPreview } from './useThermalPreview';
 // oxlint-disable-next-line import/no-unassigned-import -- Load styles with this lazy device view.
 import './thermal-mirror.css';
 
-export interface HikmicroThermalLiveViewProps { data: hikmicro.IRxEnvelope; }
+export interface HikmicroThermalLiveViewProps { data: hikmicro.IRxEnvelope; queueId?: string; }
 
 function Metric({ label, value, tone }: { label: string; value: string; tone?: string }) {
   const hasUnit = value.endsWith(' °C');
   return <div className="thermal-mirror__metric" data-tone={tone}><dt>{label}</dt><dd>{hasUnit ? <>{value.slice(0, -3)} <span className="thermal-mirror__unit">°C</span></> : value}</dd></div>;
 }
 
-function HikmicroThermalLiveView({ data }: HikmicroThermalLiveViewProps) {
+function HikmicroThermalLiveView({ data: recordedData, queueId }: HikmicroThermalLiveViewProps) {
+  const liveData = useThermalLiveStream(queueId);
+  const data = liveData ?? recordedData;
   const surfaceRef = useRef<HTMLElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const contourRef = useRef<HTMLCanvasElement>(null);

--- a/software/station/clients/station-viewer/src/devices/hikmicro-thermal/ui/useThermalLiveStream.ts
+++ b/software/station/clients/station-viewer/src/devices/hikmicro-thermal/ui/useThermalLiveStream.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import type { hikmicro } from '@/api/proto.js';
+import webSocketManager from '@/api/websocket';
+import { ThermalLiveStream } from '../live-stream';
+
+export function useThermalLiveStream(queueId?: string): hikmicro.IRxEnvelope | null {
+  const [snapshot, setSnapshot] = useState<{ queueId: string; data: hikmicro.IRxEnvelope } | null>(null);
+  useEffect(() => {
+    if (!queueId) return;
+    const stream = new ThermalLiveStream(webSocketManager.normFs, queueId, data => setSnapshot({ queueId, data }));
+    const sync = () => {
+      const connection = webSocketManager.getConnectionStats();
+      stream.setEnabled(document.visibilityState !== 'hidden'
+        && connection.status === 'connected' && connection.acquisitionMode === 'live');
+    };
+    const unsubscribe = webSocketManager.subscribeConnectionStats(sync);
+    document.addEventListener('visibilitychange', sync);
+    sync();
+    return () => {
+      stream.dispose();
+      unsubscribe();
+      document.removeEventListener('visibilitychange', sync);
+    };
+  }, [queueId]);
+  return snapshot && snapshot.queueId === queueId ? snapshot.data : null;
+}


### PR DESCRIPTION
Publish thermal frames individually instead of waiting for a 25-frame batch. Previously, the viewer displayed only the last frame of each batch, resulting in roughly one update per second.

- Change the HIKMICRO driver to one frame per envelope.
- Read thermal frames independently so a slow camera does not block other live sensors.
- Keep one request in flight, skip duplicate entries, and discard stale responses.
- Suspend reads in hidden tabs and history mode; stop polling on unmount.
- Adapt polling frequency for older stations that still send batches.
- Preserve exact-entry reads for history.

The station must be rebuilt and restarted to enable single-frame publication. No configuration changes are required.