### PR TITLE
refactor(station-viewer): simplify thermal HUD controls and connection status

### DIFF
--- a/software/station/clients/station-viewer/src/devices/hikmicro-thermal/README.md
+++ b/software/station/clients/station-viewer/src/devices/hikmicro-thermal/README.md
@@ -1,6 +1,6 @@
 # Thermal mirror
 
-The thermal view renders the decoded sensor image with a mirror control in fullscreen.
+The thermal view renders the decoded sensor image and restores saved mirror preferences.
 Decoding uses the thermal Worker with one frame in flight and one latest pending
 frame. Hidden tabs dispose the Worker and scheduled drawing.
 
@@ -27,9 +27,9 @@ The FPS label describes the configured sensor rate, not measured display FPS.
 The existing fullscreen thermal mirror adds a T-800 treatment inside the video
 bounds: a red palette, subtle scanlines and compact thermal
 readings. Fullscreen stretches the sensor image to fill the entire viewport, including
-when its aspect ratio differs from the sensor. Text branding (`// C //`), controls
-and stream status float over the image. Fullscreen always uses the T-800 HUD;
-its only controls are mirror and exit, both shown as icons. Compact widgets keep
+when its aspect ratio differs from the sensor. Text branding (`// C //`) and stream status float over the image. Fullscreen always uses the T-800 HUD;
+it has no on-screen buttons. Escape exits fullscreen through the shared
+fullscreen hook. The compact widget retains its fullscreen entry button. Compact widgets keep
 their regular palette and readings and have no HUD overlay.
 
 The overlay reads the existing decoded statistics. Calibrated readings are
@@ -81,3 +81,10 @@ of 250 ms. Same-bucket updates replace the column, real gaps stay empty, and no
 full frames are retained. Hidden-tab decoding already stops in the existing
 preview lifecycle; the graph adds no timers or additional Worker. Exiting HUD
 or losing available input unmounts the graph and releases its bounded history.
+
+Fullscreen connection feedback lives in the stream indicator: LIVE (or SYNTHETIC
+DEMO), CONNECTING / WAITING FOR FRAME, SIGNAL DELAYED / LAST FRAME, or RECOVERING.
+Unavailable input uses amber, decoder errors use red, and retained pixels remain
+visible without a banner. The indicator announces status changes politely;
+new decoded frames restore the normal status automatically. The compact widget
+keeps its existing connection notice.

--- a/software/station/clients/station-viewer/src/devices/hikmicro-thermal/ui/HikmicroThermalLiveView.tsx
+++ b/software/station/clients/station-viewer/src/devices/hikmicro-thermal/ui/HikmicroThermalLiveView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type CSSProperties } from 'react';
-import { FlipHorizontal2, Maximize2, Minimize2 } from 'lucide-react';
+import { Maximize2 } from 'lucide-react';
 import type { hikmicro } from '@/api/proto.js';
 import DeviceStatusBadge from '@/components/DeviceStatusBadge';
 import { useElementFullscreen } from '@/hooks';
@@ -35,8 +35,8 @@ function HikmicroThermalLiveView({ data: recordedData, queueId, demo = false }: 
   const available = Boolean(stats && !stale && !error);
   const reference = available ? stats!.avgC : null;
   const delta = (value: number | null | undefined) => formatTemperatureDelta(available ? value ?? null : null, reference);
-  const status = error ? 'RECOVERING' : stale ? 'SIGNAL DELAYED' : stats ? demo ? 'SYNTHETIC DEMO' : 'LIVE' : 'CONNECTING';
-  const fullscreenLabel = isFullscreen ? 'Exit thermal fullscreen' : 'Fullscreen thermal camera';
+  const status = error ? 'RECOVERING' : !stats ? 'CONNECTING' : stale ? 'SIGNAL DELAYED' : demo ? 'SYNTHETIC DEMO' : 'LIVE';
+  const statusDetail = available ? null : stats ? 'LAST FRAME' : 'WAITING FOR FRAME';
 
   useEffect(() => {
     try {
@@ -46,14 +46,9 @@ function HikmicroThermalLiveView({ data: recordedData, queueId, demo = false }: 
     } catch { /* Optional preferences; outdoor defaults still work. */ }
   }, [label]);
 
-  const changeMirror = () => {
-    setMirrored(!mirrored);
-    try { localStorage.setItem(`thermal-mirror:${label}`, JSON.stringify({ palette, mirrored: !mirrored })); } catch { /* Optional preference. */ }
-  };
   const controls = <div className="thermal-mirror__controls">
-    {isFullscreen && <button type="button" onClick={changeMirror} aria-pressed={mirrored} aria-label="Mirror thermal image" title="Mirror thermal image"><FlipHorizontal2 aria-hidden="true" /></button>}
-    <button type="button" onClick={() => void toggleFullscreen()} aria-label={fullscreenLabel} title={fullscreenLabel}>
-      {isFullscreen ? <Minimize2 aria-hidden="true" /> : <Maximize2 aria-hidden="true" />}
+    <button type="button" onClick={() => void toggleFullscreen()} aria-label="Fullscreen thermal camera" title="Fullscreen thermal camera">
+      <Maximize2 aria-hidden="true" />
     </button>
   </div>;
 
@@ -72,7 +67,6 @@ function HikmicroThermalLiveView({ data: recordedData, queueId, demo = false }: 
             {stats?.usedCalibration ? 'CALIBRATED' : 'RAW'}
           </DeviceStatusBadge>
         </>}
-        {isFullscreen && controls}
       </header>
       <div className="thermal-mirror__body">
         <div className="thermal-mirror__view">
@@ -94,7 +88,7 @@ function HikmicroThermalLiveView({ data: recordedData, queueId, demo = false }: 
               {stats?.spectrum && <ThermalSpectrogram spectrum={stats.spectrum} />}
               <span className="thermal-mirror__hud-caption thermal-mirror__hud-bottom">{demo ? 'SIMULATED INPUT' : 'HIKMICRO / THERMAL STREAM'}<span>SCAN ACTIVE</span></span>
             </div>}
-            {!available && <div className="thermal-mirror__notice" data-stale={Boolean(stats)} role="status">
+            {!isFullscreen && !available && <div className="thermal-mirror__notice" data-stale={Boolean(stats)} role="status">
               <strong>{stats ? 'Signal delayed · showing last frame' : 'Connecting to thermal camera'}</strong>
               <span>{error || stats ? 'The image will resume automatically.' : 'The first frame can take a little while.'}</span>
             </div>}
@@ -112,7 +106,9 @@ function HikmicroThermalLiveView({ data: recordedData, queueId, demo = false }: 
         </aside>}
       </div>
       {isFullscreen && <footer className="thermal-mirror__footer">
-        <span className="thermal-mirror__status" data-live={available}><i aria-hidden="true" />{status}</span>
+        <span className="thermal-mirror__status" data-live={available} data-error={Boolean(error)} role="status" aria-live="polite" aria-atomic="true">
+          <i aria-hidden="true" />{status}{statusDetail && <span className="thermal-mirror__status-detail"> / {statusDetail}</span>}
+        </span>
         <span className="thermal-mirror__device" title={label}>{label}</span>
         <span className="thermal-mirror__resolution">{stats?.width ?? 256} × {stats?.height ?? 192}</span>
       </footer>}

--- a/software/station/clients/station-viewer/src/devices/hikmicro-thermal/ui/thermal-mirror.css
+++ b/software/station/clients/station-viewer/src/devices/hikmicro-thermal/ui/thermal-mirror.css
@@ -269,3 +269,8 @@
   .thermal-mirror:fullscreen .thermal-mirror__brand { font-size: 18px; }
   .thermal-mirror:fullscreen .thermal-mirror__footer { padding: 6px 16px; font-size: 9px; }
 }
+
+/* Connection feedback stays in the fullscreen stream indicator. */
+.thermal-mirror:fullscreen .thermal-mirror__status[data-live="false"] { color: #ffd08a; }
+.thermal-mirror:fullscreen .thermal-mirror__status[data-error="true"] { color: #ffaaa0; }
+.thermal-mirror__status-detail { opacity: .75; }


### PR DESCRIPTION
Simplify the fullscreen thermal HUD by removing the mirror and exit buttons. Escape exits fullscreen; the compact widget keeps its fullscreen entry button.

Move connection feedback into the LIVE indicator instead of displaying a banner over the video:
- CONNECTING / WAITING FOR FRAME
- SIGNAL DELAYED / LAST FRAME
- RECOVERING / LAST FRAME

The last frame remains visible during interruptions, and the indicator returns to LIVE when frames resume. Changes are limited to the HIKMICRO thermal widget.